### PR TITLE
feat: org badge in header and clickable dashboard stats

### DIFF
--- a/internal/handler/admin_console.go
+++ b/internal/handler/admin_console.go
@@ -275,6 +275,7 @@ type pageData struct {
 	Title     string
 	ActiveNav string
 	User      *middleware.AuthenticatedUser
+	OrgName   string
 	CSRFToken string
 	Flash     string
 	Error     string
@@ -324,6 +325,12 @@ type paginationData struct {
 func (h *AdminConsoleHandler) render(w http.ResponseWriter, r *http.Request, pageName string, data *pageData) {
 	data.User = middleware.GetAuthenticatedUser(r.Context())
 	data.CSRFToken = middleware.GetCSRFToken(r)
+
+	if data.User != nil && data.OrgName == "" {
+		if org, err := h.store.GetOrganizationByID(r.Context(), data.User.OrgID); err == nil && org != nil {
+			data.OrgName = org.Name
+		}
+	}
 
 	flash := middleware.GetFlash(w, r)
 	if flash != "" {

--- a/internal/handler/templates/admin/base.html
+++ b/internal/handler/templates/admin/base.html
@@ -17,6 +17,12 @@
             <header class="bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between">
                 <h1 class="text-xl font-semibold text-gray-900">{{.Title}}</h1>
                 <div class="flex items-center gap-4">
+                    {{if .OrgName}}
+                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-full bg-indigo-100 text-indigo-700 border border-indigo-200">
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg>
+                        {{.OrgName}}
+                    </span>
+                    {{end}}
                     <span class="text-sm text-gray-600">{{.User.PreferredUsername}}</span>
                     <form method="POST" action="/admin/logout">
                         <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">

--- a/internal/handler/templates/admin/dashboard.html
+++ b/internal/handler/templates/admin/dashboard.html
@@ -1,99 +1,99 @@
 {{define "content"}}
-<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-6">
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+    <a href="/admin/users" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all cursor-pointer group">
         <div class="flex items-center justify-between">
             <div>
-                <p class="text-sm font-medium text-gray-500">Total Users</p>
+                <p class="text-sm font-medium text-gray-500 group-hover:text-indigo-600">Total Users</p>
                 <p class="text-3xl font-bold text-gray-900 mt-1">{{.Stats.TotalUsers}}</p>
             </div>
-            <div class="bg-blue-100 rounded-full p-3">
+            <div class="bg-blue-100 rounded-full p-3 group-hover:bg-blue-200 transition-colors">
                 <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197m13.5-9a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z"/></svg>
             </div>
         </div>
-    </div>
+    </a>
 
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <a href="/admin/sessions" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all cursor-pointer group">
         <div class="flex items-center justify-between">
             <div>
-                <p class="text-sm font-medium text-gray-500">Active Sessions</p>
+                <p class="text-sm font-medium text-gray-500 group-hover:text-indigo-600">Active Sessions</p>
                 <p class="text-3xl font-bold text-gray-900 mt-1">{{.Stats.ActiveSessions}}</p>
             </div>
-            <div class="bg-green-100 rounded-full p-3">
+            <div class="bg-green-100 rounded-full p-3 group-hover:bg-green-200 transition-colors">
                 <svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728M9.172 15.828a4 4 0 010-5.656m5.656 0a4 4 0 010 5.656M12 12h.01"/></svg>
             </div>
         </div>
-    </div>
+    </a>
 
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <a href="/admin/users" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all cursor-pointer group">
         <div class="flex items-center justify-between">
             <div>
-                <p class="text-sm font-medium text-gray-500">New Users (7 days)</p>
+                <p class="text-sm font-medium text-gray-500 group-hover:text-indigo-600">New Users (7 days)</p>
                 <p class="text-3xl font-bold text-gray-900 mt-1">{{.Stats.RecentUsers}}</p>
             </div>
-            <div class="bg-purple-100 rounded-full p-3">
+            <div class="bg-purple-100 rounded-full p-3 group-hover:bg-purple-200 transition-colors">
                 <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/></svg>
             </div>
         </div>
-    </div>
+    </a>
 
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <a href="/admin/organizations" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all cursor-pointer group">
         <div class="flex items-center justify-between">
             <div>
-                <p class="text-sm font-medium text-gray-500">Organizations</p>
+                <p class="text-sm font-medium text-gray-500 group-hover:text-indigo-600">Organizations</p>
                 <p class="text-3xl font-bold text-gray-900 mt-1">{{.Stats.TotalOrganizations}}</p>
             </div>
-            <div class="bg-orange-100 rounded-full p-3">
+            <div class="bg-orange-100 rounded-full p-3 group-hover:bg-orange-200 transition-colors">
                 <svg class="w-6 h-6 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg>
             </div>
         </div>
-    </div>
+    </a>
 
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <a href="/admin/events" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all cursor-pointer group">
         <div class="flex items-center justify-between">
             <div>
-                <p class="text-sm font-medium text-gray-500">Events (24h)</p>
+                <p class="text-sm font-medium text-gray-500 group-hover:text-indigo-600">Events (24h)</p>
                 <p class="text-3xl font-bold text-gray-900 mt-1">{{.Stats.RecentEvents}}</p>
             </div>
-            <div class="bg-yellow-100 rounded-full p-3">
+            <div class="bg-yellow-100 rounded-full p-3 group-hover:bg-yellow-200 transition-colors">
                 <svg class="w-6 h-6 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"/></svg>
             </div>
         </div>
-    </div>
+    </a>
 
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <a href="/admin/roles" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all cursor-pointer group">
         <div class="flex items-center justify-between">
             <div>
-                <p class="text-sm font-medium text-gray-500">Roles</p>
+                <p class="text-sm font-medium text-gray-500 group-hover:text-indigo-600">Roles</p>
                 <p class="text-3xl font-bold text-gray-900 mt-1">{{.Stats.TotalRoles}}</p>
             </div>
-            <div class="bg-teal-100 rounded-full p-3">
+            <div class="bg-teal-100 rounded-full p-3 group-hover:bg-teal-200 transition-colors">
                 <svg class="w-6 h-6 text-teal-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
             </div>
         </div>
-    </div>
+    </a>
 
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <a href="/admin/groups" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all cursor-pointer group">
         <div class="flex items-center justify-between">
             <div>
-                <p class="text-sm font-medium text-gray-500">Groups</p>
+                <p class="text-sm font-medium text-gray-500 group-hover:text-indigo-600">Groups</p>
                 <p class="text-3xl font-bold text-gray-900 mt-1">{{.Stats.TotalGroups}}</p>
             </div>
-            <div class="bg-pink-100 rounded-full p-3">
+            <div class="bg-pink-100 rounded-full p-3 group-hover:bg-pink-200 transition-colors">
                 <svg class="w-6 h-6 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/></svg>
             </div>
         </div>
-    </div>
+    </a>
 
-    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <a href="/admin/clients" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md hover:border-indigo-200 transition-all cursor-pointer group">
         <div class="flex items-center justify-between">
             <div>
-                <p class="text-sm font-medium text-gray-500">OAuth Clients</p>
+                <p class="text-sm font-medium text-gray-500 group-hover:text-indigo-600">OAuth Clients</p>
                 <p class="text-3xl font-bold text-gray-900 mt-1">{{.Stats.TotalClients}}</p>
             </div>
-            <div class="bg-indigo-100 rounded-full p-3">
+            <div class="bg-indigo-100 rounded-full p-3 group-hover:bg-indigo-200 transition-colors">
                 <svg class="w-6 h-6 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/></svg>
             </div>
         </div>
-    </div>
+    </a>
 </div>
 {{end}}


### PR DESCRIPTION
## Summary
- Added organization name badge (indigo pill) in admin header bar (Closes #73)
- Made all 8 dashboard stat cards clickable links to their respective admin pages (Closes #77)
- Added hover effects with smooth transitions for better visual feedback

## Test plan
- [ ] Verify org badge appears in admin header showing "default"
- [ ] Click each dashboard stat card and verify it navigates to the correct page
- [ ] Verify hover effects work (shadow, border color, label color changes)