### PR TITLE
fix: resolve QA bugs #59-#62

### DIFF
--- a/internal/handler/discovery.go
+++ b/internal/handler/discovery.go
@@ -10,19 +10,20 @@ import (
 
 // DiscoveryResponse is the OIDC Discovery metadata (RFC 8414).
 type DiscoveryResponse struct {
-	Issuer                           string   `json:"issuer"`
-	AuthorizationEndpoint            string   `json:"authorization_endpoint"`
-	TokenEndpoint                    string   `json:"token_endpoint"`
-	UserinfoEndpoint                 string   `json:"userinfo_endpoint"`
-	JWKSURI                          string   `json:"jwks_uri"`
-	ResponseTypesSupported           []string `json:"response_types_supported"`
-	GrantTypesSupported              []string `json:"grant_types_supported"`
-	SubjectTypesSupported            []string `json:"subject_types_supported"`
-	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
-	ScopesSupported                  []string `json:"scopes_supported"`
-	ClaimsSupported                  []string `json:"claims_supported"`
-	CodeChallengeMethodsSupported    []string `json:"code_challenge_methods_supported"`
-	SocialProvidersSupported         []string `json:"social_providers_supported,omitempty"`
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	UserinfoEndpoint                  string   `json:"userinfo_endpoint"`
+	JWKSURI                           string   `json:"jwks_uri"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	GrantTypesSupported               []string `json:"grant_types_supported"`
+	SubjectTypesSupported             []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported  []string `json:"id_token_signing_alg_values_supported"`
+	ScopesSupported                   []string `json:"scopes_supported"`
+	ClaimsSupported                   []string `json:"claims_supported"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+	SocialProvidersSupported          []string `json:"social_providers_supported,omitempty"`
 }
 
 // DiscoveryHandler returns the OIDC Discovery metadata JSON.
@@ -43,7 +44,8 @@ func DiscoveryHandler(issuer string, logger *slog.Logger, socialProviders ...str
 			"preferred_username", "email", "email_verified",
 			"given_name", "family_name", "org_id", "roles",
 		},
-		CodeChallengeMethodsSupported: []string{"S256"},
+		CodeChallengeMethodsSupported:     []string{"S256"},
+		TokenEndpointAuthMethodsSupported: []string{"none"},
 	}
 
 	if len(socialProviders) > 0 {

--- a/internal/handler/token.go
+++ b/internal/handler/token.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/manimovassagh/rampart/internal/apierror"
+	"github.com/manimovassagh/rampart/internal/middleware"
 	"github.com/manimovassagh/rampart/internal/model"
 	"github.com/manimovassagh/rampart/internal/oauth"
 	"github.com/manimovassagh/rampart/internal/session"
@@ -215,15 +216,19 @@ func (h *TokenHandler) Token(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// writeOAuthError writes an OAuth 2.0 error response per RFC 6749 §5.2.
+// writeOAuthError writes an OAuth 2.0 error response per RFC 6749 §5.2,
+// extended with status and request_id for consistency with other API errors.
 func (h *TokenHandler) writeOAuthError(w http.ResponseWriter, status int, code, description string) {
 	w.Header().Set("Content-Type", apierror.ContentTypeJSON)
 	w.Header().Set("Cache-Control", cacheNoStore)
 	w.WriteHeader(status)
 
-	resp := map[string]string{
+	reqID := w.Header().Get(middleware.HeaderRequestID)
+	resp := map[string]interface{}{
 		"error":             code,
 		"error_description": description,
+		"status":            status,
+		"request_id":        reqID,
 	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		h.logger.Error("failed to encode oauth error response", "error", err)

--- a/internal/handler/token_test.go
+++ b/internal/handler/token_test.go
@@ -97,7 +97,7 @@ func TestTokenInvalidCode(t *testing.T) {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
 
-	var resp map[string]string
+	var resp map[string]interface{}
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -200,7 +200,7 @@ func TestTokenWrongCodeVerifier(t *testing.T) {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
 
-	var resp map[string]string
+	var resp map[string]interface{}
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -9,6 +9,7 @@ import (
 	chimw "github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 
+	"github.com/manimovassagh/rampart/internal/apierror"
 	"github.com/manimovassagh/rampart/internal/middleware"
 )
 
@@ -30,6 +31,11 @@ func NewRouter(logger *slog.Logger, allowedOrigins []string) *chi.Mux {
 		MaxAge:           300,
 	}))
 	r.Use(middleware.Logging(logger))
+
+	// Custom 404 handler — return JSON instead of plain text
+	r.NotFound(func(w http.ResponseWriter, _ *http.Request) {
+		apierror.NotFound(w)
+	})
 
 	return r
 }
@@ -208,6 +214,11 @@ type AdminLoginEndpoints interface {
 
 // RegisterAdminConsoleRoutes mounts SSR admin console routes under /admin/.
 func RegisterAdminConsoleRoutes(r *chi.Mux, pubKey *rsa.PublicKey, hmacKey []byte, staticHandler http.Handler, login AdminLoginEndpoints, console AdminConsoleEndpoints) {
+	// Redirect /admin to /admin/ so the dashboard is reachable without trailing slash
+	r.Get("/admin", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/admin/", http.StatusMovedPermanently)
+	})
+
 	// Static assets (CSS, JS) — no auth required, long cache
 	r.Handle("/static/*", http.StripPrefix("/static/", staticHandler))
 


### PR DESCRIPTION
## Summary

Fixes 4 bugs discovered by QA agents:

- **#59** `/admin` without trailing slash returns 404 → Added 301 redirect to `/admin/`
- **#60** 404 responses return plain text → Custom JSON 404 handler using `apierror.NotFound`
- **#61** OIDC discovery missing `token_endpoint_auth_methods_supported` → Added `["none"]` (PKCE-only, no client secret auth)
- **#62** `/oauth/token` error responses missing `status` and `request_id` → Extended `writeOAuthError` to include both fields

## Test plan

- [x] `go test ./...` — all 17 packages pass
- [x] `go vet ./...` — clean
- [x] `gofmt` — clean
- [ ] Verify `GET /admin` redirects to `/admin/`
- [ ] Verify `GET /nonexistent` returns JSON `{"error":"not_found",...}`
- [ ] Verify `GET /.well-known/openid-configuration` includes `token_endpoint_auth_methods_supported`
- [ ] Verify `POST /oauth/token` errors include `status` and `request_id`

Closes #59, Closes #60, Closes #61, Closes #62