### PR TITLE
fix: switch Docker runtime to alpine for volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,16 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /rampart ./cmd/rampart
 
-# Runtime stage — distroless nonroot (~15MB)
-FROM gcr.io/distroless/static-debian12:nonroot
+# Runtime stage — alpine (~8MB, supports shell for permission setup)
+FROM alpine:3.21
+
+RUN adduser -D -u 10001 rampart && mkdir -p /data && chown rampart:rampart /data
 
 COPY --from=builder /rampart /rampart
 COPY --from=builder /app/migrations /migrations
 
 EXPOSE 8080
 
-USER nonroot:nonroot
+USER rampart
 
 ENTRYPOINT ["/rampart"]


### PR DESCRIPTION
## Summary
- Switched Docker runtime from `distroless/static-debian12:nonroot` to `alpine:3.21`
- Distroless nonroot image can't write to Docker volumes (volumes are always mounted as root)
- Added dedicated `rampart` user (UID 10001) with proper `/data` directory ownership for signing key storage

## Test plan
- [x] `docker compose up --build` starts successfully
- [x] Signing key generated and written to `/data/rampart-signing-key.pem`
- [x] All smoke tests pass (healthz, readyz, OIDC, JWKS, register, login, /me, token refresh, admin console)
- [x] `go test ./...` passes