### PR TITLE
fix: correct deploy-pages action SHA

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -362,4 +362,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac2b3c603fc # v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary
- Fixed incorrect SHA for `actions/deploy-pages@v4` that was causing Pages deployment to fail
- Enabled GitHub Pages on the repository (workflow-based deployment)

## Test plan
- [ ] Pages workflow completes successfully after merge
- [ ] Dashboard visible at https://manimovassagh.github.io/rampart/