### PR TITLE
feat: add rampart-cli management tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,18 @@ help:
 css:
 	tailwindcss --input internal/handler/static/input.css --output internal/handler/static/admin.css --minify
 
-## build: compile the binary (rebuilds CSS first)
+## build: compile the server binary (rebuilds CSS first)
 build: css
 	@mkdir -p $(BUILD_DIR)
 	go build -trimpath -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/$(APP_NAME) ./cmd/rampart
+
+## build-cli: compile the CLI binary
+build-cli:
+	@mkdir -p $(BUILD_DIR)
+	go build -trimpath -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/rampart-cli ./cmd/rampart-cli
+
+## build-all: compile both server and CLI
+build-all: build build-cli
 
 ## run: build and run the server
 run: build

--- a/cmd/rampart-cli/main.go
+++ b/cmd/rampart-cli/main.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/manimovassagh/rampart/internal/cli"
+)
+
+const version = "0.1.0"
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	cmd := os.Args[1]
+	args := os.Args[2:]
+
+	var err error
+	switch cmd {
+	case "login":
+		err = cmdLogin(args)
+	case "logout":
+		err = cmdLogout()
+	case "status":
+		err = cmdStatus()
+	case "whoami":
+		err = cmdWhoami()
+	case "users":
+		err = cmdUsers(args)
+	case "token":
+		err = cmdToken()
+	case "version":
+		fmt.Printf("rampart-cli %s\n", version)
+	case "help", "--help", "-h":
+		printUsage()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", cmd)
+		printUsage()
+		os.Exit(1)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Print(`rampart-cli — Rampart IAM management tool
+
+Usage:
+  rampart-cli <command> [options]
+
+Commands:
+  login     --issuer URL --email EMAIL --password PASS   Authenticate
+  logout                                                  Clear stored credentials
+  status                                                  Check server health
+  whoami                                                  Show current user
+  users     list | create | get <id>                      Manage users
+  token                                                   Show current access token
+  version                                                 Print version
+
+Examples:
+  rampart-cli login --issuer http://localhost:8080 --email admin@example.com --password secret
+  rampart-cli status
+  rampart-cli users list
+  rampart-cli users create --email jane@example.com --username jane --password 'P@ss1234'
+`)
+}
+
+// ── login ─────────────────────────────────────────────
+
+func cmdLogin(args []string) error {
+	var issuer, email, password string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--issuer":
+			i++
+			if i < len(args) {
+				issuer = args[i]
+			}
+		case "--email", "--identifier":
+			i++
+			if i < len(args) {
+				email = args[i]
+			}
+		case "--password":
+			i++
+			if i < len(args) {
+				password = args[i]
+			}
+		}
+	}
+
+	if issuer == "" || email == "" || password == "" {
+		return fmt.Errorf("usage: rampart-cli login --issuer URL --email EMAIL --password PASSWORD")
+	}
+
+	issuer = strings.TrimRight(issuer, "/")
+
+	cfg := &cli.Config{Issuer: issuer}
+	client := cli.NewClient(cfg)
+
+	var loginResp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		TokenType    string `json:"token_type"`
+		ExpiresIn    int    `json:"expires_in"`
+		User         struct {
+			ID       string `json:"id"`
+			Email    string `json:"email"`
+			Username string `json:"username"`
+		} `json:"user"`
+	}
+
+	err := client.Post("/login", map[string]string{
+		"identifier": email,
+		"password":   password,
+	}, &loginResp)
+	if err != nil {
+		return fmt.Errorf("login failed: %w", err)
+	}
+
+	cfg.AccessToken = loginResp.AccessToken
+	cfg.RefreshToken = loginResp.RefreshToken
+
+	if err := cli.SaveConfig(cfg); err != nil {
+		return fmt.Errorf("saving credentials: %w", err)
+	}
+
+	fmt.Printf("Logged in as %s (%s)\n", loginResp.User.Username, loginResp.User.Email)
+	fmt.Printf("Token expires in %ds\n", loginResp.ExpiresIn)
+	return nil
+}
+
+// ── logout ────────────────────────────────────────────
+
+func cmdLogout() error {
+	cfg, err := cli.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	if cfg.AccessToken != "" {
+		client := cli.NewClient(cfg)
+		_ = client.Post("/logout", map[string]string{
+			"refresh_token": cfg.RefreshToken,
+		}, nil)
+	}
+
+	cfg.AccessToken = ""
+	cfg.RefreshToken = ""
+	if err := cli.SaveConfig(cfg); err != nil {
+		return err
+	}
+
+	fmt.Println("Logged out.")
+	return nil
+}
+
+// ── status ────────────────────────────────────────────
+
+func cmdStatus() error {
+	cfg, err := cli.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	if cfg.Issuer == "" {
+		return fmt.Errorf("not configured. Run: rampart-cli login --issuer URL ...")
+	}
+
+	client := cli.NewClient(cfg)
+
+	var health struct {
+		Status string `json:"status"`
+	}
+	if err := client.Get("/healthz", &health); err != nil {
+		fmt.Printf("Server: %s\n", cfg.Issuer)
+		fmt.Printf("Status: unreachable (%v)\n", err)
+		return nil
+	}
+
+	var ready struct {
+		Status string `json:"status"`
+	}
+	_ = client.Get("/readyz", &ready)
+
+	fmt.Printf("Server:    %s\n", cfg.Issuer)
+	fmt.Printf("Health:    %s\n", health.Status)
+	fmt.Printf("Ready:     %s\n", ready.Status)
+
+	if cfg.AccessToken != "" {
+		fmt.Printf("Auth:      logged in\n")
+	} else {
+		fmt.Printf("Auth:      not logged in\n")
+	}
+	return nil
+}
+
+// ── whoami ────────────────────────────────────────────
+
+func cmdWhoami() error {
+	cfg, err := cli.LoadConfig()
+	if err != nil {
+		return err
+	}
+	if cfg.AccessToken == "" {
+		return fmt.Errorf("not logged in. Run: rampart-cli login ...")
+	}
+
+	client := cli.NewClient(cfg)
+
+	var me map[string]any
+	if err := client.Get("/me", &me); err != nil {
+		return err
+	}
+
+	fmt.Printf("User:      %s\n", me["preferred_username"])
+	fmt.Printf("Email:     %s\n", me["email"])
+	fmt.Printf("ID:        %s\n", me["id"])
+	if orgID, ok := me["org_id"]; ok {
+		fmt.Printf("Org:       %s\n", orgID)
+	}
+	if roles, ok := me["roles"]; ok {
+		fmt.Printf("Roles:     %v\n", roles)
+	}
+	return nil
+}
+
+// ── users ─────────────────────────────────────────────
+
+func cmdUsers(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: rampart-cli users <list|create|get> [options]")
+	}
+
+	cfg, err := cli.LoadConfig()
+	if err != nil {
+		return err
+	}
+	if cfg.AccessToken == "" {
+		return fmt.Errorf("not logged in. Run: rampart-cli login ...")
+	}
+
+	client := cli.NewClient(cfg)
+
+	switch args[0] {
+	case "list":
+		return cmdUsersList(client)
+	case "create":
+		return cmdUsersCreate(client, args[1:])
+	case "get":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: rampart-cli users get <user-id>")
+		}
+		return cmdUsersGet(client, args[1])
+	default:
+		return fmt.Errorf("unknown users subcommand: %s", args[0])
+	}
+}
+
+func cmdUsersList(client *cli.Client) error {
+	var resp struct {
+		Users []map[string]any `json:"users"`
+	}
+	if err := client.Get("/api/v1/admin/users", &resp); err != nil {
+		return err
+	}
+	users := resp.Users
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tUSERNAME\tEMAIL\tENABLED")
+	for _, u := range users {
+		id, _ := u["id"].(string)
+		username, _ := u["username"].(string)
+		email, _ := u["email"].(string)
+		enabled, _ := u["enabled"].(bool)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%v\n", id, username, email, enabled)
+	}
+	return w.Flush()
+}
+
+func cmdUsersCreate(client *cli.Client, args []string) error {
+	var email, username, password, givenName, familyName string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--email":
+			i++
+			if i < len(args) {
+				email = args[i]
+			}
+		case "--username":
+			i++
+			if i < len(args) {
+				username = args[i]
+			}
+		case "--password":
+			i++
+			if i < len(args) {
+				password = args[i]
+			}
+		case "--given-name":
+			i++
+			if i < len(args) {
+				givenName = args[i]
+			}
+		case "--family-name":
+			i++
+			if i < len(args) {
+				familyName = args[i]
+			}
+		}
+	}
+
+	if email == "" || username == "" || password == "" {
+		return fmt.Errorf("usage: rampart-cli users create --email EMAIL --username USER --password PASS [--given-name NAME] [--family-name NAME]")
+	}
+
+	body := map[string]string{
+		"email":       email,
+		"username":    username,
+		"password":    password,
+		"given_name":  givenName,
+		"family_name": familyName,
+	}
+
+	var user map[string]any
+	if err := client.Post("/api/v1/admin/users", body, &user); err != nil {
+		return err
+	}
+
+	fmt.Printf("Created user %s (%s)\n", user["username"], user["id"])
+	return nil
+}
+
+func cmdUsersGet(client *cli.Client, id string) error {
+	var user map[string]any
+	if err := client.Get("/api/v1/admin/users/"+id, &user); err != nil {
+		return err
+	}
+
+	data, _ := json.MarshalIndent(user, "", "  ")
+	fmt.Println(string(data))
+	return nil
+}
+
+// ── token ─────────────────────────────────────────────
+
+func cmdToken() error {
+	cfg, err := cli.LoadConfig()
+	if err != nil {
+		return err
+	}
+	if cfg.AccessToken == "" {
+		return fmt.Errorf("not logged in. Run: rampart-cli login ...")
+	}
+
+	fmt.Println(cfg.AccessToken)
+	return nil
+}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Client is the HTTP client for talking to a Rampart server.
+type Client struct {
+	BaseURL    string
+	Token      string
+	HTTPClient *http.Client
+}
+
+// NewClient creates a Client from the current config.
+func NewClient(cfg *Config) *Client {
+	return &Client{
+		BaseURL: cfg.Issuer,
+		Token:   cfg.AccessToken,
+		HTTPClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+	}
+}
+
+// do executes an HTTP request and decodes the JSON response.
+func (c *Client) do(method, path string, body any, result any) error {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshaling request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	url := c.BaseURL + path
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request to %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		var apiErr struct {
+			Error       string `json:"error"`
+			Description string `json:"error_description"`
+		}
+		if json.Unmarshal(respBody, &apiErr) == nil && apiErr.Description != "" {
+			return fmt.Errorf("%s (HTTP %d)", apiErr.Description, resp.StatusCode)
+		}
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("parsing response: %w", err)
+		}
+	}
+	return nil
+}
+
+// Get performs an authenticated GET request.
+func (c *Client) Get(path string, result any) error {
+	return c.do(http.MethodGet, path, nil, result)
+}
+
+// Post performs an authenticated POST request.
+func (c *Client) Post(path string, body any, result any) error {
+	return c.do(http.MethodPost, path, body, result)
+}
+
+// Delete performs an authenticated DELETE request.
+func (c *Client) Delete(path string, result any) error {
+	return c.do(http.MethodDelete, path, nil, result)
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const configDirName = ".rampart"
+const configFileName = "config.json"
+
+// Config holds the CLI session state persisted to disk.
+type Config struct {
+	Issuer       string `json:"issuer"`
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
+// ConfigPath returns the path to the config file (~/.rampart/config.json).
+func ConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, configDirName, configFileName), nil
+}
+
+// LoadConfig reads the CLI config from disk. Returns a zero Config if the file doesn't exist.
+func LoadConfig() (*Config, error) {
+	path, err := ConfigPath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return &Config{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// SaveConfig writes the CLI config to disk, creating the directory if needed.
+func SaveConfig(cfg *Config) error {
+	path, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveAndLoadConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpDir)
+	defer func() { _ = os.Setenv("HOME", origHome) }()
+
+	cfg := &Config{
+		Issuer:       "http://localhost:8080",
+		AccessToken:  "test-token",
+		RefreshToken: "test-refresh",
+	}
+
+	if err := SaveConfig(cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	// Verify file permissions
+	path := filepath.Join(tmpDir, configDirName, configFileName)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat config: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("config file permissions = %o, want 0600", perm)
+	}
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if loaded.Issuer != cfg.Issuer {
+		t.Errorf("Issuer = %q, want %q", loaded.Issuer, cfg.Issuer)
+	}
+	if loaded.AccessToken != cfg.AccessToken {
+		t.Errorf("AccessToken = %q, want %q", loaded.AccessToken, cfg.AccessToken)
+	}
+	if loaded.RefreshToken != cfg.RefreshToken {
+		t.Errorf("RefreshToken = %q, want %q", loaded.RefreshToken, cfg.RefreshToken)
+	}
+}
+
+func TestLoadConfigMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig on missing file: %v", err)
+	}
+	if cfg.Issuer != "" {
+		t.Errorf("expected empty config, got issuer %q", cfg.Issuer)
+	}
+}


