### PR TITLE
feat: add Playwright e2e test suite (18 tests)

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+test-results/
+playwright-report/

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.58.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.58.2"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: process.env.RAMPART_URL || "http://localhost:8080",
+    headless: true,
+    screenshot: "only-on-failure",
+  },
+  reporter: [["html", { open: "never" }], ["list"]],
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+});

--- a/e2e/tests/admin-console.spec.ts
+++ b/e2e/tests/admin-console.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from "@playwright/test";
+
+const adminUser = {
+  username: `admin${Date.now()}`,
+  email: `admin${Date.now()}@e2e.test`,
+  password: "AdminP@ss123",
+  given_name: "Admin",
+  family_name: "E2E",
+};
+
+test.describe.serial("Admin console browser flow", () => {
+  test.beforeAll(async ({ request }) => {
+    await request.post("/register", { data: adminUser });
+  });
+
+  test("login page renders correctly", async ({ page }) => {
+    await page.goto("/admin/login");
+    await expect(page.getByRole("heading", { name: "Rampart" })).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: "Username or Email" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: "Password" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Sign In" })
+    ).toBeVisible();
+  });
+
+  test("login navigates to dashboard", async ({ page }) => {
+    await page.goto("/admin/login");
+    await page
+      .getByRole("textbox", { name: "Username or Email" })
+      .fill(adminUser.email);
+    await page
+      .getByRole("textbox", { name: "Password" })
+      .fill(adminUser.password);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await expect(page).toHaveURL(/\/admin\/$/);
+    await expect(page).toHaveTitle(/Dashboard/);
+    await expect(
+      page.getByRole("heading", { name: "Dashboard" })
+    ).toBeVisible();
+    await expect(page.getByText(adminUser.username)).toBeVisible();
+  });
+
+  test("dashboard shows stat cards", async ({ page }) => {
+    await page.goto("/admin/login");
+    await page
+      .getByRole("textbox", { name: "Username or Email" })
+      .fill(adminUser.email);
+    await page
+      .getByRole("textbox", { name: "Password" })
+      .fill(adminUser.password);
+    await page.getByRole("button", { name: "Sign In" }).click();
+    await expect(page).toHaveURL(/\/admin\/$/);
+
+    const main = page.getByRole("main");
+    await expect(main.getByText("Total Users")).toBeVisible();
+    await expect(main.getByText("Active Sessions")).toBeVisible();
+    await expect(main.getByText("Organizations")).toBeVisible();
+    await expect(main.getByText("Roles")).toBeVisible();
+  });
+
+  test("navigate to Users page", async ({ page }) => {
+    await page.goto("/admin/login");
+    await page
+      .getByRole("textbox", { name: "Username or Email" })
+      .fill(adminUser.email);
+    await page
+      .getByRole("textbox", { name: "Password" })
+      .fill(adminUser.password);
+    await page.getByRole("button", { name: "Sign In" }).click();
+    await expect(page).toHaveURL(/\/admin\/$/);
+
+    await page.getByRole("link", { name: "Users" }).click();
+    await expect(page).toHaveURL(/\/admin\/users$/);
+    await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "User" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Email" })
+    ).toBeVisible();
+    await expect(page.getByText(adminUser.email)).toBeVisible();
+  });
+
+  test("navigate to Roles page", async ({ page }) => {
+    await page.goto("/admin/login");
+    await page
+      .getByRole("textbox", { name: "Username or Email" })
+      .fill(adminUser.email);
+    await page
+      .getByRole("textbox", { name: "Password" })
+      .fill(adminUser.password);
+    await page.getByRole("button", { name: "Sign In" }).click();
+    await expect(page).toHaveURL(/\/admin\/$/);
+
+    await page.getByRole("link", { name: "Roles" }).click();
+    await expect(page).toHaveURL(/\/admin\/roles$/);
+    await expect(page.getByRole("heading", { name: "Roles" })).toBeVisible();
+  });
+
+  test("navigate to Organizations page", async ({ page }) => {
+    await page.goto("/admin/login");
+    await page
+      .getByRole("textbox", { name: "Username or Email" })
+      .fill(adminUser.email);
+    await page
+      .getByRole("textbox", { name: "Password" })
+      .fill(adminUser.password);
+    await page.getByRole("button", { name: "Sign In" }).click();
+    await expect(page).toHaveURL(/\/admin\/$/);
+
+    await page.getByRole("link", { name: "Organizations" }).click();
+    await expect(page).toHaveURL(/\/admin\/organizations$/);
+    await expect(
+      page.getByRole("heading", { name: "Organizations" })
+    ).toBeVisible();
+  });
+
+  test("navigate to OIDC Config page", async ({ page }) => {
+    await page.goto("/admin/login");
+    await page
+      .getByRole("textbox", { name: "Username or Email" })
+      .fill(adminUser.email);
+    await page
+      .getByRole("textbox", { name: "Password" })
+      .fill(adminUser.password);
+    await page.getByRole("button", { name: "Sign In" }).click();
+    await expect(page).toHaveURL(/\/admin\/$/);
+
+    await page.getByRole("link", { name: "OIDC Config" }).click();
+    await expect(page).toHaveURL(/\/admin\/oidc$/);
+    await expect(
+      page.getByRole("heading", { name: "OIDC Configuration" })
+    ).toBeVisible();
+    await expect(page.getByText("Issuer")).toBeVisible();
+    await expect(page.getByText("Authorization Endpoint")).toBeVisible();
+    await expect(page.getByText("Token Endpoint")).toBeVisible();
+    await expect(page.getByText("JWKS URI")).toBeVisible();
+  });
+
+  test("sidebar navigation links are all present", async ({ page }) => {
+    await page.goto("/admin/login");
+    await page
+      .getByRole("textbox", { name: "Username or Email" })
+      .fill(adminUser.email);
+    await page
+      .getByRole("textbox", { name: "Password" })
+      .fill(adminUser.password);
+    await page.getByRole("button", { name: "Sign In" }).click();
+    await expect(page).toHaveURL(/\/admin\/$/);
+
+    const expectedLinks = [
+      "Dashboard",
+      "Users",
+      "Roles",
+      "Groups",
+      "Organizations",
+      "Sessions",
+      "Events",
+      "Clients",
+      "OIDC Config",
+    ];
+
+    for (const name of expectedLinks) {
+      await expect(page.getByRole("link", { name })).toBeVisible();
+    }
+  });
+});

