### PR TITLE
feat: org switcher — switch orgs without re-login

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -68,7 +68,7 @@ func (h *AdminHandler) Stats(w http.ResponseWriter, r *http.Request) {
 		apierror.Unauthorized(w, "Authentication required.")
 		return
 	}
-	orgID := authUser.OrgID
+	orgID := resolveOrgID(r, authUser)
 
 	totalUsers, err := h.store.CountUsers(ctx, orgID)
 	if err != nil {
@@ -117,7 +117,7 @@ func (h *AdminHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 		apierror.Unauthorized(w, "Authentication required.")
 		return
 	}
-	orgID := authUser.OrgID
+	orgID := resolveOrgID(r, authUser)
 
 	search := r.URL.Query().Get("search")
 	status := r.URL.Query().Get("status")
@@ -180,7 +180,7 @@ func (h *AdminHandler) CreateUser(w http.ResponseWriter, r *http.Request) {
 		apierror.Unauthorized(w, "Authentication required.")
 		return
 	}
-	orgID := authUser.OrgID
+	orgID := resolveOrgID(r, authUser)
 
 	// Fetch per-org password policy (fall back to defaults if settings not found).
 	passwordPolicy := auth.DefaultPasswordPolicy()
@@ -457,6 +457,18 @@ func (h *AdminHandler) RevokeSessions(w http.ResponseWriter, r *http.Request) {
 }
 
 // --- Helpers ---
+
+// resolveOrgID returns the org context for this request.
+// If the X-Org-Context header is set to a valid UUID, that is used (org switching).
+// Otherwise falls back to the authenticated user's own org from the JWT.
+func resolveOrgID(r *http.Request, authUser *middleware.AuthenticatedUser) uuid.UUID {
+	if header := r.Header.Get("X-Org-Context"); header != "" {
+		if parsed, err := uuid.Parse(header); err == nil {
+			return parsed
+		}
+	}
+	return authUser.OrgID
+}
 
 func parseUUIDParam(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
 	raw := chi.URLParam(r, "id")

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -24,7 +24,7 @@ func NewRouter(logger *slog.Logger, allowedOrigins []string) *chi.Mux {
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   allowedOrigins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", middleware.HeaderRequestID},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", middleware.HeaderRequestID, "X-Org-Context"},
 		ExposedHeaders:   []string{middleware.HeaderRequestID},
 		AllowCredentials: false,
 		MaxAge:           300,

--- a/web/src/api/admin.ts
+++ b/web/src/api/admin.ts
@@ -1,4 +1,5 @@
 import { getStoredTokens, refreshToken } from "./auth";
+import { getActiveOrgId } from "../hooks/useCurrentOrg";
 import type {
   DashboardStats,
   ListUsersResponse,
@@ -15,6 +16,12 @@ export async function authFetch(url: string, init?: RequestInit): Promise<Respon
     ...((init?.headers as Record<string, string>) ?? {}),
     Authorization: `Bearer ${accessToken}`,
   };
+
+  // Send active org context for org-scoped admin operations
+  const activeOrgId = getActiveOrgId();
+  if (activeOrgId) {
+    headers["X-Org-Context"] = activeOrgId;
+  }
 
   let res = await fetch(url, { ...init, headers });
 

--- a/web/src/components/admin/Sidebar.tsx
+++ b/web/src/components/admin/Sidebar.tsx
@@ -1,4 +1,7 @@
+import { useState, useEffect, useRef } from "react";
 import { useCurrentOrg } from "../../hooks/useCurrentOrg";
+import { listOrgs } from "../../api/organizations";
+import type { OrgResponse } from "../../types";
 
 interface SidebarProps {
   collapsed: boolean;
@@ -19,7 +22,42 @@ export default function Sidebar({
   currentPage,
   onNavigate,
 }: SidebarProps) {
-  const { org } = useCurrentOrg();
+  const { org, switchOrg } = useCurrentOrg();
+  const [showSwitcher, setShowSwitcher] = useState(false);
+  const [orgs, setOrgs] = useState<OrgResponse[]>([]);
+  const switcherRef = useRef<HTMLDivElement>(null);
+
+  // Close switcher on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (switcherRef.current && !switcherRef.current.contains(e.target as Node)) {
+        setShowSwitcher(false);
+      }
+    }
+    if (showSwitcher) {
+      document.addEventListener("mousedown", handleClick);
+    }
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [showSwitcher]);
+
+  const handleOpenSwitcher = () => {
+    if (collapsed) return;
+    setShowSwitcher(!showSwitcher);
+    if (!showSwitcher) {
+      listOrgs(1, 50).then((data) => setOrgs(data.organizations)).catch(() => {});
+    }
+  };
+
+  const handleSwitch = async (target: OrgResponse) => {
+    if (target.id === org?.id) {
+      setShowSwitcher(false);
+      return;
+    }
+    await switchOrg(target.id);
+    setShowSwitcher(false);
+    // Navigate to dashboard to refresh data in the new org context
+    onNavigate("dashboard");
+  };
 
   return (
     <aside
@@ -80,26 +118,75 @@ export default function Sidebar({
         })}
       </nav>
 
-      {/* Current organization badge */}
+      {/* Organization switcher */}
       {org && (
-        <div className="border-t border-slate-200 p-2">
+        <div className="relative border-t border-slate-200 p-2" ref={switcherRef}>
+          {/* Switcher dropdown — opens upward */}
+          {showSwitcher && !collapsed && (
+            <div className="absolute bottom-full left-2 right-2 mb-1 rounded-lg border border-slate-200 bg-white py-1 shadow-lg">
+              <p className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+                Switch organization
+              </p>
+              {orgs.length === 0 && (
+                <div className="flex justify-center py-3">
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-slate-200 border-t-slate-600" />
+                </div>
+              )}
+              {orgs.map((o) => (
+                <button
+                  key={o.id}
+                  onClick={() => handleSwitch(o)}
+                  className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+                    o.id === org.id
+                      ? "bg-indigo-50 text-indigo-700"
+                      : "text-slate-700 hover:bg-slate-50"
+                  }`}
+                >
+                  <div className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded text-xs font-bold ${
+                    o.id === org.id
+                      ? "bg-indigo-100 text-indigo-700"
+                      : "bg-slate-100 text-slate-600"
+                  }`}>
+                    {(o.display_name || o.name).charAt(0).toUpperCase()}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="truncate text-xs font-medium">
+                      {o.display_name || o.name}
+                    </p>
+                    <p className="truncate text-[10px] text-slate-400">{o.slug}</p>
+                  </div>
+                  {o.id === org.id && (
+                    <svg viewBox="0 0 20 20" fill="currentColor" className="ml-auto h-4 w-4 flex-shrink-0 text-indigo-600">
+                      <path fillRule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clipRule="evenodd" />
+                    </svg>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+
           <button
-            onClick={() => onNavigate(`organizations/${org.id}`)}
+            onClick={handleOpenSwitcher}
             className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-indigo-50"
-            title={`Managing: ${org.display_name || org.name}`}
+            title={collapsed ? (org.display_name || org.name) : `Switch organization`}
           >
             <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-indigo-100 text-xs font-bold text-indigo-700">
               {(org.display_name || org.name).charAt(0).toUpperCase()}
             </div>
             {!collapsed && (
-              <div className="min-w-0 text-left">
-                <p className="truncate text-xs font-semibold text-slate-900">
-                  {org.display_name || org.name}
-                </p>
-                <p className="truncate text-[10px] text-slate-400">
-                  {org.slug}
-                </p>
-              </div>
+              <>
+                <div className="min-w-0 text-left">
+                  <p className="truncate text-xs font-semibold text-slate-900">
+                    {org.display_name || org.name}
+                  </p>
+                  <p className="truncate text-[10px] text-slate-400">
+                    {org.slug}
+                  </p>
+                </div>
+                <svg viewBox="0 0 20 20" fill="currentColor" className="ml-auto h-3.5 w-3.5 flex-shrink-0 text-slate-400">
+                  <path fillRule="evenodd" d="M5.22 8.22a.75.75 0 011.06 0L10 11.94l3.72-3.72a.75.75 0 111.06 1.06l-4.25 4.25a.75.75 0 01-1.06 0L5.22 9.28a.75.75 0 010-1.06z" clipRule="evenodd" />
+                </svg>
+              </>
             )}
           </button>
         </div>

--- a/web/src/hooks/useCurrentOrg.ts
+++ b/web/src/hooks/useCurrentOrg.ts
@@ -1,15 +1,29 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { getMe } from "../api/auth";
 import { getOrg } from "../api/organizations";
 import type { OrgResponse } from "../types";
 
+const ACTIVE_ORG_KEY = "rampart_active_org_id";
+
 let cachedOrg: OrgResponse | null = null;
+let defaultOrgId: string | null = null;
 let fetchPromise: Promise<OrgResponse | null> | null = null;
+const listeners = new Set<(org: OrgResponse | null) => void>();
+
+function notify(org: OrgResponse | null) {
+  listeners.forEach((fn) => fn(org));
+}
 
 async function resolveOrg(): Promise<OrgResponse | null> {
   const me = await getMe();
   if (!me) return null;
-  return getOrg(me.org_id);
+  defaultOrgId = me.org_id;
+
+  // Check if user previously selected a different org
+  const savedOrgId = localStorage.getItem(ACTIVE_ORG_KEY);
+  const targetOrgId = savedOrgId || me.org_id;
+
+  return getOrg(targetOrgId);
 }
 
 function fetchOnce(): Promise<OrgResponse | null> {
@@ -19,9 +33,15 @@ function fetchOnce(): Promise<OrgResponse | null> {
   return fetchPromise;
 }
 
+export function getActiveOrgId(): string | null {
+  return cachedOrg?.id ?? localStorage.getItem(ACTIVE_ORG_KEY) ?? defaultOrgId;
+}
+
 export function clearOrgCache() {
   cachedOrg = null;
+  defaultOrgId = null;
   fetchPromise = null;
+  localStorage.removeItem(ACTIVE_ORG_KEY);
 }
 
 export function useCurrentOrg() {
@@ -29,13 +49,36 @@ export function useCurrentOrg() {
   const [loading, setLoading] = useState(!cachedOrg);
 
   useEffect(() => {
-    if (cachedOrg) return;
-    fetchOnce().then((result) => {
-      cachedOrg = result;
-      setOrg(result);
-      setLoading(false);
-    });
+    // Subscribe to org changes from other components
+    const handler = (updated: OrgResponse | null) => setOrg(updated);
+    listeners.add(handler);
+
+    if (!cachedOrg) {
+      fetchOnce().then((result) => {
+        cachedOrg = result;
+        setOrg(result);
+        setLoading(false);
+      });
+    }
+
+    return () => {
+      listeners.delete(handler);
+    };
   }, []);
 
-  return { org, loading };
+  const switchOrg = useCallback(async (orgId: string) => {
+    try {
+      const newOrg = await getOrg(orgId);
+      cachedOrg = newOrg;
+      localStorage.setItem(ACTIVE_ORG_KEY, orgId);
+      // Reset fetch promise so future calls use the new org
+      fetchPromise = null;
+      setOrg(newOrg);
+      notify(newOrg);
+    } catch {
+      // If org fetch fails, stay on current org
+    }
+  }, []);
+
+  return { org, loading, switchOrg, defaultOrgId };
 }


### PR DESCRIPTION
## Summary

- Admins can now **switch between organizations** directly from the sidebar — no logout/re-login needed
- Sidebar org badge opens a dropdown listing all organizations with current org highlighted
- Backend accepts `X-Org-Context` header to override JWT org context for admin operations
- All admin API calls (stats, users, create user) now respect the selected org
- Switching orgs navigates to dashboard to refresh all data

## How it works

| Layer | Change |
|-------|--------|
| **Backend** | New `resolveOrgID()` helper checks `X-Org-Context` header first, falls back to JWT org |
| **CORS** | Added `X-Org-Context` to allowed headers |
| **Frontend API** | `authFetch()` sends `X-Org-Context` on every admin request |
| **Frontend Hook** | `useCurrentOrg()` now supports `switchOrg()` with localStorage persistence |
| **Sidebar** | Org badge opens upward dropdown with all orgs, checkmark on active |

## Why this matters

In Keycloak, switching realms requires navigating through menus and the UI often doesn't clearly indicate which realm you're in. Rampart's org switcher is always one click away in the sidebar, and the active org is visible in 5 places simultaneously.

## Test plan

- [ ] Click org badge in sidebar — dropdown shows all orgs
- [ ] Switch to a different org — dashboard/users update to show that org's data
- [ ] Create user in switched org — user belongs to selected org, not JWT org
- [ ] Refresh page — selected org persists (localStorage)
- [ ] Logout and login — resets to default org
- [ ] `go test -race ./...` passes
- [ ] `npx tsc --noEmit && npx vite build` passes