### PR DESCRIPTION
## Summary
Adds `rampart-cli`, a command-line tool for managing Rampart IAM servers.

### Commands
| Command | Description |
|---------|------------|
| `login --issuer URL --email EMAIL --password PASS` | Authenticate and store credentials |
| `logout` | Clear credentials, invalidate refresh token |
| `status` | Check server health + auth status |
| `whoami` | Show current user identity |
| `users list` | List all users (admin API) |
| `users create --email --username --password` | Create a user |
| `users get <id>` | Get user details as JSON |
| `token` | Print raw access token (for piping) |
| `version` | Print CLI version |

### Architecture
- Separate binary: `cmd/rampart-cli/main.go`
- HTTP client: `internal/cli/client.go` — thin REST wrapper
- Config: `internal/cli/config.go` — stored at `~/.rampart/config.json` (0600 perms)
- Zero external dependencies — stdlib only
- Makefile: `make build-cli` and `make build-all`

## Test plan
- [x] `go build ./cmd/rampart-cli/` compiles
- [x] `go test ./internal/cli/` passes (config save/load + permissions)
- [x] `go test ./...` all tests pass
- [x] Manual smoke test against Docker containers:
  - login, status, whoami, users list, token, logout all verified working

## Demo
```
$ rampart-cli login --issuer http://localhost:8080 --email smoke2@test.com --password 'SecureP@ss123'
Logged in as smokeuser2 (smoke2@test.com)
Token expires in 900s

$ rampart-cli status
Server:    http://localhost:8080
Health:    alive
Ready:     ready
Auth:      logged in

$ rampart-cli users list
ID                                    USERNAME    EMAIL                ENABLED
e0e3ff11-...  smokeuser2  smoke2@test.com      true
0661e6e2-...  smokeuser   smoke@test.com       true
ada5f4be-...  admin       admin@rampart.local  true
```