### PR TITLE
feat: Claude Code skills for multi-stack auth

### DIFF
--- a/.claude/skills/rampart-docker-quickstart/SKILL.md
+++ b/.claude/skills/rampart-docker-quickstart/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: rampart-docker-quickstart
+description: Spin up a Rampart IAM server with Docker Compose. Creates docker-compose.yml with Rampart, PostgreSQL, and Redis, ready to use as your auth provider. Use when you need a local Rampart instance for development.
+argument-hint: [project-name]
+user-invocable: true
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Spin Up Rampart with Docker Compose
+
+Get a fully working Rampart IAM server running locally in seconds.
+
+## What This Skill Does
+
+1. Creates a `docker-compose.yml` with Rampart, PostgreSQL, and Redis
+2. Configures networking and health checks
+3. Creates a default admin user
+4. Exposes the admin console and all OIDC endpoints
+5. Registers an OAuth client for your app
+
+## Step-by-Step
+
+### 1. Create docker-compose.yml
+
+Create `docker-compose.yml` (or `rampart/docker-compose.yml` to keep it separate):
+
+```yaml
+version: "3.9"
+
+services:
+  rampart:
+    image: ghcr.io/manimovassagh/rampart:latest
+    # Or build from source:
+    # build: https://github.com/manimovassagh/rampart.git
+    ports:
+      - "8080:8080"
+    environment:
+      RAMPART_DB_URL: postgres://rampart:rampart@postgres:5432/rampart?sslmode=disable
+      RAMPART_REDIS_URL: redis://redis:6379/0
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: rampart
+      POSTGRES_PASSWORD: rampart
+      POSTGRES_DB: rampart
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "rampart"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:
+```
+
+### 2. Start the stack
+
+```bash
+docker compose up -d
+```
+
+Wait for Rampart to be healthy:
+
+```bash
+docker compose exec rampart wget -qO- http://localhost:8080/healthz
+# Should return: {"status":"alive"}
+```
+
+### 3. Create an admin user
+
+```bash
+curl -s http://localhost:8080/register -H 'Content-Type: application/json' \
+  -d '{"username":"admin","email":"admin@example.com","password":"AdminP@ss123","given_name":"Admin","family_name":"User"}'
+```
+
+### 4. Access the admin console
+
+Open http://localhost:8080/admin/login and sign in with `admin@example.com` / `AdminP@ss123`.
+
+### 5. Register your app as an OAuth client
+
+In the admin console: **Clients > Create Client**
+
+| Field | Value |
+|-------|-------|
+| Name | $ARGUMENTS or "My App" |
+| Client ID | `my-app` |
+| Type | Public (for SPAs) or Confidential (for server apps) |
+| Redirect URI | `http://localhost:3000/callback` (adjust to your app's port) |
+
+### 6. OIDC Discovery
+
+Your app can discover all endpoints at:
+
+```
+http://localhost:8080/.well-known/openid-configuration
+```
+
+Key endpoints:
+- **Authorization**: `http://localhost:8080/oauth/authorize`
+- **Token**: `http://localhost:8080/oauth/token`
+- **UserInfo**: `http://localhost:8080/me`
+- **JWKS**: `http://localhost:8080/.well-known/jwks.json`
+
+### 7. Add to .gitignore
+
+```
+# Rampart local data
+pgdata/
+```
+
+### 8. Environment variables for your app
+
+Add to your app's `.env`:
+
+```bash
+RAMPART_ISSUER=http://localhost:8080
+RAMPART_CLIENT_ID=my-app
+```
+
+## Quick Test
+
+```bash
+# Register a test user
+curl -s localhost:8080/register -H 'Content-Type: application/json' \
+  -d '{"username":"testuser","email":"test@example.com","password":"Test1234!","given_name":"Test","family_name":"User"}'
+
+# Login and get tokens
+curl -s localhost:8080/login -H 'Content-Type: application/json' \
+  -d '{"identifier":"test@example.com","password":"Test1234!"}'
+
+# Use the access_token from above
+curl -s localhost:8080/me -H 'Authorization: Bearer <access_token>'
+```
+
+## Next Steps
+
+After Rampart is running, use one of the stack-specific skills to integrate auth into your app:
+
+- `/rampart-node-setup` — Express/Node.js backend
+- `/rampart-react-setup` — React SPA
+- `/rampart-nextjs-setup` — Next.js full-stack
+- `/rampart-python-setup` — FastAPI or Flask
+- `/rampart-go-setup` — Go backend
+- `/rampart-spring-setup` — Spring Boot (Java/Kotlin)
+
+## Checklist
+
+- [ ] `docker-compose.yml` created
+- [ ] Stack running (`docker compose up -d`)
+- [ ] Admin user created
+- [ ] Admin console accessible at http://localhost:8080/admin
+- [ ] OAuth client registered for your app
+- [ ] App `.env` configured with `RAMPART_ISSUER`

--- a/.claude/skills/rampart-fullstack-secure/SKILL.md
+++ b/.claude/skills/rampart-fullstack-secure/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: rampart-fullstack-secure
+description: Secure an entire full-stack application with Rampart IAM. Detects your tech stack (frontend + backend), spins up Rampart, and wires up authentication end-to-end. The one-stop skill for adding auth to any project.
+argument-hint: [issuer-url]
+user-invocable: true
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent
+---
+
+# Secure a Full-Stack App with Rampart
+
+Automatically detect your tech stack and add end-to-end authentication powered by Rampart.
+
+## What This Skill Does
+
+1. Scans your project to detect frontend and backend frameworks
+2. Spins up Rampart (or connects to an existing instance)
+3. Configures backend JWT validation middleware
+4. Configures frontend OAuth 2.0 PKCE login flow
+5. Registers the OAuth client in Rampart
+6. Wires everything together end-to-end
+
+## Detection Rules
+
+### Backend Detection
+
+Scan the project for these indicators:
+
+| Framework | Detection | Skill to use |
+|-----------|-----------|-------------|
+| **Express/Node.js** | `package.json` with `express`, or `require("express")` / `import express` | `/rampart-node-setup` |
+| **Next.js** | `package.json` with `next`, or `next.config.*` exists | `/rampart-nextjs-setup` |
+| **FastAPI** | `requirements.txt`/`pyproject.toml` with `fastapi`, or `from fastapi import` | `/rampart-python-setup` (FastAPI) |
+| **Flask** | `requirements.txt`/`pyproject.toml` with `flask`, or `from flask import` | `/rampart-python-setup` (Flask) |
+| **Go** | `go.mod` exists, `net/http` or chi/gin/fiber imports | `/rampart-go-setup` |
+| **Spring Boot** | `pom.xml`/`build.gradle` with `spring-boot`, `@SpringBootApplication` | `/rampart-spring-setup` |
+
+### Frontend Detection
+
+| Framework | Detection | Skill to use |
+|-----------|-----------|-------------|
+| **React (Vite/CRA)** | `package.json` with `react` (but no `next`) | `/rampart-react-setup` |
+| **Next.js** | Already handled as full-stack in backend detection | `/rampart-nextjs-setup` |
+| **Vue** | `package.json` with `vue` | Adapt React patterns for Vue |
+| **Angular** | `angular.json` exists | Adapt React patterns for Angular |
+| **Vanilla JS/TS** | None of the above frameworks detected | Use `@rampart/web` adapter patterns |
+
+## Execution Plan
+
+### Step 1: Detect the stack
+
+```
+Scan for:
+- package.json, go.mod, pom.xml, build.gradle, requirements.txt, pyproject.toml
+- Framework-specific config files
+- Import patterns in source files
+```
+
+Report what was found to the user before proceeding.
+
+### Step 2: Check for Rampart
+
+If `$ARGUMENTS` is provided, use it as the issuer URL and skip to Step 4.
+
+Otherwise, check if Rampart is already running:
+
+```bash
+curl -sf http://localhost:8080/healthz
+```
+
+If not running, ask the user:
+> "No Rampart server detected. Want me to set one up with Docker Compose?"
+
+If yes, use the `/rampart-docker-quickstart` skill.
+
+### Step 3: Register an OAuth client
+
+Create a client in Rampart for this application:
+
+- **Client ID**: Derive from `package.json` name, `go.mod` module, or project directory name
+- **Type**: Public for SPAs, Confidential for server-rendered apps
+- **Redirect URI**: Based on the detected dev server port (Vite=5173, CRA=3000, Next.js=3000, etc.)
+
+### Step 4: Secure the backend
+
+Based on detected framework, apply the appropriate skill:
+
+- Express → `/rampart-node-setup $ARGUMENTS`
+- Next.js → `/rampart-nextjs-setup $ARGUMENTS`
+- FastAPI/Flask → `/rampart-python-setup $ARGUMENTS`
+- Go → `/rampart-go-setup $ARGUMENTS`
+- Spring Boot → `/rampart-spring-setup $ARGUMENTS`
+
+### Step 5: Secure the frontend
+
+If a separate frontend is detected:
+
+- React → `/rampart-react-setup $ARGUMENTS`
+- For other frameworks, adapt the React PKCE patterns
+
+### Step 6: Add environment variables
+
+Create or update `.env` / `.env.local` with:
+
+```
+RAMPART_ISSUER=http://localhost:8080
+RAMPART_CLIENT_ID=<detected-client-id>
+```
+
+### Step 7: Verify the setup
+
+Guide the user through testing:
+
+1. Start Rampart (if using Docker)
+2. Start the backend
+3. Start the frontend
+4. Navigate to a protected page
+5. Verify redirect to Rampart login
+6. Login and verify redirect back with user session
+
+## Output
+
+After completion, provide a summary:
+
+```
+Rampart Auth Setup Complete
+
+Stack detected:
+  Backend:  Express (Node.js)
+  Frontend: React (Vite)
+
+Rampart:    http://localhost:8080
+Client ID:  my-app
+Redirect:   http://localhost:5173/callback
+
+Files modified:
+  - src/middleware/auth.ts (JWT validation)
+  - src/auth/AuthProvider.tsx (OAuth context)
+  - src/auth/Callback.tsx (Token exchange)
+  - .env (Rampart config)
+
+Test it:
+  1. docker compose up -d     # Start Rampart
+  2. npm run dev               # Start your app
+  3. Open http://localhost:5173/dashboard
+  4. You'll be redirected to Rampart login
+```
+
+## Supported Stack Combinations
+
+| Backend | Frontend | Status |
+|---------|----------|--------|
+| Express | React | Full support |
+| Express | Next.js | Full support |
+| Next.js (full-stack) | — | Full support |
+| FastAPI | React | Full support |
+| FastAPI | Vue/Angular | Adapt React patterns |
+| Flask | React | Full support |
+| Go (chi/gin/fiber) | React | Full support |
+| Spring Boot | React | Full support |
+| Spring Boot | Angular | Adapt React patterns |
+
+## Checklist
+
+- [ ] Tech stack detected and confirmed with user
+- [ ] Rampart server running (new or existing)
+- [ ] OAuth client registered
+- [ ] Backend auth middleware installed
+- [ ] Frontend auth flow configured
+- [ ] Environment variables set
+- [ ] End-to-end login flow tested

--- a/.claude/skills/rampart-go-setup/SKILL.md
+++ b/.claude/skills/rampart-go-setup/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: rampart-go-setup
+description: Add Rampart authentication to a Go backend (net/http, chi, gin, or fiber). Sets up JWT middleware that verifies tokens against Rampart's JWKS endpoint and provides typed claims. Use when securing a Go API with Rampart.
+argument-hint: [issuer-url]
+user-invocable: true
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Add Rampart Authentication to a Go Backend
+
+Set up JWT-based middleware that validates Rampart access tokens via JWKS.
+
+## What This Skill Does
+
+1. Installs `github.com/golang-jwt/jwt/v5` and `github.com/MicahParks/keyfunc/v2`
+2. Creates auth middleware with JWKS-based token validation
+3. Provides typed claims in request context
+4. Works with net/http, chi, gin, or fiber
+
+## Step-by-Step
+
+### 1. Detect the router
+
+Check the project's imports for: `net/http`, `github.com/go-chi/chi`, `github.com/gin-gonic/gin`, or `github.com/gofiber/fiber`. Proceed with the matching setup.
+
+### 2. Install dependencies
+
+```bash
+go get github.com/golang-jwt/jwt/v5
+go get github.com/MicahParks/keyfunc/v2
+```
+
+### 3. Create the auth package
+
+Create `internal/auth/rampart.go` (or `pkg/auth/rampart.go`):
+
+```go
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/MicahParks/keyfunc/v2"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type Claims struct {
+	Sub               string `json:"sub"`
+	Email             string `json:"email"`
+	PreferredUsername  string `json:"preferred_username"`
+	OrgID             string `json:"org_id"`
+	EmailVerified     bool   `json:"email_verified"`
+	GivenName         string `json:"given_name,omitempty"`
+	FamilyName        string `json:"family_name,omitempty"`
+	jwt.RegisteredClaims
+}
+
+type contextKey struct{}
+
+var claimsKey = contextKey{}
+
+type Middleware struct {
+	jwks   *keyfunc.JWKS
+	issuer string
+}
+
+func NewMiddleware(issuer string) (*Middleware, error) {
+	jwksURL := issuer + "/.well-known/jwks.json"
+	jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{
+		RefreshInterval: 1 * time.Hour,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch JWKS: %w", err)
+	}
+	return &Middleware{jwks: jwks, issuer: issuer}, nil
+}
+
+func (m *Middleware) Handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			writeError(w, 401, "Missing authorization header.")
+			return
+		}
+
+		tokenStr := authHeader[7:]
+		claims := &Claims{}
+		token, err := jwt.ParseWithClaims(tokenStr, claims, m.jwks.Keyfunc,
+			jwt.WithIssuer(m.issuer),
+			jwt.WithValidMethods([]string{"RS256"}),
+		)
+		if err != nil || !token.Valid {
+			writeError(w, 401, "Invalid or expired access token.")
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), claimsKey, claims)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func GetClaims(ctx context.Context) *Claims {
+	claims, _ := ctx.Value(claimsKey).(*Claims)
+	return claims
+}
+
+func writeError(w http.ResponseWriter, status int, desc string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]any{
+		"error":             "unauthorized",
+		"error_description": desc,
+		"status":            status,
+	})
+}
+```
+
+### 4. Wire it up
+
+#### net/http or chi:
+
+```go
+issuer := os.Getenv("RAMPART_ISSUER")
+if issuer == "" {
+    issuer = "http://localhost:8080"
+}
+
+authMW, err := auth.NewMiddleware(issuer)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Protect all routes
+mux.Handle("/api/", authMW.Handler(apiRouter))
+
+// Or protect specific routes (chi)
+r.Group(func(r chi.Router) {
+    r.Use(authMW.Handler)
+    r.Get("/api/profile", profileHandler)
+})
+```
+
+#### Access claims in a handler:
+
+```go
+func profileHandler(w http.ResponseWriter, r *http.Request) {
+    claims := auth.GetClaims(r.Context())
+    json.NewEncoder(w).Encode(map[string]string{
+        "id":       claims.Sub,
+        "email":    claims.Email,
+        "username": claims.PreferredUsername,
+        "org":      claims.OrgID,
+    })
+}
+```
+
+### 5. Environment variables
+
+```bash
+RAMPART_ISSUER=http://localhost:8080
+```
+
+If `$ARGUMENTS` is provided, use it as the issuer URL.
+
+## Checklist
+
+- [ ] JWT and JWKS dependencies installed
+- [ ] Auth middleware created with JWKS verification
+- [ ] Middleware applied to protected routes
+- [ ] Handlers access claims via `auth.GetClaims(ctx)`
+- [ ] Issuer URL configured via environment variable
+- [ ] 401 errors return Rampart-compatible JSON

--- a/.claude/skills/rampart-nextjs-setup/SKILL.md
+++ b/.claude/skills/rampart-nextjs-setup/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: rampart-nextjs-setup
+description: Add Rampart authentication to a Next.js app. Sets up server-side JWT validation, API route protection, middleware auth guards, and client-side auth context. Use when securing a Next.js app with Rampart.
+argument-hint: [issuer-url]
+user-invocable: true
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Add Rampart Authentication to a Next.js App
+
+Set up JWT-based auth in a Next.js app with server-side validation and client-side auth context.
+
+## What This Skill Does
+
+1. Installs `jose` for JWT verification
+2. Creates server-side auth utilities (validate tokens, protect API routes)
+3. Adds Next.js middleware for route protection
+4. Sets up client-side auth context with login/logout
+5. Handles OAuth 2.0 PKCE flow with Rampart
+
+## Step-by-Step
+
+### 1. Install dependencies
+
+```bash
+npm install jose
+```
+
+### 2. Create server-side auth utility
+
+Create `lib/auth.ts`:
+
+```typescript
+import { jwtVerify, createRemoteJWKSSet } from "jose";
+
+const issuer = process.env.RAMPART_ISSUER || "$ARGUMENTS" || "http://localhost:8080";
+const JWKS = createRemoteJWKSSet(new URL("/.well-known/jwks.json", issuer));
+
+export interface RampartClaims {
+  sub: string;
+  iss: string;
+  exp: number;
+  iat: number;
+  org_id: string;
+  preferred_username: string;
+  email: string;
+  email_verified: boolean;
+  given_name?: string;
+  family_name?: string;
+}
+
+export async function verifyToken(token: string): Promise<RampartClaims | null> {
+  try {
+    const { payload } = await jwtVerify(token, JWKS, { issuer });
+    return payload as unknown as RampartClaims;
+  } catch {
+    return null;
+  }
+}
+
+export function getTokenFromHeader(authHeader: string | null): string | null {
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  return authHeader.slice(7);
+}
+```
+
+### 3. Create API route helper
+
+Create `lib/with-auth.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { verifyToken, getTokenFromHeader, RampartClaims } from "./auth";
+
+type AuthenticatedHandler = (
+  req: NextRequest,
+  context: { claims: RampartClaims }
+) => Promise<NextResponse> | NextResponse;
+
+export function withAuth(handler: AuthenticatedHandler) {
+  return async (req: NextRequest) => {
+    const token = getTokenFromHeader(req.headers.get("authorization"));
+    if (!token) {
+      return NextResponse.json(
+        { error: "unauthorized", error_description: "Missing authorization header." },
+        { status: 401 }
+      );
+    }
+    const claims = await verifyToken(token);
+    if (!claims) {
+      return NextResponse.json(
+        { error: "unauthorized", error_description: "Invalid or expired access token." },
+        { status: 401 }
+      );
+    }
+    return handler(req, { claims });
+  };
+}
+```
+
+### 4. Protect an API route (App Router)
+
+Create `app/api/profile/route.ts`:
+
+```typescript
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/with-auth";
+
+export const GET = withAuth(async (req, { claims }) => {
+  return NextResponse.json({
+    id: claims.sub,
+    email: claims.email,
+    username: claims.preferred_username,
+    org: claims.org_id,
+  });
+});
+```
+
+### 5. Add Next.js middleware for page protection
+
+Create `middleware.ts` in the project root:
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+
+const protectedPaths = ["/dashboard", "/settings", "/profile"];
+const issuer = process.env.RAMPART_ISSUER || "http://localhost:8080";
+const clientId = process.env.RAMPART_CLIENT_ID || "my-nextjs-app";
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  // Skip non-protected paths
+  if (!protectedPaths.some((p) => pathname.startsWith(p))) {
+    return NextResponse.next();
+  }
+
+  // Check for session cookie or token
+  const token = req.cookies.get("rampart_token")?.value;
+  if (token) return NextResponse.next();
+
+  // Redirect to Rampart login
+  const callbackUrl = new URL("/api/auth/callback", req.url);
+  const loginUrl = new URL("/oauth/authorize", issuer);
+  loginUrl.searchParams.set("response_type", "code");
+  loginUrl.searchParams.set("client_id", clientId);
+  loginUrl.searchParams.set("redirect_uri", callbackUrl.toString());
+  loginUrl.searchParams.set("scope", "openid profile email");
+
+  return NextResponse.redirect(loginUrl);
+}
+
+export const config = {
+  matcher: ["/dashboard/:path*", "/settings/:path*", "/profile/:path*"],
+};
+```
+
+### 6. Create the OAuth callback API route
+
+Create `app/api/auth/callback/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+
+const issuer = process.env.RAMPART_ISSUER || "http://localhost:8080";
+const clientId = process.env.RAMPART_CLIENT_ID || "my-nextjs-app";
+
+export async function GET(req: NextRequest) {
+  const code = req.nextUrl.searchParams.get("code");
+  if (!code) {
+    return NextResponse.redirect(new URL("/", req.url));
+  }
+
+  const tokenRes = await fetch(`${issuer}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: new URL("/api/auth/callback", req.url).toString(),
+      client_id: clientId,
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    return NextResponse.redirect(new URL("/?error=auth_failed", req.url));
+  }
+
+  const tokens = await tokenRes.json();
+  const response = NextResponse.redirect(new URL("/dashboard", req.url));
+
+  response.cookies.set("rampart_token", tokens.access_token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: tokens.expires_in,
+    path: "/",
+  });
+
+  return response;
+}
+```
+
+### 7. Create logout route
+
+Create `app/api/auth/logout/route.ts`:
+
+```typescript
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const response = NextResponse.redirect(new URL("/", req.url));
+  response.cookies.delete("rampart_token");
+  return response;
+}
+```
+
+### 8. Add environment variables
+
+Add to `.env.local`:
+
+```
+RAMPART_ISSUER=http://localhost:8080
+RAMPART_CLIENT_ID=my-nextjs-app
+```
+
+### 9. Register the client in Rampart
+
+```
+# Rampart Admin > Clients > Create Client
+# - Name: My Next.js App
+# - Client ID: my-nextjs-app
+# - Type: Confidential (if using server-side) or Public
+# - Redirect URI: http://localhost:3000/api/auth/callback
+```
+
+## Checklist
+
+- [ ] `jose` installed
+- [ ] `lib/auth.ts` and `lib/with-auth.ts` created
+- [ ] API routes use `withAuth()` wrapper
+- [ ] `middleware.ts` protects pages
+- [ ] OAuth callback route handles token exchange
+- [ ] Environment variables configured
+- [ ] OAuth client registered in Rampart

--- a/.claude/skills/rampart-python-setup/SKILL.md
+++ b/.claude/skills/rampart-python-setup/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: rampart-python-setup
+description: Add Rampart authentication to a Python app (FastAPI or Flask). Sets up JWT verification middleware, dependency injection for auth claims, and route protection. Use when securing a Python backend with Rampart.
+argument-hint: [issuer-url]
+user-invocable: true
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Add Rampart Authentication to a Python App
+
+Set up JWT-based authentication with a Rampart IAM server in FastAPI or Flask.
+
+## What This Skill Does
+
+1. Installs `PyJWT` and `cryptography` for JWT verification
+2. Creates auth middleware that validates Rampart JWTs
+3. Fetches JWKS from Rampart for key verification
+4. Provides typed user claims as a dependency/decorator
+5. Returns Rampart-compatible 401 JSON errors
+
+## Step-by-Step
+
+### 1. Detect the framework
+
+Check if the project uses FastAPI or Flask. Look for `from fastapi import` or `from flask import` in imports. Proceed with the matching framework below.
+
+---
+
+## FastAPI Setup
+
+### 2. Install dependencies
+
+```bash
+pip install PyJWT[crypto] httpx
+# or add to requirements.txt / pyproject.toml
+```
+
+### 3. Create the auth module
+
+Create `auth/rampart.py`:
+
+```python
+from typing import Optional
+from dataclasses import dataclass
+import httpx
+import jwt
+from jwt import PyJWKClient
+from fastapi import Request, HTTPException, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+ISSUER = "$ARGUMENTS" or "http://localhost:8080"
+JWKS_URL = f"{ISSUER}/.well-known/jwks.json"
+
+_jwk_client = PyJWKClient(JWKS_URL)
+_bearer = HTTPBearer()
+
+
+@dataclass
+class RampartUser:
+    sub: str
+    email: str
+    preferred_username: str
+    org_id: str
+    email_verified: bool = False
+    given_name: Optional[str] = None
+    family_name: Optional[str] = None
+
+
+def _verify_token(token: str) -> dict:
+    signing_key = _jwk_client.get_signing_key_from_jwt(token)
+    return jwt.decode(
+        token,
+        signing_key.key,
+        algorithms=["RS256"],
+        issuer=ISSUER,
+        options={"require": ["sub", "iss", "exp", "iat"]},
+    )
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer),
+) -> RampartUser:
+    try:
+        claims = _verify_token(credentials.credentials)
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired.")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid or expired access token.")
+
+    return RampartUser(
+        sub=claims["sub"],
+        email=claims.get("email", ""),
+        preferred_username=claims.get("preferred_username", ""),
+        org_id=claims.get("org_id", ""),
+        email_verified=claims.get("email_verified", False),
+        given_name=claims.get("given_name"),
+        family_name=claims.get("family_name"),
+    )
+```
+
+### 4. Protect FastAPI routes
+
+```python
+from fastapi import FastAPI, Depends
+from auth.rampart import get_current_user, RampartUser
+
+app = FastAPI()
+
+@app.get("/api/profile")
+async def profile(user: RampartUser = Depends(get_current_user)):
+    return {
+        "id": user.sub,
+        "email": user.email,
+        "username": user.preferred_username,
+        "org": user.org_id,
+    }
+
+@app.get("/api/admin")
+async def admin_only(user: RampartUser = Depends(get_current_user)):
+    # Add role checks here
+    return {"message": f"Hello admin {user.preferred_username}"}
+```
+
+---
+
+## Flask Setup
+
+### 2. Install dependencies
+
+```bash
+pip install PyJWT[crypto] requests
+```
+
+### 3. Create the auth module
+
+Create `auth/rampart.py`:
+
+```python
+from functools import wraps
+from dataclasses import dataclass
+from typing import Optional
+import jwt
+from jwt import PyJWKClient
+from flask import request, jsonify, g
+
+ISSUER = "$ARGUMENTS" or "http://localhost:8080"
+JWKS_URL = f"{ISSUER}/.well-known/jwks.json"
+
+_jwk_client = PyJWKClient(JWKS_URL)
+
+
+@dataclass
+class RampartUser:
+    sub: str
+    email: str
+    preferred_username: str
+    org_id: str
+    email_verified: bool = False
+    given_name: Optional[str] = None
+    family_name: Optional[str] = None
+
+
+def require_auth(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            return jsonify(error="unauthorized", error_description="Missing authorization header.", status=401), 401
+
+        token = auth_header[7:]
+        try:
+            signing_key = _jwk_client.get_signing_key_from_jwt(token)
+            claims = jwt.decode(token, signing_key.key, algorithms=["RS256"], issuer=ISSUER)
+        except jwt.ExpiredSignatureError:
+            return jsonify(error="unauthorized", error_description="Token expired.", status=401), 401
+        except jwt.InvalidTokenError:
+            return jsonify(error="unauthorized", error_description="Invalid or expired access token.", status=401), 401
+
+        g.user = RampartUser(
+            sub=claims["sub"],
+            email=claims.get("email", ""),
+            preferred_username=claims.get("preferred_username", ""),
+            org_id=claims.get("org_id", ""),
+            email_verified=claims.get("email_verified", False),
+            given_name=claims.get("given_name"),
+            family_name=claims.get("family_name"),
+        )
+        return f(*args, **kwargs)
+    return decorated
+```
+
+### 4. Protect Flask routes
+
+```python
+from flask import Flask, jsonify, g
+from auth.rampart import require_auth
+
+app = Flask(__name__)
+
+@app.get("/api/profile")
+@require_auth
+def profile():
+    return jsonify(id=g.user.sub, email=g.user.email, username=g.user.preferred_username)
+```
+
+---
+
+## Environment Variables
+
+```bash
+RAMPART_ISSUER=http://localhost:8080
+```
+
+If `$ARGUMENTS` is empty, use `os.environ.get("RAMPART_ISSUER", "http://localhost:8080")` in the code.
+
+## Checklist
+
+- [ ] `PyJWT[crypto]` installed
+- [ ] Auth module created with JWKS verification
+- [ ] Protected routes use dependency injection (FastAPI) or decorator (Flask)
+- [ ] 401 errors return Rampart-compatible JSON
+- [ ] Issuer URL configured via environment variable

--- a/.claude/skills/rampart-react-setup/SKILL.md
+++ b/.claude/skills/rampart-react-setup/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: rampart-react-setup
+description: Add Rampart authentication to a React (Vite/CRA) app. Sets up OAuth 2.0 PKCE login flow, auth context, protected routes, and token management. Use when securing a React SPA with Rampart.
+argument-hint: [issuer-url]
+user-invocable: true
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Add Rampart Authentication to a React App
+
+Set up OAuth 2.0 Authorization Code + PKCE login flow in a React SPA using `@rampart/react`.
+
+## What This Skill Does
+
+1. Installs `@rampart/react` (or sets up a lightweight auth module)
+2. Creates an `AuthProvider` context with login/logout/token state
+3. Adds a `useAuth()` hook for accessing user info and tokens
+4. Creates a `ProtectedRoute` component for guarding routes
+5. Handles the OAuth callback and token refresh
+
+## Step-by-Step
+
+### 1. Install dependencies
+
+```bash
+npm install @rampart/react
+# or if @rampart/react is not published yet:
+npm install jose
+```
+
+### 2. Find the app entry point
+
+Look for `App.tsx`, `main.tsx`, or `src/App.tsx`.
+
+### 3. Create the auth configuration
+
+Create `src/auth/config.ts`:
+
+```typescript
+export const authConfig = {
+  issuer: "$ARGUMENTS" || process.env.VITE_RAMPART_ISSUER || "http://localhost:8080",
+  clientId: process.env.VITE_RAMPART_CLIENT_ID || "my-app",
+  redirectUri: window.location.origin + "/callback",
+  scopes: ["openid", "profile", "email"],
+};
+```
+
+### 4. Create the auth context
+
+Create `src/auth/AuthProvider.tsx`:
+
+```tsx
+import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from "react";
+import { authConfig } from "./config";
+
+interface User {
+  sub: string;
+  email: string;
+  preferred_username: string;
+  org_id: string;
+  given_name?: string;
+  family_name?: string;
+}
+
+interface AuthContextType {
+  user: User | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: () => void;
+  logout: () => void;
+  getAccessToken: () => string | null;
+}
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be inside AuthProvider");
+  return ctx;
+}
+
+function generateCodeVerifier(): string {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return btoa(String.fromCharCode(...array))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function generateCodeChallenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const getAccessToken = useCallback(() => localStorage.getItem("rampart_access_token"), []);
+
+  const login = useCallback(async () => {
+    const verifier = generateCodeVerifier();
+    const challenge = await generateCodeChallenge(verifier);
+    sessionStorage.setItem("pkce_verifier", verifier);
+
+    const params = new URLSearchParams({
+      response_type: "code",
+      client_id: authConfig.clientId,
+      redirect_uri: authConfig.redirectUri,
+      scope: authConfig.scopes.join(" "),
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    });
+
+    window.location.href = `${authConfig.issuer}/oauth/authorize?${params}`;
+  }, []);
+
+  const logout = useCallback(() => {
+    localStorage.removeItem("rampart_access_token");
+    localStorage.removeItem("rampart_refresh_token");
+    setUser(null);
+    window.location.href = "/";
+  }, []);
+
+  const fetchUser = useCallback(async (token: string) => {
+    const res = await fetch(`${authConfig.issuer}/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      setUser(await res.json());
+    } else {
+      localStorage.removeItem("rampart_access_token");
+      setUser(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    const token = localStorage.getItem("rampart_access_token");
+    if (token) {
+      fetchUser(token).finally(() => setIsLoading(false));
+    } else {
+      setIsLoading(false);
+    }
+  }, [fetchUser]);
+
+  return (
+    <AuthContext.Provider value={{ user, isAuthenticated: !!user, isLoading, login, logout, getAccessToken }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+```
+
+### 5. Create the callback handler
+
+Create `src/auth/Callback.tsx`:
+
+```tsx
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { authConfig } from "./config";
+
+export function AuthCallback() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const verifier = sessionStorage.getItem("pkce_verifier");
+
+    if (!code || !verifier) {
+      navigate("/");
+      return;
+    }
+
+    fetch(`${authConfig.issuer}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: authConfig.redirectUri,
+        client_id: authConfig.clientId,
+        code_verifier: verifier,
+      }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        localStorage.setItem("rampart_access_token", data.access_token);
+        if (data.refresh_token) localStorage.setItem("rampart_refresh_token", data.refresh_token);
+        sessionStorage.removeItem("pkce_verifier");
+        navigate("/");
+      })
+      .catch(() => navigate("/"));
+  }, [navigate]);
+
+  return <div>Signing you in...</div>;
+}
+```
+
+### 6. Create ProtectedRoute
+
+Create `src/auth/ProtectedRoute.tsx`:
+
+```tsx
+import { useAuth } from "./AuthProvider";
+
+export function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, isLoading, login } = useAuth();
+
+  if (isLoading) return <div>Loading...</div>;
+  if (!isAuthenticated) {
+    login();
+    return <div>Redirecting to login...</div>;
+  }
+  return <>{children}</>;
+}
+```
+
+### 7. Wire it up in the app
+
+```tsx
+import { AuthProvider } from "./auth/AuthProvider";
+import { AuthCallback } from "./auth/Callback";
+import { ProtectedRoute } from "./auth/ProtectedRoute";
+
+function App() {
+  return (
+    <AuthProvider>
+      <Routes>
+        <Route path="/callback" element={<AuthCallback />} />
+        <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
+        <Route path="/" element={<Home />} />
+      </Routes>
+    </AuthProvider>
+  );
+}
+```
+
+### 8. Register the OAuth client in Rampart
+
+Either via the admin dashboard or CLI:
+
+```bash
+# Via the Rampart admin console: Clients > Create Client
+# - Name: My React App
+# - Client ID: my-app
+# - Type: Public
+# - Redirect URI: http://localhost:5173/callback (Vite default)
+```
+
+### 9. Add environment variables
+
+Create or update `.env`:
+
+```
+VITE_RAMPART_ISSUER=http://localhost:8080
+VITE_RAMPART_CLIENT_ID=my-app
+```
+
+## Checklist
+
+- [ ] Auth dependencies installed
+- [ ] `AuthProvider` wraps the app
+- [ ] `/callback` route handles OAuth redirect
+- [ ] Protected routes use `<ProtectedRoute>`
+- [ ] OAuth client registered in Rampart with correct redirect URI
+- [ ] Environment variables set for issuer and client ID

--- a/.claude/skills/rampart-spring-setup/SKILL.md
+++ b/.claude/skills/rampart-spring-setup/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: rampart-spring-setup
+description: Add Rampart authentication to a Spring Boot app. Configures Spring Security OAuth2 Resource Server with JWT validation against Rampart's JWKS. Use when securing a Java/Kotlin Spring Boot API with Rampart.
+argument-hint: [issuer-url]
+user-invocable: true
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Add Rampart Authentication to a Spring Boot App
+
+Configure Spring Security to validate Rampart JWTs using the OAuth2 Resource Server.
+
+## What This Skill Does
+
+1. Adds Spring Security OAuth2 Resource Server dependency
+2. Configures `application.yml` with Rampart's issuer/JWKS
+3. Sets up `SecurityFilterChain` with JWT validation
+4. Creates a helper to extract Rampart claims from the security context
+5. Protects endpoints with `@PreAuthorize` or `SecurityFilterChain` rules
+
+## Step-by-Step
+
+### 1. Add dependencies
+
+#### Maven (`pom.xml`):
+
+```xml
+<dependency>
+  <groupId>org.springframework.boot</groupId>
+  <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+</dependency>
+```
+
+#### Gradle (`build.gradle.kts`):
+
+```kotlin
+implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+```
+
+### 2. Configure application properties
+
+Add to `application.yml` (or `application.properties`):
+
+```yaml
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${RAMPART_ISSUER:http://localhost:8080}
+          jwk-set-uri: ${RAMPART_ISSUER:http://localhost:8080}/.well-known/jwks.json
+```
+
+If `$ARGUMENTS` is provided, use it instead of the default.
+
+### 3. Create Security Configuration
+
+Create `config/SecurityConfig.java`:
+
+```java
+package com.example.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/public/**", "/health", "/actuator/**").permitAll()
+                .requestMatchers("/api/**").authenticated()
+                .anyRequest().permitAll()
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> {}));
+
+        return http.build();
+    }
+}
+```
+
+### 4. Create a claims helper
+
+Create `security/RampartClaims.java`:
+
+```java
+package com.example.security;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class RampartClaims {
+
+    public static Jwt getJwt() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        return (Jwt) auth.getPrincipal();
+    }
+
+    public static String getUserId() {
+        return getJwt().getSubject();
+    }
+
+    public static String getEmail() {
+        return getJwt().getClaimAsString("email");
+    }
+
+    public static String getUsername() {
+        return getJwt().getClaimAsString("preferred_username");
+    }
+
+    public static String getOrgId() {
+        return getJwt().getClaimAsString("org_id");
+    }
+}
+```
+
+### 5. Use in a controller
+
+```java
+@RestController
+@RequestMapping("/api")
+public class ProfileController {
+
+    @GetMapping("/profile")
+    public Map<String, String> profile(@AuthenticationPrincipal Jwt jwt) {
+        return Map.of(
+            "id", jwt.getSubject(),
+            "email", jwt.getClaimAsString("email"),
+            "username", jwt.getClaimAsString("preferred_username"),
+            "org", jwt.getClaimAsString("org_id")
+        );
+    }
+
+    @GetMapping("/admin")
+    @PreAuthorize("hasAuthority('SCOPE_admin')")
+    public Map<String, String> admin(@AuthenticationPrincipal Jwt jwt) {
+        return Map.of("message", "Hello admin " + jwt.getClaimAsString("preferred_username"));
+    }
+}
+```
+
+### 6. Custom error response (optional)
+
+Create `config/AuthEntryPoint.java` to return Rampart-style 401 JSON:
+
+```java
+@Component
+public class AuthEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest req, HttpServletResponse res, AuthenticationException ex)
+            throws IOException {
+        res.setContentType("application/json");
+        res.setStatus(401);
+        res.getWriter().write(
+            "{\"error\":\"unauthorized\",\"error_description\":\"Invalid or expired access token.\",\"status\":401}"
+        );
+    }
+}
+```
+
+Then wire it in `SecurityConfig`:
+
+```java
+.oauth2ResourceServer(oauth2 -> oauth2
+    .jwt(jwt -> {})
+    .authenticationEntryPoint(authEntryPoint)
+)
+```
+
+## Checklist
+
+- [ ] `spring-boot-starter-oauth2-resource-server` added
+- [ ] Issuer URI and JWK set URI configured
+- [ ] `SecurityFilterChain` with JWT validation
+- [ ] Public vs protected endpoints defined
+- [ ] Controllers use `@AuthenticationPrincipal Jwt` for claims
+- [ ] Environment variable `RAMPART_ISSUER` set


### PR DESCRIPTION
## Summary
Add 7 Claude Code skills that let developers secure any full-stack app with Rampart using AI-assisted setup:

| Skill | Stack | What it does |
|-------|-------|-------------|
| `/rampart-docker-quickstart` | Docker | Spins up Rampart + Postgres + Redis |
| `/rampart-node-setup` | Express | JWT middleware (existing) |
| `/rampart-react-setup` | React (Vite/CRA) | OAuth 2.0 PKCE flow, AuthProvider, ProtectedRoute |
| `/rampart-nextjs-setup` | Next.js | Server-side JWT, middleware guards, API protection |
| `/rampart-python-setup` | FastAPI / Flask | JWT verification, dependency injection / decorator |
| `/rampart-go-setup` | Go (net/http, chi, gin, fiber) | JWKS middleware, typed claims |
| `/rampart-spring-setup` | Spring Boot | OAuth2 Resource Server, SecurityFilterChain |
| `/rampart-fullstack-secure` | Any combo | Auto-detects stack and wires everything end-to-end |

## Usage
A developer working on any project just types:
```
/rampart-fullstack-secure http://localhost:8080
```
And Claude will detect their stack, set up Rampart, and wire auth into both frontend and backend.

## Test plan
- [ ] Each skill loads correctly in Claude Code
- [ ] Skills appear in `/help` skill list