--- a/e2e/tests/auth-flow.spec.ts
+++ b/e2e/tests/auth-flow.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from "@playwright/test";
+
+const testUser = {
+  username: `pw${Date.now()}`,
+  email: `pw${Date.now()}@e2e.test`,
+  password: "E2eSecureP@ss1",
+  given_name: "PW",
+  family_name: "Test",
+};
+
+let accessToken = "";
+let refreshToken = "";
+
+test.describe.serial("Authentication flow", () => {
+  test("register a new user via API", async ({ request }) => {
+    const resp = await request.post("/register", { data: testUser });
+    expect(resp.ok()).toBeTruthy();
+
+    const body = await resp.json();
+    expect(body.id).toBeTruthy();
+    expect(body.username).toBe(testUser.username);
+    expect(body.email).toBe(testUser.email);
+    expect(body.enabled).toBe(true);
+  });
+
+  test("login returns tokens", async ({ request }) => {
+    const resp = await request.post("/login", {
+      data: {
+        identifier: testUser.email,
+        password: testUser.password,
+      },
+    });
+    expect(resp.ok()).toBeTruthy();
+
+    const body = await resp.json();
+    expect(body.access_token).toBeTruthy();
+    expect(body.refresh_token).toBeTruthy();
+    expect(body.token_type).toBe("Bearer");
+    expect(body.expires_in).toBeGreaterThan(0);
+    expect(body.user.email).toBe(testUser.email);
+
+    accessToken = body.access_token;
+    refreshToken = body.refresh_token;
+  });
+
+  test("GET /me returns user identity", async ({ request }) => {
+    const resp = await request.get("/me", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    expect(resp.ok()).toBeTruthy();
+
+    const body = await resp.json();
+    expect(body.preferred_username).toBe(testUser.username);
+    expect(body.email).toBe(testUser.email);
+    expect(body.id).toBeTruthy();
+    expect(body.org_id).toBeTruthy();
+  });
+
+  test("token refresh returns new access token", async ({ request }) => {
+    const resp = await request.post("/token/refresh", {
+      data: { refresh_token: refreshToken },
+    });
+    expect(resp.ok()).toBeTruthy();
+
+    const body = await resp.json();
+    expect(body.access_token).toBeTruthy();
+    expect(body.token_type).toBe("Bearer");
+    expect(body.expires_in).toBeGreaterThan(0);
+  });
+
+  test("invalid credentials returns 401", async ({ request }) => {
+    const resp = await request.post("/login", {
+      data: {
+        identifier: testUser.email,
+        password: "wrong-password",
+      },
+    });
+    expect(resp.status()).toBe(401);
+  });
+
+  test("GET /me without token returns 401", async ({ request }) => {
+    const resp = await request.get("/me");
+    expect(resp.status()).toBe(401);
+  });
+});

--- a/e2e/tests/health.spec.ts
+++ b/e2e/tests/health.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Health endpoints", () => {
+  test("GET /healthz returns alive", async ({ request }) => {
+    const resp = await request.get("/healthz");
+    expect(resp.ok()).toBeTruthy();
+    const body = await resp.json();
+    expect(body.status).toBe("alive");
+  });
+
+  test("GET /readyz returns ready", async ({ request }) => {
+    const resp = await request.get("/readyz");
+    expect(resp.ok()).toBeTruthy();
+    const body = await resp.json();
+    expect(body.status).toBe("ready");
+  });
+});

