### PR TITLE
fix: return 400 for empty POST /login body

### DIFF
--- a/internal/handler/login.go
+++ b/internal/handler/login.go
@@ -115,7 +115,7 @@ func (h *LoginHandler) Login(w http.ResponseWriter, r *http.Request) {
 	req.Identifier = strings.TrimSpace(req.Identifier)
 	req.OrgSlug = strings.ToLower(strings.TrimSpace(req.OrgSlug))
 	if req.Identifier == "" || req.Password == "" {
-		apierror.Unauthorized(w, invalidCredentialsMsg)
+		apierror.BadRequest(w, "Identifier and password are required.")
 		return
 	}
 

--- a/internal/handler/login_test.go
+++ b/internal/handler/login_test.go
@@ -284,8 +284,37 @@ func TestLoginEmptyCredentials(t *testing.T) {
 
 	h.Login(w, req)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestLoginEmptyBody(t *testing.T) {
+	store := &mockLoginStore{defaultOrgID: uuid.New()}
+	sessions := &mockSessionStore{}
+	h := newTestLoginHandler(store, sessions)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"emptyJSON", `{}`},
+		{"missingPassword", `{"identifier":"admin@rampart.local"}`},
+		{"missingIdentifier", `{"password":"Str0ng!Pass"}`},
+		{"whitespaceIdentifier", `{"identifier":"  ","password":"Str0ng!Pass"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/login", bytes.NewReader([]byte(tc.body)))
+			w := httptest.NewRecorder()
+
+			h.Login(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Empty POST /login now returns 400 Bad Request instead of 401 Unauthorized
- 401 reserved for actual invalid credentials
- Table-driven test with 4 sub-cases

Closes #65

## Test plan
- [x] All tests pass