### PR TITLE
feat: admin console with user management

### DIFF
--- a/cmd/rampart/main.go
+++ b/cmd/rampart/main.go
@@ -60,6 +60,9 @@ func run(_ *slog.Logger) error {
 
 	server.RegisterProtectedRoutes(router, cfg.JWTSecret, handler.Me)
 
+	adminHandler := handler.NewAdminHandler(db, sessionStore, logger)
+	server.RegisterAdminRoutes(router, cfg.JWTSecret, adminHandler)
+
 	srv := server.New(cfg.Addr(), router, logger)
 
 	errCh := make(chan error, 1)

--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -125,4 +126,148 @@ func (db *DB) GetUserByUsername(ctx context.Context, username string, orgID uuid
 		return nil, fmt.Errorf("querying user by username: %w", err)
 	}
 	return &u, nil
+}
+
+// ListUsers returns a paginated, searchable, filterable list of users.
+func (db *DB) ListUsers(ctx context.Context, orgID uuid.UUID, search, status string, limit, offset int) ([]*model.User, int, error) {
+	where := []string{"org_id = $1"}
+	args := []any{orgID}
+	paramIdx := 2
+
+	if search != "" {
+		where = append(where, fmt.Sprintf(
+			"(username ILIKE $%d OR email ILIKE $%d OR given_name ILIKE $%d OR family_name ILIKE $%d)",
+			paramIdx, paramIdx, paramIdx, paramIdx,
+		))
+		args = append(args, "%"+search+"%")
+		paramIdx++
+	}
+
+	if status == "enabled" {
+		where = append(where, fmt.Sprintf("enabled = $%d", paramIdx))
+		args = append(args, true)
+		paramIdx++
+	} else if status == "disabled" {
+		where = append(where, fmt.Sprintf("enabled = $%d", paramIdx))
+		args = append(args, false)
+		paramIdx++
+	}
+
+	whereClause := strings.Join(where, " AND ")
+
+	// Count total matching rows.
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM users WHERE %s", whereClause)
+	var total int
+	if err := db.Pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("counting users: %w", err)
+	}
+
+	// Fetch page.
+	dataQuery := fmt.Sprintf(`
+		SELECT id, org_id, username, email, email_verified, given_name, family_name,
+		       enabled, mfa_enabled, last_login_at, created_at, updated_at
+		FROM users
+		WHERE %s
+		ORDER BY created_at DESC
+		LIMIT $%d OFFSET $%d`, whereClause, paramIdx, paramIdx+1)
+	args = append(args, limit, offset)
+
+	rows, err := db.Pool.Query(ctx, dataQuery, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("listing users: %w", err)
+	}
+	defer rows.Close()
+
+	var users []*model.User
+	for rows.Next() {
+		var u model.User
+		if err := rows.Scan(
+			&u.ID, &u.OrgID, &u.Username, &u.Email, &u.EmailVerified,
+			&u.GivenName, &u.FamilyName, &u.Enabled, &u.MFAEnabled,
+			&u.LastLoginAt, &u.CreatedAt, &u.UpdatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scanning user row: %w", err)
+		}
+		users = append(users, &u)
+	}
+
+	return users, total, nil
+}
+
+// UpdateUser updates mutable fields on a user.
+func (db *DB) UpdateUser(ctx context.Context, id uuid.UUID, req *model.UpdateUserRequest) (*model.User, error) {
+	query := `
+		UPDATE users
+		SET username = COALESCE(NULLIF($2, ''), username),
+		    email = COALESCE(NULLIF($3, ''), email),
+		    given_name = $4,
+		    family_name = $5,
+		    enabled = $6,
+		    email_verified = $7,
+		    updated_at = now()
+		WHERE id = $1
+		RETURNING id, org_id, username, email, email_verified, given_name, family_name,
+		          enabled, mfa_enabled, last_login_at, created_at, updated_at`
+
+	var u model.User
+	err := db.Pool.QueryRow(ctx, query,
+		id, req.Username, req.Email,
+		req.GivenName, req.FamilyName,
+		req.Enabled, req.EmailVerified,
+	).Scan(
+		&u.ID, &u.OrgID, &u.Username, &u.Email, &u.EmailVerified,
+		&u.GivenName, &u.FamilyName, &u.Enabled, &u.MFAEnabled,
+		&u.LastLoginAt, &u.CreatedAt, &u.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("updating user: %w", err)
+	}
+	return &u, nil
+}
+
+// DeleteUser removes a user by ID.
+func (db *DB) DeleteUser(ctx context.Context, id uuid.UUID) error {
+	tag, err := db.Pool.Exec(ctx, "DELETE FROM users WHERE id = $1", id)
+	if err != nil {
+		return fmt.Errorf("deleting user: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("user not found")
+	}
+	return nil
+}
+
+// UpdatePassword sets a new password hash for a user.
+func (db *DB) UpdatePassword(ctx context.Context, id uuid.UUID, passwordHash []byte) error {
+	_, err := db.Pool.Exec(ctx, "UPDATE users SET password_hash = $2, updated_at = now() WHERE id = $1", id, passwordHash)
+	if err != nil {
+		return fmt.Errorf("updating password: %w", err)
+	}
+	return nil
+}
+
+// CountUsers returns the total number of users in an organization.
+func (db *DB) CountUsers(ctx context.Context, orgID uuid.UUID) (int, error) {
+	var count int
+	err := db.Pool.QueryRow(ctx, "SELECT COUNT(*) FROM users WHERE org_id = $1", orgID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("counting users: %w", err)
+	}
+	return count, nil
+}
+
+// CountRecentUsers returns the number of users created in the last N days.
+func (db *DB) CountRecentUsers(ctx context.Context, orgID uuid.UUID, days int) (int, error) {
+	var count int
+	err := db.Pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM users WHERE org_id = $1 AND created_at > now() - make_interval(days => $2)",
+		orgID, days,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("counting recent users: %w", err)
+	}
+	return count, nil
 }

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -1,0 +1,456 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/manimovassagh/rampart/internal/apierror"
+	"github.com/manimovassagh/rampart/internal/auth"
+	"github.com/manimovassagh/rampart/internal/middleware"
+	"github.com/manimovassagh/rampart/internal/model"
+	"github.com/manimovassagh/rampart/internal/session"
+)
+
+const (
+	defaultPageLimit = 20
+	maxPageLimit     = 100
+)
+
+// AdminUserStore defines the database operations required by AdminHandler.
+type AdminUserStore interface {
+	GetDefaultOrganizationID(ctx context.Context) (uuid.UUID, error)
+	GetUserByEmail(ctx context.Context, email string, orgID uuid.UUID) (*model.User, error)
+	GetUserByUsername(ctx context.Context, username string, orgID uuid.UUID) (*model.User, error)
+	GetUserByID(ctx context.Context, id uuid.UUID) (*model.User, error)
+	CreateUser(ctx context.Context, user *model.User) (*model.User, error)
+	ListUsers(ctx context.Context, orgID uuid.UUID, search, status string, limit, offset int) ([]*model.User, int, error)
+	UpdateUser(ctx context.Context, id uuid.UUID, req *model.UpdateUserRequest) (*model.User, error)
+	DeleteUser(ctx context.Context, id uuid.UUID) error
+	UpdatePassword(ctx context.Context, id uuid.UUID, passwordHash []byte) error
+	CountUsers(ctx context.Context, orgID uuid.UUID) (int, error)
+	CountRecentUsers(ctx context.Context, orgID uuid.UUID, days int) (int, error)
+}
+
+// AdminSessionStore defines the session operations required by AdminHandler.
+type AdminSessionStore interface {
+	ListByUserID(ctx context.Context, userID uuid.UUID) ([]*session.Session, error)
+	CountByUserID(ctx context.Context, userID uuid.UUID) (int, error)
+	CountActive(ctx context.Context) (int, error)
+	DeleteByUserID(ctx context.Context, userID uuid.UUID) error
+}
+
+// AdminHandler handles admin console endpoints.
+type AdminHandler struct {
+	store    AdminUserStore
+	sessions AdminSessionStore
+	logger   *slog.Logger
+}
+
+// NewAdminHandler creates a handler with admin dependencies.
+func NewAdminHandler(store AdminUserStore, sessions AdminSessionStore, logger *slog.Logger) *AdminHandler {
+	return &AdminHandler{store: store, sessions: sessions, logger: logger}
+}
+
+// Stats handles GET /api/v1/admin/stats.
+func (h *AdminHandler) Stats(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	orgID, err := h.store.GetDefaultOrganizationID(ctx)
+	if err != nil {
+		h.logger.Error("failed to get default organization", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	totalUsers, err := h.store.CountUsers(ctx, orgID)
+	if err != nil {
+		h.logger.Error("failed to count users", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	activeSessions, err := h.sessions.CountActive(ctx)
+	if err != nil {
+		h.logger.Error("failed to count active sessions", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	recentUsers, err := h.store.CountRecentUsers(ctx, orgID, 7)
+	if err != nil {
+		h.logger.Error("failed to count recent users", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	stats := model.DashboardStats{
+		TotalUsers:     totalUsers,
+		ActiveSessions: activeSessions,
+		RecentUsers:    recentUsers,
+	}
+
+	writeJSON(w, http.StatusOK, stats, h.logger)
+}
+
+// ListUsers handles GET /api/v1/admin/users.
+func (h *AdminHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	orgID, err := h.store.GetDefaultOrganizationID(ctx)
+	if err != nil {
+		h.logger.Error("failed to get default organization", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	search := r.URL.Query().Get("search")
+	status := r.URL.Query().Get("status")
+	page := queryInt(r, "page", 1)
+	limit := queryInt(r, "limit", defaultPageLimit)
+
+	if limit > maxPageLimit {
+		limit = maxPageLimit
+	}
+	if page < 1 {
+		page = 1
+	}
+	offset := (page - 1) * limit
+
+	users, total, err := h.store.ListUsers(ctx, orgID, search, status, limit, offset)
+	if err != nil {
+		h.logger.Error("failed to list users", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	adminUsers := make([]*model.AdminUserResponse, len(users))
+	for i, u := range users {
+		count, err := h.sessions.CountByUserID(ctx, u.ID)
+		if err != nil {
+			h.logger.Warn("failed to count sessions for user", "user_id", u.ID, "error", err)
+		}
+		adminUsers[i] = u.ToAdminResponse(count)
+	}
+
+	resp := model.ListUsersResponse{
+		Users: adminUsers,
+		Total: total,
+		Page:  page,
+		Limit: limit,
+	}
+
+	writeJSON(w, http.StatusOK, resp, h.logger)
+}
+
+// CreateUser handles POST /api/v1/admin/users.
+func (h *AdminHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+
+	var req model.CreateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apierror.BadRequest(w, "Invalid or malformed JSON request body.")
+		return
+	}
+
+	req.Email = strings.ToLower(strings.TrimSpace(req.Email))
+	req.Username = strings.TrimSpace(req.Username)
+	req.GivenName = strings.TrimSpace(req.GivenName)
+	req.FamilyName = strings.TrimSpace(req.FamilyName)
+
+	if fieldErrors := auth.ValidateRegistration(req.Email, req.Password, req.Username); len(fieldErrors) > 0 {
+		apiFieldErrors := make([]apierror.FieldError, len(fieldErrors))
+		for i, fe := range fieldErrors {
+			apiFieldErrors[i] = apierror.FieldError{Field: fe.Field, Message: fe.Message}
+		}
+		apierror.WriteValidation(w, apiFieldErrors)
+		return
+	}
+
+	ctx := r.Context()
+
+	orgID, err := h.store.GetDefaultOrganizationID(ctx)
+	if err != nil {
+		h.logger.Error("failed to get default organization", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	existing, err := h.store.GetUserByEmail(ctx, req.Email, orgID)
+	if err != nil {
+		h.logger.Error("failed to check existing email", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+	if existing != nil {
+		apierror.Conflict(w, "A user with this email already exists.")
+		return
+	}
+
+	existing, err = h.store.GetUserByUsername(ctx, req.Username, orgID)
+	if err != nil {
+		h.logger.Error("failed to check existing username", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+	if existing != nil {
+		apierror.Conflict(w, "A user with this username already exists.")
+		return
+	}
+
+	hash, err := auth.HashPassword(req.Password)
+	if err != nil {
+		h.logger.Error("failed to hash password", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	user := &model.User{
+		OrgID:        orgID,
+		Username:     req.Username,
+		Email:        req.Email,
+		GivenName:    req.GivenName,
+		FamilyName:   req.FamilyName,
+		PasswordHash: []byte(hash),
+		Enabled:      req.Enabled,
+	}
+
+	created, err := h.store.CreateUser(ctx, user)
+	if err != nil {
+		h.logger.Error("failed to create user", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, created.ToAdminResponse(0), h.logger)
+}
+
+// GetUser handles GET /api/v1/admin/users/{id}.
+func (h *AdminHandler) GetUser(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseUUIDParam(w, r)
+	if !ok {
+		return
+	}
+
+	ctx := r.Context()
+
+	user, err := h.store.GetUserByID(ctx, userID)
+	if err != nil {
+		h.logger.Error("failed to get user", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+	if user == nil {
+		apierror.NotFound(w)
+		return
+	}
+
+	sessionCount, err := h.sessions.CountByUserID(ctx, userID)
+	if err != nil {
+		h.logger.Warn("failed to count sessions", "user_id", userID, "error", err)
+	}
+
+	writeJSON(w, http.StatusOK, user.ToAdminResponse(sessionCount), h.logger)
+}
+
+// UpdateUser handles PUT /api/v1/admin/users/{id}.
+func (h *AdminHandler) UpdateUser(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseUUIDParam(w, r)
+	if !ok {
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+
+	var req model.UpdateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apierror.BadRequest(w, "Invalid or malformed JSON request body.")
+		return
+	}
+
+	req.Username = strings.TrimSpace(req.Username)
+	req.Email = strings.ToLower(strings.TrimSpace(req.Email))
+	req.GivenName = strings.TrimSpace(req.GivenName)
+	req.FamilyName = strings.TrimSpace(req.FamilyName)
+
+	ctx := r.Context()
+
+	updated, err := h.store.UpdateUser(ctx, userID, &req)
+	if err != nil {
+		h.logger.Error("failed to update user", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+	if updated == nil {
+		apierror.NotFound(w)
+		return
+	}
+
+	sessionCount, err := h.sessions.CountByUserID(ctx, userID)
+	if err != nil {
+		h.logger.Warn("failed to count sessions", "user_id", userID, "error", err)
+	}
+
+	writeJSON(w, http.StatusOK, updated.ToAdminResponse(sessionCount), h.logger)
+}
+
+// DeleteUser handles DELETE /api/v1/admin/users/{id}.
+func (h *AdminHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseUUIDParam(w, r)
+	if !ok {
+		return
+	}
+
+	// Prevent self-deletion.
+	authUser := middleware.GetAuthenticatedUser(r.Context())
+	if authUser != nil && authUser.UserID == userID {
+		apierror.BadRequest(w, "You cannot delete your own account.")
+		return
+	}
+
+	ctx := r.Context()
+
+	// Delete sessions first.
+	if err := h.sessions.DeleteByUserID(ctx, userID); err != nil {
+		h.logger.Error("failed to delete user sessions", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	if err := h.store.DeleteUser(ctx, userID); err != nil {
+		h.logger.Error("failed to delete user", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ResetPassword handles POST /api/v1/admin/users/{id}/reset-password.
+func (h *AdminHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseUUIDParam(w, r)
+	if !ok {
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+
+	var req model.ResetPasswordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apierror.BadRequest(w, "Invalid or malformed JSON request body.")
+		return
+	}
+
+	if fe := auth.ValidatePassword(req.Password); fe != nil {
+		apierror.WriteValidation(w, []apierror.FieldError{{Field: fe.Field, Message: fe.Message}})
+		return
+	}
+
+	ctx := r.Context()
+
+	user, err := h.store.GetUserByID(ctx, userID)
+	if err != nil {
+		h.logger.Error("failed to get user", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+	if user == nil {
+		apierror.NotFound(w)
+		return
+	}
+
+	hash, err := auth.HashPassword(req.Password)
+	if err != nil {
+		h.logger.Error("failed to hash password", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	if err := h.store.UpdatePassword(ctx, userID, []byte(hash)); err != nil {
+		h.logger.Error("failed to update password", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListSessions handles GET /api/v1/admin/users/{id}/sessions.
+func (h *AdminHandler) ListSessions(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseUUIDParam(w, r)
+	if !ok {
+		return
+	}
+
+	sessions, err := h.sessions.ListByUserID(r.Context(), userID)
+	if err != nil {
+		h.logger.Error("failed to list sessions", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	resp := make([]*model.SessionResponse, len(sessions))
+	for i, s := range sessions {
+		resp[i] = &model.SessionResponse{
+			ID:        s.ID,
+			CreatedAt: s.CreatedAt,
+			ExpiresAt: s.ExpiresAt,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp, h.logger)
+}
+
+// RevokeSessions handles DELETE /api/v1/admin/users/{id}/sessions.
+func (h *AdminHandler) RevokeSessions(w http.ResponseWriter, r *http.Request) {
+	userID, ok := parseUUIDParam(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.sessions.DeleteByUserID(r.Context(), userID); err != nil {
+		h.logger.Error("failed to revoke sessions", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Helpers ---
+
+func parseUUIDParam(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	raw := chi.URLParam(r, "id")
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		apierror.BadRequest(w, "Invalid UUID parameter.")
+		return uuid.UUID{}, false
+	}
+	return id, true
+}
+
+func queryInt(r *http.Request, key string, fallback int) int {
+	val := r.URL.Query().Get(key)
+	if val == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(val)
+	if err != nil || n < 0 {
+		return fallback
+	}
+	return n
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any, logger *slog.Logger) {
+	w.Header().Set("Content-Type", apierror.ContentTypeJSON)
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		logger.Error("failed to encode response", "error", err)
+	}
+}

--- a/internal/handler/admin_test.go
+++ b/internal/handler/admin_test.go
@@ -1,0 +1,463 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/manimovassagh/rampart/internal/middleware"
+	"github.com/manimovassagh/rampart/internal/model"
+	"github.com/manimovassagh/rampart/internal/session"
+)
+
+// mockAdminUserStore implements AdminUserStore for testing.
+type mockAdminUserStore struct {
+	defaultOrgID     uuid.UUID
+	defaultOrgErr    error
+	userByID         *model.User
+	userByIDErr      error
+	emailUser        *model.User
+	emailErr         error
+	usernameUser     *model.User
+	usernameErr      error
+	createdUser      *model.User
+	createErr        error
+	listUsers        []*model.User
+	listTotal        int
+	listErr          error
+	updatedUser      *model.User
+	updateErr        error
+	deleteErr        error
+	updatePwErr      error
+	countUsers       int
+	countUsersErr    error
+	countRecent      int
+	countRecentErr   error
+}
+
+func (m *mockAdminUserStore) GetDefaultOrganizationID(_ context.Context) (uuid.UUID, error) {
+	return m.defaultOrgID, m.defaultOrgErr
+}
+func (m *mockAdminUserStore) GetUserByID(_ context.Context, _ uuid.UUID) (*model.User, error) {
+	return m.userByID, m.userByIDErr
+}
+func (m *mockAdminUserStore) GetUserByEmail(_ context.Context, _ string, _ uuid.UUID) (*model.User, error) {
+	return m.emailUser, m.emailErr
+}
+func (m *mockAdminUserStore) GetUserByUsername(_ context.Context, _ string, _ uuid.UUID) (*model.User, error) {
+	return m.usernameUser, m.usernameErr
+}
+func (m *mockAdminUserStore) CreateUser(_ context.Context, user *model.User) (*model.User, error) {
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	if m.createdUser != nil {
+		return m.createdUser, nil
+	}
+	user.ID = uuid.New()
+	user.CreatedAt = time.Now()
+	user.UpdatedAt = time.Now()
+	return user, nil
+}
+func (m *mockAdminUserStore) ListUsers(_ context.Context, _ uuid.UUID, _, _ string, _, _ int) ([]*model.User, int, error) {
+	return m.listUsers, m.listTotal, m.listErr
+}
+func (m *mockAdminUserStore) UpdateUser(_ context.Context, _ uuid.UUID, _ *model.UpdateUserRequest) (*model.User, error) {
+	return m.updatedUser, m.updateErr
+}
+func (m *mockAdminUserStore) DeleteUser(_ context.Context, _ uuid.UUID) error {
+	return m.deleteErr
+}
+func (m *mockAdminUserStore) UpdatePassword(_ context.Context, _ uuid.UUID, _ []byte) error {
+	return m.updatePwErr
+}
+func (m *mockAdminUserStore) CountUsers(_ context.Context, _ uuid.UUID) (int, error) {
+	return m.countUsers, m.countUsersErr
+}
+func (m *mockAdminUserStore) CountRecentUsers(_ context.Context, _ uuid.UUID, _ int) (int, error) {
+	return m.countRecent, m.countRecentErr
+}
+
+// mockAdminSessionStore implements AdminSessionStore for testing.
+type mockAdminSessionStore struct {
+	sessions       []*session.Session
+	listErr        error
+	countByUser    int
+	countByUserErr error
+	countActive    int
+	countActiveErr error
+	deleteErr      error
+}
+
+func (m *mockAdminSessionStore) ListByUserID(_ context.Context, _ uuid.UUID) ([]*session.Session, error) {
+	return m.sessions, m.listErr
+}
+func (m *mockAdminSessionStore) CountByUserID(_ context.Context, _ uuid.UUID) (int, error) {
+	return m.countByUser, m.countByUserErr
+}
+func (m *mockAdminSessionStore) CountActive(_ context.Context) (int, error) {
+	return m.countActive, m.countActiveErr
+}
+func (m *mockAdminSessionStore) DeleteByUserID(_ context.Context, _ uuid.UUID) error {
+	return m.deleteErr
+}
+
+func newAdminTestUser() *model.User {
+	return &model.User{
+		ID:        uuid.New(),
+		OrgID:     uuid.New(),
+		Username:  "testuser",
+		Email:     "test@rampart.local",
+		Enabled:   true,
+		GivenName: "Test",
+		FamilyName: "User",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+}
+
+func newTestAdminHandler(store *mockAdminUserStore, sessions *mockAdminSessionStore) *AdminHandler {
+	return NewAdminHandler(store, sessions, noopLogger())
+}
+
+func TestAdminStatsSuccess(t *testing.T) {
+	store := &mockAdminUserStore{
+		defaultOrgID: uuid.New(),
+		countUsers:   42,
+		countRecent:  5,
+	}
+	sessions := &mockAdminSessionStore{countActive: 10}
+	h := newTestAdminHandler(store, sessions)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	w := httptest.NewRecorder()
+
+	h.Stats(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var stats model.DashboardStats
+	if err := json.NewDecoder(w.Body).Decode(&stats); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if stats.TotalUsers != 42 {
+		t.Errorf("total_users = %d, want 42", stats.TotalUsers)
+	}
+	if stats.ActiveSessions != 10 {
+		t.Errorf("active_sessions = %d, want 10", stats.ActiveSessions)
+	}
+	if stats.RecentUsers != 5 {
+		t.Errorf("recent_users = %d, want 5", stats.RecentUsers)
+	}
+}
+
+func TestAdminListUsersSuccess(t *testing.T) {
+	user := newAdminTestUser()
+	store := &mockAdminUserStore{
+		defaultOrgID: user.OrgID,
+		listUsers:    []*model.User{user},
+		listTotal:    1,
+	}
+	sessions := &mockAdminSessionStore{countByUser: 2}
+	h := newTestAdminHandler(store, sessions)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users?page=1&limit=20", http.NoBody)
+	w := httptest.NewRecorder()
+
+	h.ListUsers(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp model.ListUsersResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Total != 1 {
+		t.Errorf("total = %d, want 1", resp.Total)
+	}
+	if len(resp.Users) != 1 {
+		t.Fatalf("users length = %d, want 1", len(resp.Users))
+	}
+	if resp.Users[0].SessionCount != 2 {
+		t.Errorf("session_count = %d, want 2", resp.Users[0].SessionCount)
+	}
+}
+
+func TestAdminCreateUserSuccess(t *testing.T) {
+	store := &mockAdminUserStore{defaultOrgID: uuid.New()}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	body := []byte(`{"username":"newuser","email":"new@test.com","password":"Str0ng!Pass","given_name":"New","family_name":"User","enabled":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.CreateUser(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want %d; body = %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+}
+
+func TestAdminCreateUserDuplicateEmail(t *testing.T) {
+	existing := newAdminTestUser()
+	store := &mockAdminUserStore{
+		defaultOrgID: existing.OrgID,
+		emailUser:    existing,
+	}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	body := []byte(`{"username":"other","email":"test@rampart.local","password":"Str0ng!Pass","given_name":"A","family_name":"B","enabled":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.CreateUser(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+	}
+}
+
+func TestAdminCreateUserValidationError(t *testing.T) {
+	store := &mockAdminUserStore{defaultOrgID: uuid.New()}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	body := []byte(`{"username":"x","email":"bad","password":"short","given_name":"","family_name":"","enabled":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.CreateUser(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAdminGetUserSuccess(t *testing.T) {
+	user := newAdminTestUser()
+	store := &mockAdminUserStore{userByID: user}
+	sessions := &mockAdminSessionStore{countByUser: 3}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/admin/users/{id}", h.GetUser)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users/"+user.ID.String(), http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp model.AdminUserResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Username != "testuser" {
+		t.Errorf("username = %q, want testuser", resp.Username)
+	}
+	if resp.SessionCount != 3 {
+		t.Errorf("session_count = %d, want 3", resp.SessionCount)
+	}
+}
+
+func TestAdminGetUserNotFound(t *testing.T) {
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/admin/users/{id}", h.GetUser)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users/"+uuid.New().String(), http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestAdminGetUserInvalidUUID(t *testing.T) {
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/admin/users/{id}", h.GetUser)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users/not-a-uuid", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAdminUpdateUserSuccess(t *testing.T) {
+	user := newAdminTestUser()
+	store := &mockAdminUserStore{updatedUser: user}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Put("/api/v1/admin/users/{id}", h.UpdateUser)
+
+	body := []byte(`{"username":"updated","email":"updated@test.com","given_name":"Up","family_name":"Dated","enabled":true,"email_verified":true}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/users/"+user.ID.String(), bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestAdminDeleteUserSuccess(t *testing.T) {
+	user := newAdminTestUser()
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	// Use a different user as the authenticated caller.
+	callerID := uuid.New()
+	authUser := &middleware.AuthenticatedUser{UserID: callerID, OrgID: user.OrgID}
+
+	r := chi.NewRouter()
+	r.Delete("/api/v1/admin/users/{id}", h.DeleteUser)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/users/"+user.ID.String(), http.NoBody)
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
+func TestAdminDeleteUserSelfDeletion(t *testing.T) {
+	user := newAdminTestUser()
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	authUser := &middleware.AuthenticatedUser{UserID: user.ID, OrgID: user.OrgID}
+
+	r := chi.NewRouter()
+	r.Delete("/api/v1/admin/users/{id}", h.DeleteUser)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/users/"+user.ID.String(), http.NoBody)
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAdminResetPasswordSuccess(t *testing.T) {
+	user := newAdminTestUser()
+	store := &mockAdminUserStore{userByID: user}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Post("/api/v1/admin/users/{id}/reset-password", h.ResetPassword)
+
+	body := []byte(`{"password":"NewStr0ng!Pass"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+user.ID.String()+"/reset-password", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d; body = %s", w.Code, http.StatusNoContent, w.Body.String())
+	}
+}
+
+func TestAdminResetPasswordWeakPassword(t *testing.T) {
+	user := newAdminTestUser()
+	store := &mockAdminUserStore{userByID: user}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Post("/api/v1/admin/users/{id}/reset-password", h.ResetPassword)
+
+	body := []byte(`{"password":"weak"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+user.ID.String()+"/reset-password", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAdminListSessionsSuccess(t *testing.T) {
+	userID := uuid.New()
+	sess := &session.Session{
+		ID:        uuid.New(),
+		UserID:    userID,
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+		CreatedAt: time.Now(),
+	}
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{sessions: []*session.Session{sess}}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/admin/users/{id}/sessions", h.ListSessions)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users/"+userID.String()+"/sessions", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp []*model.SessionResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp) != 1 {
+		t.Errorf("sessions length = %d, want 1", len(resp))
+	}
+}
+
+func TestAdminRevokeSessionsSuccess(t *testing.T) {
+	userID := uuid.New()
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Delete("/api/v1/admin/users/{id}/sessions", h.RevokeSessions)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/users/"+userID.String()+"/sessions", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -64,3 +64,86 @@ func (u *User) ToResponse() *UserResponse {
 		UpdatedAt:     u.UpdatedAt,
 	}
 }
+
+// AdminUserResponse is an enriched user representation for the admin console.
+type AdminUserResponse struct {
+	ID            uuid.UUID  `json:"id"`
+	OrgID         uuid.UUID  `json:"org_id"`
+	Username      string     `json:"username"`
+	Email         string     `json:"email"`
+	EmailVerified bool       `json:"email_verified"`
+	GivenName     string     `json:"given_name,omitempty"`
+	FamilyName    string     `json:"family_name,omitempty"`
+	Enabled       bool       `json:"enabled"`
+	MFAEnabled    bool       `json:"mfa_enabled"`
+	LastLoginAt   *time.Time `json:"last_login_at,omitempty"`
+	SessionCount  int        `json:"session_count"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+}
+
+// ToAdminResponse converts a User to an AdminUserResponse.
+func (u *User) ToAdminResponse(sessionCount int) *AdminUserResponse {
+	return &AdminUserResponse{
+		ID:            u.ID,
+		OrgID:         u.OrgID,
+		Username:      u.Username,
+		Email:         u.Email,
+		EmailVerified: u.EmailVerified,
+		GivenName:     u.GivenName,
+		FamilyName:    u.FamilyName,
+		Enabled:       u.Enabled,
+		MFAEnabled:    u.MFAEnabled,
+		LastLoginAt:   u.LastLoginAt,
+		SessionCount:  sessionCount,
+		CreatedAt:     u.CreatedAt,
+		UpdatedAt:     u.UpdatedAt,
+	}
+}
+
+// ListUsersResponse is a paginated list of users for the admin API.
+type ListUsersResponse struct {
+	Users []*AdminUserResponse `json:"users"`
+	Total int                  `json:"total"`
+	Page  int                  `json:"page"`
+	Limit int                  `json:"limit"`
+}
+
+// CreateUserRequest is the expected JSON body for admin user creation.
+type CreateUserRequest struct {
+	Username   string `json:"username"`
+	Email      string `json:"email"`
+	Password   string `json:"password"`
+	GivenName  string `json:"given_name"`
+	FamilyName string `json:"family_name"`
+	Enabled    bool   `json:"enabled"`
+}
+
+// UpdateUserRequest is the expected JSON body for admin user updates.
+type UpdateUserRequest struct {
+	Username      string `json:"username"`
+	Email         string `json:"email"`
+	GivenName     string `json:"given_name"`
+	FamilyName    string `json:"family_name"`
+	Enabled       bool   `json:"enabled"`
+	EmailVerified bool   `json:"email_verified"`
+}
+
+// ResetPasswordRequest is the expected JSON body for admin password resets.
+type ResetPasswordRequest struct {
+	Password string `json:"password"`
+}
+
+// DashboardStats contains summary statistics for the admin dashboard.
+type DashboardStats struct {
+	TotalUsers     int `json:"total_users"`
+	ActiveSessions int `json:"active_sessions"`
+	RecentUsers    int `json:"recent_users"`
+}
+
+// SessionResponse is a session representation for the admin API.
+type SessionResponse struct {
+	ID        uuid.UUID `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -58,3 +58,33 @@ func RegisterProtectedRoutes(r *chi.Mux, jwtSecret string, meHandler http.Handle
 		r.Get("/me", meHandler)
 	})
 }
+
+// AdminEndpoints groups the handler methods needed by RegisterAdminRoutes.
+type AdminEndpoints interface {
+	Stats(w http.ResponseWriter, r *http.Request)
+	ListUsers(w http.ResponseWriter, r *http.Request)
+	CreateUser(w http.ResponseWriter, r *http.Request)
+	GetUser(w http.ResponseWriter, r *http.Request)
+	UpdateUser(w http.ResponseWriter, r *http.Request)
+	DeleteUser(w http.ResponseWriter, r *http.Request)
+	ResetPassword(w http.ResponseWriter, r *http.Request)
+	ListSessions(w http.ResponseWriter, r *http.Request)
+	RevokeSessions(w http.ResponseWriter, r *http.Request)
+}
+
+// RegisterAdminRoutes mounts admin console endpoints under /api/v1/admin.
+func RegisterAdminRoutes(r *chi.Mux, jwtSecret string, admin AdminEndpoints) {
+	r.Group(func(r chi.Router) {
+		r.Use(middleware.Auth(jwtSecret))
+
+		r.Get("/api/v1/admin/stats", admin.Stats)
+		r.Get("/api/v1/admin/users", admin.ListUsers)
+		r.Post("/api/v1/admin/users", admin.CreateUser)
+		r.Get("/api/v1/admin/users/{id}", admin.GetUser)
+		r.Put("/api/v1/admin/users/{id}", admin.UpdateUser)
+		r.Delete("/api/v1/admin/users/{id}", admin.DeleteUser)
+		r.Post("/api/v1/admin/users/{id}/reset-password", admin.ResetPassword)
+		r.Get("/api/v1/admin/users/{id}/sessions", admin.ListSessions)
+		r.Delete("/api/v1/admin/users/{id}/sessions", admin.RevokeSessions)
+	})
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -103,3 +103,51 @@ func (s *PGStore) DeleteByUserID(ctx context.Context, userID uuid.UUID) error {
 	}
 	return nil
 }
+
+// ListByUserID returns all active sessions for a user.
+func (s *PGStore) ListByUserID(ctx context.Context, userID uuid.UUID) ([]*Session, error) {
+	query := `
+		SELECT id, user_id, refresh_token_hash, expires_at, created_at
+		FROM sessions
+		WHERE user_id = $1 AND expires_at > now()
+		ORDER BY created_at DESC`
+
+	rows, err := s.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("listing sessions by user: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []*Session
+	for rows.Next() {
+		var sess Session
+		if err := rows.Scan(&sess.ID, &sess.UserID, &sess.RefreshTokenHash, &sess.ExpiresAt, &sess.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scanning session row: %w", err)
+		}
+		sessions = append(sessions, &sess)
+	}
+	return sessions, nil
+}
+
+// CountByUserID returns the number of active sessions for a user.
+func (s *PGStore) CountByUserID(ctx context.Context, userID uuid.UUID) (int, error) {
+	var count int
+	err := s.pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM sessions WHERE user_id = $1 AND expires_at > now()",
+		userID,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("counting sessions by user: %w", err)
+	}
+	return count, nil
+}
+
+// CountActive returns the total number of active sessions across all users.
+func (s *PGStore) CountActive(ctx context.Context) (int, error) {
+	var count int
+	err := s.pool.QueryRow(ctx, "SELECT COUNT(*) FROM sessions WHERE expires_at > now()").Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("counting active sessions: %w", err)
+	}
+	return count, nil
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,91 +1,138 @@
 import { useState, useEffect, useCallback } from "react";
 import LoginForm from "./components/LoginForm";
 import RegistrationForm from "./components/RegistrationForm";
-import Dashboard from "./components/Dashboard";
+import Layout from "./components/admin/Layout";
+import DashboardPage from "./components/admin/DashboardPage";
+import UsersPage from "./components/admin/UsersPage";
+import UserDetailPage from "./components/admin/UserDetailPage";
+import UserCreatePage from "./components/admin/UserCreatePage";
+import ToastContainer from "./components/admin/Toast";
 import { getStoredTokens } from "./api/auth";
 
-type Route = "login" | "register" | "dashboard";
+type Route = "login" | "register" | "admin";
 
 function getRoute(): Route {
   const hash = window.location.hash.replace("#/", "");
   if (hash === "register") return "register";
-  if (hash === "dashboard") return "dashboard";
+  if (hash.startsWith("admin")) return "admin";
+  // Legacy: redirect old "dashboard" hash to admin
+  if (hash === "dashboard") return "admin";
   return "login";
+}
+
+function getAdminPage(): string {
+  const hash = window.location.hash.replace("#/", "");
+  if (hash.startsWith("admin/")) return hash.slice(6);
+  return "dashboard";
 }
 
 export default function App() {
   const [route, setRoute] = useState<Route>(getRoute);
+  const [adminPage, setAdminPage] = useState(getAdminPage);
 
   useEffect(() => {
     function onHashChange() {
       setRoute(getRoute());
+      setAdminPage(getAdminPage());
     }
     window.addEventListener("hashchange", onHashChange);
     return () => window.removeEventListener("hashchange", onHashChange);
   }, []);
 
-  // If user has tokens, redirect to dashboard
+  // If user has tokens, redirect to admin
   useEffect(() => {
     if (route === "login" || route === "register") {
       const { accessToken } = getStoredTokens();
       if (accessToken) {
-        navigate("dashboard");
+        navigate("admin/dashboard");
       }
     }
   }, [route]);
 
-  function navigate(r: Route) {
-    window.location.hash = `#/${r}`;
+  function navigate(path: string) {
+    window.location.hash = `#/${path}`;
   }
 
   const handleLogout = useCallback(() => {
     navigate("login");
   }, []);
 
-  return (
-    <div className="flex min-h-screen flex-col bg-gradient-to-br from-slate-50 to-slate-100">
-      {/* Header bar */}
-      <header className="border-b border-slate-200 bg-white px-6 py-4 shadow-sm">
-        <div className="mx-auto flex max-w-7xl items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-slate-900">
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="h-5 w-5 text-white"
-            >
-              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-            </svg>
-          </div>
-          <span className="text-xl font-bold tracking-tight text-slate-900">
-            Rampart
-          </span>
-        </div>
-      </header>
+  const handleAdminNavigate = useCallback((page: string) => {
+    navigate(`admin/${page}`);
+  }, []);
 
-      {/* Main content */}
-      <main className="flex flex-1 items-center justify-center px-4 py-12">
-        <div className="w-full max-w-md">
-          {route === "login" && (
-            <LoginForm
-              onSuccess={() => navigate("dashboard")}
-              onNavigateRegister={() => navigate("register")}
+  // Auth pages (login/register)
+  if (route !== "admin") {
+    return (
+      <div className="flex min-h-screen flex-col bg-gradient-to-br from-slate-50 to-slate-100">
+        <header className="border-b border-slate-200 bg-white px-6 py-4 shadow-sm">
+          <div className="mx-auto flex max-w-7xl items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-slate-900">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-5 w-5 text-white"
+              >
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+              </svg>
+            </div>
+            <span className="text-xl font-bold tracking-tight text-slate-900">
+              Rampart
+            </span>
+          </div>
+        </header>
+
+        <main className="flex flex-1 items-center justify-center px-4 py-12">
+          <div className="w-full max-w-md">
+            {route === "login" && (
+              <LoginForm
+                onSuccess={() => navigate("admin/dashboard")}
+                onNavigateRegister={() => navigate("register")}
+              />
+            )}
+            {route === "register" && (
+              <RegistrationForm onNavigateLogin={() => navigate("login")} />
+            )}
+            <p className="mt-6 text-center text-xs text-slate-400">
+              Powered by Rampart Identity Server
+            </p>
+          </div>
+        </main>
+        <ToastContainer />
+      </div>
+    );
+  }
+
+  // Admin console
+  return (
+    <>
+      <Layout
+        currentPage={adminPage}
+        onNavigate={handleAdminNavigate}
+        onLogout={handleLogout}
+      >
+        {adminPage === "dashboard" && (
+          <DashboardPage onNavigate={handleAdminNavigate} />
+        )}
+        {adminPage === "users" && (
+          <UsersPage onNavigate={handleAdminNavigate} />
+        )}
+        {adminPage === "users/new" && (
+          <UserCreatePage onNavigate={handleAdminNavigate} />
+        )}
+        {adminPage.startsWith("users/") &&
+          adminPage !== "users/new" && (
+            <UserDetailPage
+              userId={adminPage.slice(6)}
+              onNavigate={handleAdminNavigate}
             />
           )}
-          {route === "register" && (
-            <RegistrationForm onNavigateLogin={() => navigate("login")} />
-          )}
-          {route === "dashboard" && (
-            <Dashboard onLogout={handleLogout} />
-          )}
-          <p className="mt-6 text-center text-xs text-slate-400">
-            Powered by Rampart Identity Server
-          </p>
-        </div>
-      </main>
-    </div>
+      </Layout>
+      <ToastContainer />
+    </>
   );
 }

--- a/web/src/api/admin.ts
+++ b/web/src/api/admin.ts
@@ -1,0 +1,133 @@
+import { getStoredTokens, refreshToken } from "./auth";
+import type {
+  DashboardStats,
+  ListUsersResponse,
+  AdminUserResponse,
+  CreateUserRequest,
+  UpdateUserRequest,
+  ResetPasswordRequest,
+  SessionResponse,
+} from "../types";
+
+async function authFetch(url: string, init?: RequestInit): Promise<Response> {
+  const { accessToken } = getStoredTokens();
+  const headers: Record<string, string> = {
+    ...((init?.headers as Record<string, string>) ?? {}),
+    Authorization: `Bearer ${accessToken}`,
+  };
+
+  let res = await fetch(url, { ...init, headers });
+
+  if (res.status === 401) {
+    const refreshed = await refreshToken();
+    if (!refreshed) throw new Error("Session expired");
+    headers.Authorization = `Bearer ${refreshed.access_token}`;
+    res = await fetch(url, { ...init, headers });
+  }
+
+  return res;
+}
+
+async function authJSON<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await authFetch(url, init);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { error_description?: string }).error_description ??
+        `Request failed: ${res.status}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+export async function getStats(): Promise<DashboardStats> {
+  return authJSON<DashboardStats>("/api/v1/admin/stats");
+}
+
+export async function listUsers(
+  page = 1,
+  limit = 20,
+  search = "",
+  status = "",
+): Promise<ListUsersResponse> {
+  const params = new URLSearchParams({
+    page: String(page),
+    limit: String(limit),
+  });
+  if (search) params.set("search", search);
+  if (status) params.set("status", status);
+  return authJSON<ListUsersResponse>(`/api/v1/admin/users?${params}`);
+}
+
+export async function getUser(id: string): Promise<AdminUserResponse> {
+  return authJSON<AdminUserResponse>(`/api/v1/admin/users/${id}`);
+}
+
+export async function createUser(
+  data: CreateUserRequest,
+): Promise<AdminUserResponse> {
+  return authJSON<AdminUserResponse>("/api/v1/admin/users", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateUser(
+  id: string,
+  data: UpdateUserRequest,
+): Promise<AdminUserResponse> {
+  return authJSON<AdminUserResponse>(`/api/v1/admin/users/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteUser(id: string): Promise<void> {
+  const res = await authFetch(`/api/v1/admin/users/${id}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { error_description?: string }).error_description ??
+        `Delete failed: ${res.status}`,
+    );
+  }
+}
+
+export async function resetPassword(
+  id: string,
+  data: ResetPasswordRequest,
+): Promise<void> {
+  const res = await authFetch(`/api/v1/admin/users/${id}/reset-password`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { error_description?: string }).error_description ??
+        `Reset failed: ${res.status}`,
+    );
+  }
+}
+
+export async function listSessions(id: string): Promise<SessionResponse[]> {
+  return authJSON<SessionResponse[]>(`/api/v1/admin/users/${id}/sessions`);
+}
+
+export async function revokeSessions(id: string): Promise<void> {
+  const res = await authFetch(`/api/v1/admin/users/${id}/sessions`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { error_description?: string }).error_description ??
+        `Revoke failed: ${res.status}`,
+    );
+  }
+}

--- a/web/src/components/admin/DashboardPage.tsx
+++ b/web/src/components/admin/DashboardPage.tsx
@@ -1,0 +1,91 @@
+import { useState, useEffect } from "react";
+import { getStats } from "../../api/admin";
+import type { DashboardStats } from "../../types";
+
+interface DashboardPageProps {
+  onNavigate: (page: string) => void;
+}
+
+export default function DashboardPage({ onNavigate }: DashboardPageProps) {
+  const [stats, setStats] = useState<DashboardStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getStats()
+      .then(setStats)
+      .catch(() => setStats(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-slate-900" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <h1 className="text-2xl font-bold text-slate-900">Dashboard</h1>
+      <p className="mt-1 text-sm text-slate-500">
+        Overview of your identity server
+      </p>
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-3">
+        <StatCard
+          label="Total Users"
+          value={stats?.total_users ?? 0}
+          color="bg-blue-50 text-blue-700"
+        />
+        <StatCard
+          label="Active Sessions"
+          value={stats?.active_sessions ?? 0}
+          color="bg-emerald-50 text-emerald-700"
+        />
+        <StatCard
+          label="New Users (7d)"
+          value={stats?.recent_users ?? 0}
+          color="bg-purple-50 text-purple-700"
+        />
+      </div>
+
+      <div className="mt-8">
+        <h2 className="text-lg font-semibold text-slate-900">Quick Actions</h2>
+        <div className="mt-3 flex flex-wrap gap-3">
+          <button
+            onClick={() => onNavigate("users")}
+            className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            View all users
+          </button>
+          <button
+            onClick={() => onNavigate("users/new")}
+            className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800"
+          >
+            Create user
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: number;
+  color: string;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <p className="text-sm font-medium text-slate-500">{label}</p>
+      <p className={`mt-2 text-3xl font-bold ${color} inline-block rounded-lg px-2 py-1`}>
+        {value}
+      </p>
+    </div>
+  );
+}

--- a/web/src/components/admin/Layout.tsx
+++ b/web/src/components/admin/Layout.tsx
@@ -1,0 +1,69 @@
+import { useState, useCallback } from "react";
+import Sidebar from "./Sidebar";
+import { logout } from "../../api/auth";
+
+interface LayoutProps {
+  currentPage: string;
+  onNavigate: (page: string) => void;
+  onLogout: () => void;
+  children: React.ReactNode;
+}
+
+export default function Layout({
+  currentPage,
+  onNavigate,
+  onLogout,
+  children,
+}: LayoutProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const handleLogout = useCallback(async () => {
+    await logout();
+    onLogout();
+  }, [onLogout]);
+
+  return (
+    <div className="flex h-screen bg-slate-50">
+      <Sidebar
+        collapsed={collapsed}
+        onToggle={() => setCollapsed(!collapsed)}
+        currentPage={currentPage}
+        onNavigate={onNavigate}
+      />
+
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Topbar */}
+        <header className="flex h-14 items-center justify-between border-b border-slate-200 bg-white px-6">
+          <div className="flex items-center gap-3">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-slate-900">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-4 w-4 text-white"
+              >
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+              </svg>
+            </div>
+            <span className="text-sm font-bold tracking-tight text-slate-900">
+              Rampart
+            </span>
+          </div>
+
+          <button
+            onClick={handleLogout}
+            className="rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Sign out
+          </button>
+        </header>
+
+        {/* Main content area */}
+        <main className="flex-1 overflow-y-auto p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/admin/Modal.tsx
+++ b/web/src/components/admin/Modal.tsx
@@ -1,0 +1,49 @@
+interface ModalProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  confirmVariant?: "danger" | "primary";
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function Modal({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  confirmVariant = "primary",
+  onConfirm,
+  onCancel,
+}: ModalProps) {
+  if (!open) return null;
+
+  const confirmClasses =
+    confirmVariant === "danger"
+      ? "bg-red-600 hover:bg-red-700 text-white"
+      : "bg-slate-900 hover:bg-slate-800 text-white";
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+        <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+        <p className="mt-2 text-sm text-slate-600">{message}</p>
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className={`rounded-lg px-4 py-2 text-sm font-medium ${confirmClasses}`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/admin/Sidebar.tsx
+++ b/web/src/components/admin/Sidebar.tsx
@@ -1,0 +1,95 @@
+interface SidebarProps {
+  collapsed: boolean;
+  onToggle: () => void;
+  currentPage: string;
+  onNavigate: (page: string) => void;
+}
+
+const navItems = [
+  { id: "dashboard", label: "Dashboard", icon: ChartIcon },
+  { id: "users", label: "Users", icon: UsersIcon },
+];
+
+export default function Sidebar({
+  collapsed,
+  onToggle,
+  currentPage,
+  onNavigate,
+}: SidebarProps) {
+  return (
+    <aside
+      className={`flex flex-col border-r border-slate-200 bg-white transition-all duration-200 ${
+        collapsed ? "w-16" : "w-56"
+      }`}
+    >
+      <div className="flex h-14 items-center justify-between border-b border-slate-200 px-3">
+        {!collapsed && (
+          <span className="text-sm font-bold tracking-tight text-slate-900">
+            Admin
+          </span>
+        )}
+        <button
+          onClick={onToggle}
+          className="rounded-md p-1.5 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+        >
+          <svg
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="h-4 w-4"
+          >
+            {collapsed ? (
+              <path
+                fillRule="evenodd"
+                d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+                clipRule="evenodd"
+              />
+            ) : (
+              <path
+                fillRule="evenodd"
+                d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+                clipRule="evenodd"
+              />
+            )}
+          </svg>
+        </button>
+      </div>
+
+      <nav className="flex-1 p-2">
+        {navItems.map((item) => {
+          const active = currentPage.startsWith(item.id);
+          return (
+            <button
+              key={item.id}
+              onClick={() => onNavigate(item.id)}
+              className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                active
+                  ? "bg-slate-100 text-slate-900"
+                  : "text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+              }`}
+            >
+              <item.icon className="h-4 w-4 flex-shrink-0" />
+              {!collapsed && <span>{item.label}</span>}
+            </button>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}
+
+function ChartIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 20 20" fill="currentColor" className={className}>
+      <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zm6-4a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zm6-3a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />
+    </svg>
+  );
+}
+
+function UsersIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 20 20" fill="currentColor" className={className}>
+      <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zm8 0a3 3 0 11-6 0 3 3 0 016 0zm-4.07 11c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z" />
+    </svg>
+  );
+}

--- a/web/src/components/admin/Toast.tsx
+++ b/web/src/components/admin/Toast.tsx
@@ -1,0 +1,51 @@
+import { useState, useEffect, useCallback } from "react";
+
+export interface ToastMessage {
+  id: number;
+  type: "success" | "error";
+  text: string;
+}
+
+let nextId = 0;
+let addToastFn: ((type: "success" | "error", text: string) => void) | null =
+  null;
+
+export function toast(type: "success" | "error", text: string) {
+  addToastFn?.(type, text);
+}
+
+export default function ToastContainer() {
+  const [messages, setMessages] = useState<ToastMessage[]>([]);
+
+  const addToast = useCallback((type: "success" | "error", text: string) => {
+    const id = nextId++;
+    setMessages((prev) => [...prev, { id, type, text }]);
+    setTimeout(() => {
+      setMessages((prev) => prev.filter((m) => m.id !== id));
+    }, 4000);
+  }, []);
+
+  useEffect(() => {
+    addToastFn = addToast;
+    return () => {
+      addToastFn = null;
+    };
+  }, [addToast]);
+
+  if (messages.length === 0) return null;
+
+  return (
+    <div className="fixed right-4 top-4 z-50 flex flex-col gap-2">
+      {messages.map((m) => (
+        <div
+          key={m.id}
+          className={`rounded-lg px-4 py-3 text-sm font-medium text-white shadow-lg transition-all ${
+            m.type === "success" ? "bg-emerald-600" : "bg-red-600"
+          }`}
+        >
+          {m.text}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/admin/UserCreatePage.tsx
+++ b/web/src/components/admin/UserCreatePage.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import { createUser } from "../../api/admin";
+import { toast } from "./Toast";
+
+interface UserCreatePageProps {
+  onNavigate: (page: string) => void;
+}
+
+export default function UserCreatePage({ onNavigate }: UserCreatePageProps) {
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [givenName, setGivenName] = useState("");
+  const [familyName, setFamilyName] = useState("");
+  const [enabled, setEnabled] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const user = await createUser({
+        username,
+        email,
+        password,
+        given_name: givenName,
+        family_name: familyName,
+        enabled,
+      });
+      toast("success", `User ${user.username} created`);
+      onNavigate(`users/${user.id}`);
+    } catch (err) {
+      toast("error", (err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-lg">
+      <button
+        onClick={() => onNavigate("users")}
+        className="mb-4 text-sm text-slate-500 hover:text-slate-700"
+      >
+        &larr; Back to users
+      </button>
+
+      <h1 className="text-2xl font-bold text-slate-900">Create User</h1>
+      <p className="mt-1 text-sm text-slate-500">
+        Add a new user to the system
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+        <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-700">
+              Username
+            </label>
+            <input
+              type="text"
+              required
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700">
+              Email
+            </label>
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700">
+              Password
+            </label>
+            <input
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+            />
+            <p className="mt-1 text-xs text-slate-400">
+              Min 8 chars, uppercase, lowercase, digit, special character
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-slate-700">
+                First name
+              </label>
+              <input
+                type="text"
+                value={givenName}
+                onChange={(e) => setGivenName(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700">
+                Last name
+              </label>
+              <input
+                type="text"
+                value={familyName}
+                onChange={(e) => setFamilyName(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              />
+            </div>
+          </div>
+          <label className="flex items-center gap-2 text-sm text-slate-700">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+              className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+            />
+            Account enabled
+          </label>
+        </div>
+
+        <button
+          type="submit"
+          disabled={saving}
+          className="w-full rounded-lg bg-slate-900 py-2.5 text-sm font-medium text-white hover:bg-slate-800 disabled:opacity-50"
+        >
+          {saving ? "Creating..." : "Create user"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/web/src/components/admin/UserDetailPage.tsx
+++ b/web/src/components/admin/UserDetailPage.tsx
@@ -1,0 +1,320 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  getUser,
+  updateUser,
+  deleteUser,
+  resetPassword,
+  listSessions,
+  revokeSessions,
+} from "../../api/admin";
+import type {
+  AdminUserResponse,
+  SessionResponse,
+  UpdateUserRequest,
+} from "../../types";
+import Modal from "./Modal";
+import { toast } from "./Toast";
+
+interface UserDetailPageProps {
+  userId: string;
+  onNavigate: (page: string) => void;
+}
+
+export default function UserDetailPage({
+  userId,
+  onNavigate,
+}: UserDetailPageProps) {
+  const [user, setUser] = useState<AdminUserResponse | null>(null);
+  const [sessions, setSessions] = useState<SessionResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  // Form state
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [givenName, setGivenName] = useState("");
+  const [familyName, setFamilyName] = useState("");
+  const [enabled, setEnabled] = useState(true);
+  const [emailVerified, setEmailVerified] = useState(false);
+
+  // Password reset
+  const [newPassword, setNewPassword] = useState("");
+
+  // Modals
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showRevokeModal, setShowRevokeModal] = useState(false);
+
+  const fetchData = useCallback(() => {
+    setLoading(true);
+    Promise.all([getUser(userId), listSessions(userId)])
+      .then(([u, s]) => {
+        setUser(u);
+        setSessions(s);
+        setUsername(u.username);
+        setEmail(u.email);
+        setGivenName(u.given_name ?? "");
+        setFamilyName(u.family_name ?? "");
+        setEnabled(u.enabled);
+        setEmailVerified(u.email_verified);
+      })
+      .catch(() => toast("error", "Failed to load user"))
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const req: UpdateUserRequest = {
+        username,
+        email,
+        given_name: givenName,
+        family_name: familyName,
+        enabled,
+        email_verified: emailVerified,
+      };
+      const updated = await updateUser(userId, req);
+      setUser(updated);
+      toast("success", "User updated");
+    } catch (e) {
+      toast("error", (e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteUser(userId);
+      toast("success", "User deleted");
+      onNavigate("users");
+    } catch (e) {
+      toast("error", (e as Error).message);
+    }
+    setShowDeleteModal(false);
+  };
+
+  const handleResetPassword = async () => {
+    if (!newPassword) return;
+    try {
+      await resetPassword(userId, { password: newPassword });
+      setNewPassword("");
+      toast("success", "Password reset");
+    } catch (e) {
+      toast("error", (e as Error).message);
+    }
+  };
+
+  const handleRevokeSessions = async () => {
+    try {
+      await revokeSessions(userId);
+      setSessions([]);
+      toast("success", "All sessions revoked");
+    } catch (e) {
+      toast("error", (e as Error).message);
+    }
+    setShowRevokeModal(false);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-slate-900" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="text-center py-20 text-slate-500">User not found</div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <button
+        onClick={() => onNavigate("users")}
+        className="mb-4 text-sm text-slate-500 hover:text-slate-700"
+      >
+        &larr; Back to users
+      </button>
+
+      <h1 className="text-2xl font-bold text-slate-900">{user.username}</h1>
+      <p className="mt-1 text-sm text-slate-500">{user.email}</p>
+
+      {/* Profile Card */}
+      <div className="mt-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">Profile</h2>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          <Field label="Username" value={username} onChange={setUsername} />
+          <Field label="Email" value={email} onChange={setEmail} />
+          <Field label="First name" value={givenName} onChange={setGivenName} />
+          <Field
+            label="Last name"
+            value={familyName}
+            onChange={setFamilyName}
+          />
+        </div>
+        <div className="mt-4 flex flex-wrap gap-4">
+          <Toggle label="Enabled" checked={enabled} onChange={setEnabled} />
+          <Toggle
+            label="Email verified"
+            checked={emailVerified}
+            onChange={setEmailVerified}
+          />
+        </div>
+        <div className="mt-6">
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800 disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save changes"}
+          </button>
+        </div>
+      </div>
+
+      {/* Sessions Card */}
+      <div className="mt-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">
+            Sessions ({sessions.length})
+          </h2>
+          {sessions.length > 0 && (
+            <button
+              onClick={() => setShowRevokeModal(true)}
+              className="text-sm font-medium text-red-600 hover:text-red-700"
+            >
+              Revoke all
+            </button>
+          )}
+        </div>
+        {sessions.length === 0 ? (
+          <p className="mt-3 text-sm text-slate-400">No active sessions</p>
+        ) : (
+          <div className="mt-3 divide-y divide-slate-100">
+            {sessions.map((s) => (
+              <div key={s.id} className="flex items-center justify-between py-2">
+                <div>
+                  <p className="text-sm font-mono text-slate-700">
+                    {s.id.slice(0, 8)}...
+                  </p>
+                  <p className="text-xs text-slate-400">
+                    Created {new Date(s.created_at).toLocaleString()}
+                  </p>
+                </div>
+                <span className="text-xs text-slate-400">
+                  Expires {new Date(s.expires_at).toLocaleString()}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Password Reset Card */}
+      <div className="mt-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">Reset Password</h2>
+        <div className="mt-3 flex gap-3">
+          <input
+            type="password"
+            placeholder="New password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+          />
+          <button
+            onClick={handleResetPassword}
+            disabled={!newPassword}
+            className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+
+      {/* Danger Zone */}
+      <div className="mt-6 rounded-xl border border-red-200 bg-red-50 p-6">
+        <h2 className="text-lg font-semibold text-red-900">Danger Zone</h2>
+        <p className="mt-1 text-sm text-red-700">
+          Deleting this user is permanent and cannot be undone.
+        </p>
+        <button
+          onClick={() => setShowDeleteModal(true)}
+          className="mt-4 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+        >
+          Delete user
+        </button>
+      </div>
+
+      {/* Modals */}
+      <Modal
+        open={showDeleteModal}
+        title="Delete user"
+        message={`Are you sure you want to delete ${user.username}? This action cannot be undone.`}
+        confirmLabel="Delete"
+        confirmVariant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setShowDeleteModal(false)}
+      />
+      <Modal
+        open={showRevokeModal}
+        title="Revoke all sessions"
+        message={`This will sign ${user.username} out of all devices immediately.`}
+        confirmLabel="Revoke all"
+        confirmVariant="danger"
+        onConfirm={handleRevokeSessions}
+        onCancel={() => setShowRevokeModal(false)}
+      />
+    </div>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-slate-700">
+        {label}
+      </label>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+      />
+    </div>
+  );
+}
+
+function Toggle({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-sm text-slate-700">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+      />
+      {label}
+    </label>
+  );
+}

--- a/web/src/components/admin/UsersPage.tsx
+++ b/web/src/components/admin/UsersPage.tsx
@@ -1,0 +1,190 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { listUsers } from "../../api/admin";
+import type { AdminUserResponse, ListUsersResponse } from "../../types";
+
+interface UsersPageProps {
+  onNavigate: (page: string) => void;
+}
+
+export default function UsersPage({ onNavigate }: UsersPageProps) {
+  const [data, setData] = useState<ListUsersResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [status, setStatus] = useState("");
+  const [page, setPage] = useState(1);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const fetchUsers = useCallback(
+    (p: number, s: string, st: string) => {
+      setLoading(true);
+      listUsers(p, 20, s, st)
+        .then(setData)
+        .catch(() => setData(null))
+        .finally(() => setLoading(false));
+    },
+    [],
+  );
+
+  useEffect(() => {
+    fetchUsers(page, search, status);
+  }, [page, status, fetchUsers]);
+
+  // Debounced search
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setPage(1);
+      fetchUsers(1, value, status);
+    }, 300);
+  };
+
+  const totalPages = data ? Math.ceil(data.total / data.limit) : 0;
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Users</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            {data ? `${data.total} total users` : "Loading..."}
+          </p>
+        </div>
+        <button
+          onClick={() => onNavigate("users/new")}
+          className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800"
+        >
+          Create user
+        </button>
+      </div>
+
+      {/* Search + Filter */}
+      <div className="mt-4 flex gap-3">
+        <input
+          type="text"
+          placeholder="Search users..."
+          value={search}
+          onChange={(e) => handleSearchChange(e.target.value)}
+          className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+        />
+        <select
+          value={status}
+          onChange={(e) => {
+            setStatus(e.target.value);
+            setPage(1);
+          }}
+          className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+        >
+          <option value="">All statuses</option>
+          <option value="enabled">Enabled</option>
+          <option value="disabled">Disabled</option>
+        </select>
+      </div>
+
+      {/* Table */}
+      <div className="mt-4 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-slate-200 border-t-slate-900" />
+          </div>
+        ) : (
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 bg-slate-50">
+                <th className="px-4 py-3 font-medium text-slate-600">User</th>
+                <th className="px-4 py-3 font-medium text-slate-600">Email</th>
+                <th className="px-4 py-3 font-medium text-slate-600">Status</th>
+                <th className="px-4 py-3 font-medium text-slate-600">Sessions</th>
+                <th className="px-4 py-3 font-medium text-slate-600">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data?.users.map((user) => (
+                <UserRow
+                  key={user.id}
+                  user={user}
+                  onClick={() => onNavigate(`users/${user.id}`)}
+                />
+              ))}
+              {data?.users.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-8 text-center text-slate-400"
+                  >
+                    No users found
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-between">
+          <p className="text-sm text-slate-500">
+            Page {page} of {totalPages}
+          </p>
+          <div className="flex gap-2">
+            <button
+              disabled={page <= 1}
+              onClick={() => setPage(page - 1)}
+              className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            >
+              Previous
+            </button>
+            <button
+              disabled={page >= totalPages}
+              onClick={() => setPage(page + 1)}
+              className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UserRow({
+  user,
+  onClick,
+}: {
+  user: AdminUserResponse;
+  onClick: () => void;
+}) {
+  return (
+    <tr
+      onClick={onClick}
+      className="cursor-pointer border-b border-slate-100 transition-colors hover:bg-slate-50"
+    >
+      <td className="px-4 py-3">
+        <div className="font-medium text-slate-900">{user.username}</div>
+        {(user.given_name || user.family_name) && (
+          <div className="text-xs text-slate-500">
+            {[user.given_name, user.family_name].filter(Boolean).join(" ")}
+          </div>
+        )}
+      </td>
+      <td className="px-4 py-3 text-slate-600">{user.email}</td>
+      <td className="px-4 py-3">
+        <span
+          className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+            user.enabled
+              ? "bg-emerald-50 text-emerald-700"
+              : "bg-red-50 text-red-700"
+          }`}
+        >
+          {user.enabled ? "Enabled" : "Disabled"}
+        </span>
+      </td>
+      <td className="px-4 py-3 text-slate-600">{user.session_count}</td>
+      <td className="px-4 py-3 text-slate-500 text-xs">
+        {new Date(user.created_at).toLocaleDateString()}
+      </td>
+    </tr>
+  );
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -67,3 +67,62 @@ export interface MeResponse {
   given_name?: string;
   family_name?: string;
 }
+
+// Admin types
+
+export interface AdminUserResponse {
+  id: string;
+  org_id: string;
+  username: string;
+  email: string;
+  email_verified: boolean;
+  given_name?: string;
+  family_name?: string;
+  enabled: boolean;
+  mfa_enabled: boolean;
+  last_login_at?: string;
+  session_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ListUsersResponse {
+  users: AdminUserResponse[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export interface CreateUserRequest {
+  username: string;
+  email: string;
+  password: string;
+  given_name: string;
+  family_name: string;
+  enabled: boolean;
+}
+
+export interface UpdateUserRequest {
+  username: string;
+  email: string;
+  given_name: string;
+  family_name: string;
+  enabled: boolean;
+  email_verified: boolean;
+}
+
+export interface ResetPasswordRequest {
+  password: string;
+}
+
+export interface DashboardStats {
+  total_users: number;
+  active_sessions: number;
+  recent_users: number;
+}
+
+export interface SessionResponse {
+  id: string;
+  created_at: string;
+  expires_at: string;
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       '/me': 'http://localhost:8080',
       '/healthz': 'http://localhost:8080',
       '/readyz': 'http://localhost:8080',
+      '/api': 'http://localhost:8080',
     },
   },
 })


### PR DESCRIPTION
## Summary

- **9 admin API endpoints** under `/api/v1/admin` — dashboard stats, full user CRUD, password reset, session management
- **Modern admin console UI** — collapsible sidebar, stat cards, searchable user table with debounced search + filters + pagination, editable user detail pages, confirmation modals, toast notifications
- **16 unit tests** covering all admin endpoints including self-deletion prevention
- No new npm dependencies — pure React + Tailwind

## Backend

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/v1/admin/stats` | Dashboard stats (total users, active sessions, new users 7d) |
| `GET` | `/api/v1/admin/users` | List users (paginated, searchable, filterable) |
| `POST` | `/api/v1/admin/users` | Create user (admin-initiated) |
| `GET` | `/api/v1/admin/users/{id}` | Get user detail + session count |
| `PUT` | `/api/v1/admin/users/{id}` | Update user fields |
| `DELETE` | `/api/v1/admin/users/{id}` | Delete user (self-deletion prevented) |
| `POST` | `/api/v1/admin/users/{id}/reset-password` | Reset password |
| `GET` | `/api/v1/admin/users/{id}/sessions` | List user sessions |
| `DELETE` | `/api/v1/admin/users/{id}/sessions` | Revoke all sessions |

## Frontend

- **Layout**: collapsible sidebar + topbar + scrollable content
- **Dashboard**: stat cards + quick actions
- **Users list**: searchable table, debounced search, status filters, pagination, color-coded badges
- **User detail**: editable profile, sessions list, password reset, danger zone with confirmation
- **User create**: admin-initiated creation form with validation
- **Modal + Toast**: confirmation dialogs + notification system

## Design Decisions

- Any authenticated user = admin (role system is next PR)
- Handler defines its own interfaces — PGStore satisfies implicitly
- No new npm deps — pure Tailwind + React
- Dynamic SQL with $N params for safe ListUsers query building

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./internal/...` — all pass (16 new admin tests)
- [x] `golangci-lint run ./...` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vite build` — clean
- [ ] Manual: login → dashboard with real stats → users list with search → user detail → edit/delete/reset password