--- a/e2e/tests/oidc-discovery.spec.ts
+++ b/e2e/tests/oidc-discovery.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("OIDC Discovery", () => {
+  test("GET /.well-known/openid-configuration returns valid metadata", async ({
+    request,
+  }) => {
+    const resp = await request.get("/.well-known/openid-configuration");
+    expect(resp.ok()).toBeTruthy();
+
+    const body = await resp.json();
+    expect(body.issuer).toBeTruthy();
+    expect(body.authorization_endpoint).toContain("/oauth/authorize");
+    expect(body.token_endpoint).toContain("/oauth/token");
+    expect(body.jwks_uri).toContain("/.well-known/jwks.json");
+    expect(body.response_types_supported).toContain("code");
+    expect(body.grant_types_supported).toContain("authorization_code");
+    expect(body.scopes_supported).toContain("openid");
+    expect(body.id_token_signing_alg_values_supported).toContain("RS256");
+    expect(body.code_challenge_methods_supported).toContain("S256");
+  });
+
+  test("GET /.well-known/jwks.json returns RSA key", async ({ request }) => {
+    const resp = await request.get("/.well-known/jwks.json");
+    expect(resp.ok()).toBeTruthy();
+
+    const body = await resp.json();
+    expect(body.keys).toHaveLength(1);
+    expect(body.keys[0].kty).toBe("RSA");
+    expect(body.keys[0].alg).toBe("RS256");
+    expect(body.keys[0].use).toBe("sig");
+    expect(body.keys[0].kid).toBeTruthy();
+    expect(body.keys[0].n).toBeTruthy();
+    expect(body.keys[0].e).toBe("AQAB");
+  });
+});


### PR DESCRIPTION
## Summary
Adds a comprehensive Playwright end-to-end test suite covering API endpoints and admin console browser flows.

### Test coverage (18 tests)

| File | Tests | What it covers |
|------|-------|---------------|
| `health.spec.ts` | 2 | `/healthz`, `/readyz` |
| `oidc-discovery.spec.ts` | 2 | OpenID Configuration, JWKS |
| `auth-flow.spec.ts` | 6 | Register, login, /me, token refresh, invalid creds, 401 |
| `admin-console.spec.ts` | 8 | Login page, dashboard, stat cards, users, roles, orgs, OIDC, sidebar |

### Setup
```bash
cd e2e
npm install
npx playwright install chromium
npx playwright test
```

Requires a running Rampart server at `localhost:8080` (set `RAMPART_URL` to override).

## Test plan
- [x] All 18 tests pass locally against Docker containers
- [x] Tests run in ~7 seconds (headless Chromium)
- [x] API tests use Playwright's `request` context (no browser needed)
- [x] Browser tests cover full login → dashboard → navigation flow