### PR TITLE
fix: redirect GET /admin to /admin/

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -743,6 +743,18 @@ func TestRegisterAdminConsoleRoutes(t *testing.T) {
 
 	RegisterAdminConsoleRoutes(r, testPubKey, hmacKey, staticHandler, &stubAdminLoginEndpoints{}, &stubAdminConsoleEndpoints{})
 
+	// GET /admin (no trailing slash) should redirect to /admin/
+	req := httptest.NewRequest(http.MethodGet, "/admin", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMovedPermanently {
+		t.Errorf("GET /admin: status = %d, want %d", w.Code, http.StatusMovedPermanently)
+	}
+	if loc := w.Header().Get("Location"); loc != "/admin/" {
+		t.Errorf("GET /admin: Location = %q, want %q", loc, "/admin/")
+	}
+
 	// Public routes should be accessible (200)
 	publicPaths := []struct {
 		method string


### PR DESCRIPTION
## Summary
- GET `/admin` now returns 301 redirect to `/admin/` instead of 404
- Added test coverage for the redirect behavior

Closes #64

## Test plan
- [x] Test verifies 301 status and Location header
- [x] All existing tests pass