### PR TITLE
test: boost coverage for auth, oauth, and admin handlers

### DIFF
--- a/internal/handler/admin_test.go
+++ b/internal/handler/admin_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -483,5 +484,457 @@ func TestAdminRevokeSessionsSuccess(t *testing.T) {
 
 	if w.Code != http.StatusNoContent {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
+func TestAdminStatsNoAuth(t *testing.T) {
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	// No auth context set
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	w := httptest.NewRecorder()
+
+	h.Stats(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestAdminStatsCountUsersError(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockAdminUserStore{
+		countUsersErr: fmt.Errorf("db error"),
+	}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	authUser := &middleware.AuthenticatedUser{UserID: uuid.New(), OrgID: orgID}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.Stats(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAdminStatsCountActiveSessionsError(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockAdminUserStore{countUsers: 10}
+	sessions := &mockAdminSessionStore{countActiveErr: fmt.Errorf("redis down")}
+	h := newTestAdminHandler(store, sessions)
+
+	authUser := &middleware.AuthenticatedUser{UserID: uuid.New(), OrgID: orgID}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.Stats(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAdminStatsCountRecentUsersError(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockAdminUserStore{countUsers: 10, countRecentErr: fmt.Errorf("db error")}
+	sessions := &mockAdminSessionStore{countActive: 5}
+	h := newTestAdminHandler(store, sessions)
+
+	authUser := &middleware.AuthenticatedUser{UserID: uuid.New(), OrgID: orgID}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.Stats(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAdminStatsCountOrgsError(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockAdminUserStore{countUsers: 10, countRecent: 2, countOrgsErr: fmt.Errorf("db error")}
+	sessions := &mockAdminSessionStore{countActive: 5}
+	h := newTestAdminHandler(store, sessions)
+
+	authUser := &middleware.AuthenticatedUser{UserID: uuid.New(), OrgID: orgID}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.Stats(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAdminListUsersNoAuth(t *testing.T) {
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users", http.NoBody)
+	w := httptest.NewRecorder()
+
+	h.ListUsers(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestAdminListUsersStoreError(t *testing.T) {
+	store := &mockAdminUserStore{listErr: fmt.Errorf("db error")}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	authUser := &middleware.AuthenticatedUser{UserID: uuid.New(), OrgID: uuid.New()}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users?page=1&limit=20", http.NoBody)
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.ListUsers(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAdminCreateUserNoAuth(t *testing.T) {
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	body := []byte(`{"username":"newuser","email":"new@test.com","password":"Str0ng!Pass","given_name":"New","family_name":"User","enabled":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.CreateUser(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestAdminCreateUserInvalidJSON(t *testing.T) {
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+
+	h.CreateUser(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAdminCreateUserDuplicateUsername(t *testing.T) {
+	existing := newAdminTestUser()
+	store := &mockAdminUserStore{
+		usernameUser: existing,
+	}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	authUser := &middleware.AuthenticatedUser{UserID: uuid.New(), OrgID: existing.OrgID}
+	body := []byte(`{"username":"testuser","email":"other@test.com","password":"Str0ng!Pass","given_name":"A","family_name":"B","enabled":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users", bytes.NewReader(body))
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.CreateUser(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+	}
+}
+
+func TestAdminUpdateUserInvalidJSON(t *testing.T) {
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Put("/api/v1/admin/users/{id}", h.UpdateUser)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/users/"+uuid.New().String(), bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAdminUpdateUserNotFound(t *testing.T) {
+	store := &mockAdminUserStore{updatedUser: nil} // not found
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Put("/api/v1/admin/users/{id}", h.UpdateUser)
+
+	body := []byte(`{"username":"updated","email":"updated@test.com","given_name":"Up","family_name":"Dated","enabled":true}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/users/"+uuid.New().String(), bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestAdminUpdateUserStoreError(t *testing.T) {
+	store := &mockAdminUserStore{updateErr: fmt.Errorf("db error")}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Put("/api/v1/admin/users/{id}", h.UpdateUser)
+
+	body := []byte(`{"username":"updated","email":"updated@test.com","given_name":"Up","family_name":"Dated","enabled":true}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/users/"+uuid.New().String(), bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAdminDeleteUserNoAuth(t *testing.T) {
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Delete("/api/v1/admin/users/{id}", h.DeleteUser)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/users/"+uuid.New().String(), http.NoBody)
+	// No auth context set — should proceed without self-deletion check
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
+func TestAdminDeleteUserSessionDeleteError(t *testing.T) {
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{deleteErr: fmt.Errorf("session delete failed")}
+	h := newTestAdminHandler(store, sessions)
+
+	callerID := uuid.New()
+	authUser := &middleware.AuthenticatedUser{UserID: callerID, OrgID: uuid.New()}
+
+	r := chi.NewRouter()
+	r.Delete("/api/v1/admin/users/{id}", h.DeleteUser)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/users/"+uuid.New().String(), http.NoBody)
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAdminDeleteUserStoreError(t *testing.T) {
+	store := &mockAdminUserStore{deleteErr: fmt.Errorf("db error")}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	callerID := uuid.New()
+	authUser := &middleware.AuthenticatedUser{UserID: callerID, OrgID: uuid.New()}
+
+	r := chi.NewRouter()
+	r.Delete("/api/v1/admin/users/{id}", h.DeleteUser)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/users/"+uuid.New().String(), http.NoBody)
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAdminResetPasswordNotFound(t *testing.T) {
+	store := &mockAdminUserStore{userByID: nil}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Post("/api/v1/admin/users/{id}/reset-password", h.ResetPassword)
+
+	body := []byte(`{"password":"NewStr0ng!Pass"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+uuid.New().String()+"/reset-password", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestAdminResetPasswordInvalidJSON(t *testing.T) {
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Post("/api/v1/admin/users/{id}/reset-password", h.ResetPassword)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+uuid.New().String()+"/reset-password", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAdminResetPasswordUpdateError(t *testing.T) {
+	user := newAdminTestUser()
+	store := &mockAdminUserStore{userByID: user, updatePwErr: fmt.Errorf("db error")}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Post("/api/v1/admin/users/{id}/reset-password", h.ResetPassword)
+
+	body := []byte(`{"password":"NewStr0ng!Pass"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/"+user.ID.String()+"/reset-password", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAdminGetUserStoreError(t *testing.T) {
+	store := &mockAdminUserStore{userByIDErr: fmt.Errorf("db error")}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/admin/users/{id}", h.GetUser)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users/"+uuid.New().String(), http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAdminListSessionsError(t *testing.T) {
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{listErr: fmt.Errorf("db error")}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/admin/users/{id}/sessions", h.ListSessions)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users/"+uuid.New().String()+"/sessions", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAdminRevokeSessionsError(t *testing.T) {
+	store := &mockAdminUserStore{}
+	sessions := &mockAdminSessionStore{deleteErr: fmt.Errorf("session store down")}
+	h := newTestAdminHandler(store, sessions)
+
+	r := chi.NewRouter()
+	r.Delete("/api/v1/admin/users/{id}/sessions", h.RevokeSessions)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/users/"+uuid.New().String()+"/sessions", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestAdminResolveOrgIDWithHeader(t *testing.T) {
+	orgID := uuid.New()
+	headerOrgID := uuid.New()
+	store := &mockAdminUserStore{countUsers: 5, countRecent: 1, countOrgs: 1}
+	sessions := &mockAdminSessionStore{countActive: 2}
+	h := newTestAdminHandler(store, sessions)
+
+	authUser := &middleware.AuthenticatedUser{UserID: uuid.New(), OrgID: orgID}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	req.Header.Set("X-Org-Context", headerOrgID.String())
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.Stats(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestAdminListUsersWithPaginationLimits(t *testing.T) {
+	store := &mockAdminUserStore{
+		listUsers: []*model.User{},
+		listTotal: 0,
+	}
+	sessions := &mockAdminSessionStore{}
+	h := newTestAdminHandler(store, sessions)
+
+	authUser := &middleware.AuthenticatedUser{UserID: uuid.New(), OrgID: uuid.New()}
+
+	// Test with limit exceeding max
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users?page=1&limit=200", http.NoBody)
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.ListUsers(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp model.ListUsersResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Limit != maxPageLimit {
+		t.Errorf("limit = %d, want %d (clamped to max)", resp.Limit, maxPageLimit)
 	}
 }

--- a/internal/handler/login_test.go
+++ b/internal/handler/login_test.go
@@ -718,6 +718,130 @@ func TestLoginSessionCreateError(t *testing.T) {
 	}
 }
 
+func TestLoginOrgSettingsError(t *testing.T) {
+	user := newTestUser()
+	store := &mockLoginStore{
+		defaultOrgID:   user.OrgID,
+		emailUser:      user,
+		orgSettingsErr: fmt.Errorf("db error fetching settings"),
+	}
+	sessions := &mockSessionStore{}
+	h := newTestLoginHandler(store, sessions)
+
+	body := []byte(`{"identifier": "admin@rampart.local", "password": "Str0ng!Pass"}`)
+	req := httptest.NewRequest(http.MethodPost, "/login", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.Login(w, req)
+
+	// Should succeed even if org settings fail (falls back to defaults)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp LoginResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	// Default accessTTL is 15 minutes = 900 seconds
+	if resp.ExpiresIn != 900 {
+		t.Errorf("expires_in = %d, want 900 (default)", resp.ExpiresIn)
+	}
+}
+
+func TestLoginWhitespaceTrimmingOnIdentifier(t *testing.T) {
+	user := newTestUser()
+	store := &mockLoginStore{
+		defaultOrgID: user.OrgID,
+		emailUser:    user,
+	}
+	sessions := &mockSessionStore{}
+	h := newTestLoginHandler(store, sessions)
+
+	body := []byte(`{"identifier": "  admin@rampart.local  ", "password": "Str0ng!Pass"}`)
+	req := httptest.NewRequest(http.MethodPost, "/login", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.Login(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestLoginOnlyPasswordEmpty(t *testing.T) {
+	store := &mockLoginStore{defaultOrgID: uuid.New()}
+	sessions := &mockSessionStore{}
+	h := newTestLoginHandler(store, sessions)
+
+	body := []byte(`{"identifier": "admin@rampart.local", "password": ""}`)
+	req := httptest.NewRequest(http.MethodPost, "/login", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.Login(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestLoginOnlyIdentifierEmpty(t *testing.T) {
+	store := &mockLoginStore{defaultOrgID: uuid.New()}
+	sessions := &mockSessionStore{}
+	h := newTestLoginHandler(store, sessions)
+
+	body := []byte(`{"identifier": "", "password": "Str0ng!Pass"}`)
+	req := httptest.NewRequest(http.MethodPost, "/login", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.Login(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRefreshDisabledUserAccount(t *testing.T) {
+	user := newTestUser()
+	user.Enabled = false
+	sess := &session.Session{
+		ID:        uuid.New(),
+		UserID:    user.ID,
+		ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
+	}
+	store := &mockLoginStore{userByID: user}
+	sessions := &mockSessionStore{found: sess}
+	h := newTestLoginHandler(store, sessions)
+
+	body := []byte(`{"refresh_token": "some-token"}`)
+	req := httptest.NewRequest(http.MethodPost, "/token/refresh", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.Refresh(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestLogoutWithUserAudit(t *testing.T) {
+	user := newTestUser()
+	sess := &session.Session{ID: uuid.New(), UserID: user.ID}
+	store := &mockLoginStore{userByID: user}
+	sessions := &mockSessionStore{found: sess}
+	h := newTestLoginHandler(store, sessions)
+
+	body := []byte(`{"refresh_token": "some-token"}`)
+	req := httptest.NewRequest(http.MethodPost, "/logout", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.Logout(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
 func TestLoginWithOrgSettings(t *testing.T) {
 	user := newTestUser()
 	store := &mockLoginStore{

--- a/internal/handler/social_test.go
+++ b/internal/handler/social_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -459,6 +460,140 @@ func TestSocialInitiateLoginUnknownClient(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "Unknown client_id") {
 		t.Error("expected unknown client error")
+	}
+}
+
+func TestSocialCallbackExistingSocialAccountLinksUser(t *testing.T) {
+	orgID := uuid.New()
+	existingUser := &model.User{
+		ID:       uuid.New(),
+		OrgID:    orgID,
+		Username: "existinguser",
+		Email:    "test@example.com",
+		Enabled:  true,
+	}
+	store := &mockSocialStore{
+		oauthClient:  newSocialTestOAuthClient(orgID),
+		defaultOrgID: orgID,
+		emailUser:    existingUser,
+		socialAccount: &model.SocialAccount{
+			ID:             uuid.New(),
+			UserID:         existingUser.ID,
+			Provider:       "google",
+			ProviderUserID: "provider-123",
+		},
+	}
+	hmacKey := []byte("test-hmac-key")
+	reg := newTestSocialRegistry(&mockProvider{name: "google", authURL: "https://accounts.google.com/auth"})
+	h := NewSocialHandler(store, reg, noopLogger(), nil, hmacKey, "http://localhost:8080")
+
+	payload := socialCookiePayload{
+		ClientID:      "test-client",
+		RedirectURI:   "http://localhost:3002/callback",
+		Scope:         "openid",
+		State:         "original-state",
+		CodeChallenge: "xyz",
+		ProviderState: "provider-state-existing",
+	}
+	cookieValue, err := h.signCookiePayload(&payload)
+	if err != nil {
+		t.Fatalf("failed to sign cookie: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Get("/oauth/social/{provider}/callback", h.Callback)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/social/google/callback?code=authcode&state=provider-state-existing", http.NoBody)
+	req.AddCookie(&http.Cookie{
+		Name:  socialCookieName,
+		Value: cookieValue,
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("status = %d, want %d; body = %s", w.Code, http.StatusFound, w.Body.String())
+	}
+
+	location := w.Header().Get("Location")
+	if !strings.HasPrefix(location, "http://localhost:3002/callback?code=") {
+		t.Errorf("Location = %q, want redirect to client callback", location)
+	}
+}
+
+func TestSocialCallbackStoreCodeError(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockSocialStore{
+		oauthClient:  newSocialTestOAuthClient(orgID),
+		defaultOrgID: orgID,
+		emailUser:    nil, // new user
+		storeErr:     fmt.Errorf("db error storing code"),
+	}
+	hmacKey := []byte("test-hmac-key")
+	reg := newTestSocialRegistry(&mockProvider{name: "google", authURL: "https://accounts.google.com/auth"})
+	h := NewSocialHandler(store, reg, noopLogger(), nil, hmacKey, "http://localhost:8080")
+
+	payload := socialCookiePayload{
+		ClientID:      "test-client",
+		RedirectURI:   "http://localhost:3002/callback",
+		Scope:         "openid",
+		State:         "original-state",
+		CodeChallenge: "xyz",
+		ProviderState: "provider-state-err",
+	}
+	cookieValue, err := h.signCookiePayload(&payload)
+	if err != nil {
+		t.Fatalf("failed to sign cookie: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Get("/oauth/social/{provider}/callback", h.Callback)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/social/google/callback?code=authcode&state=provider-state-err", http.NoBody)
+	req.AddCookie(&http.Cookie{
+		Name:  socialCookieName,
+		Value: cookieValue,
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestSocialInitiateClientFetchError(t *testing.T) {
+	store := &mockSocialStore{
+		oauthErr: fmt.Errorf("db error"),
+	}
+	reg := newTestSocialRegistry(&mockProvider{name: "google", authURL: "https://accounts.google.com/auth"})
+	h := NewSocialHandler(store, reg, noopLogger(), nil, []byte("test-hmac-key"), "http://localhost:8080")
+
+	r := chi.NewRouter()
+	r.Get("/oauth/social/{provider}", h.InitiateLogin)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/social/google?client_id=test-client&redirect_uri=http://localhost:3002/callback&state=abc", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestCookieVerifyMalformedPayload(t *testing.T) {
+	h := NewSocialHandler(nil, nil, noopLogger(), nil, []byte("secret-key"), "http://localhost:8080")
+
+	// No dot separator
+	_, err := h.verifyCookiePayload("nodotseparator")
+	if err == nil {
+		t.Error("expected error for cookie without dot separator")
+	}
+
+	// Invalid hex signature
+	_, err = h.verifyCookiePayload("validbase64.invalidhex!!!")
+	if err == nil {
+		t.Error("expected error for invalid hex signature")
 	}
 }
 

--- a/internal/handler/token_test.go
+++ b/internal/handler/token_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -26,6 +27,8 @@ type mockTokenStore struct {
 	userByIDErr    error
 	orgSettings    *model.OrgSettings
 	orgSettingsErr error
+	roles          []string
+	rolesErr       error
 }
 
 func (m *mockTokenStore) GetOAuthClient(_ context.Context, _ string) (*model.OAuthClient, error) {
@@ -45,7 +48,7 @@ func (m *mockTokenStore) GetOrgSettings(_ context.Context, _ uuid.UUID) (*model.
 }
 
 func (m *mockTokenStore) GetEffectiveUserRoles(_ context.Context, _ uuid.UUID) ([]string, error) {
-	return nil, nil
+	return m.roles, m.rolesErr
 }
 
 func TestTokenMissingGrantType(t *testing.T) {
@@ -270,5 +273,388 @@ func TestTokenValidExchange(t *testing.T) {
 	// Verify Cache-Control is no-store
 	if cc := w.Header().Get("Cache-Control"); cc != "no-store" {
 		t.Errorf("Cache-Control = %q, want no-store", cc)
+	}
+}
+
+func TestTokenMethodNotAllowed(t *testing.T) {
+	store := &mockTokenStore{}
+	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/token", http.NoBody)
+	w := httptest.NewRecorder()
+
+	h.Token(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestTokenUnknownClientID(t *testing.T) {
+	store := &mockTokenStore{
+		oauthClient: nil, // client not found
+	}
+	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
+
+	body := "grant_type=authorization_code&code=validcode&client_id=unknown-client&redirect_uri=http://localhost:3002/callback&code_verifier=" + testVerifier
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.Token(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp["error"] != "invalid_client" {
+		t.Errorf("error = %q, want invalid_client", resp["error"])
+	}
+}
+
+func TestTokenClientFetchError(t *testing.T) {
+	store := &mockTokenStore{
+		oauthErr: fmt.Errorf("db connection failed"),
+	}
+	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
+
+	body := "grant_type=authorization_code&code=validcode&client_id=test-client&redirect_uri=http://localhost:3002/callback&code_verifier=" + testVerifier
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.Token(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestTokenConsumeCodeError(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockTokenStore{
+		oauthClient: newTestOAuthClient(orgID),
+		consumeErr:  fmt.Errorf("db error consuming code"),
+	}
+	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
+
+	body := "grant_type=authorization_code&code=validcode&client_id=test-client&redirect_uri=http://localhost:3002/callback&code_verifier=" + testVerifier
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.Token(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestTokenUserDisabledAfterCodeExchange(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	verifier := testVerifier
+	challenge := oauth.ComputeS256Challenge(verifier)
+
+	disabledUser := &model.User{
+		ID:       userID,
+		OrgID:    orgID,
+		Username: "disabled",
+		Email:    "disabled@test.com",
+		Enabled:  false,
+	}
+
+	store := &mockTokenStore{
+		oauthClient: newTestOAuthClient(orgID),
+		authCode: &model.AuthorizationCode{
+			ID:            uuid.New(),
+			ClientID:      "test-client",
+			UserID:        userID,
+			OrgID:         orgID,
+			RedirectURI:   "http://localhost:3002/callback",
+			CodeChallenge: challenge,
+			ExpiresAt:     time.Now().Add(10 * time.Minute),
+		},
+		userByID: disabledUser,
+	}
+	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
+
+	body := "grant_type=authorization_code&code=validcode&client_id=test-client&redirect_uri=http://localhost:3002/callback&code_verifier=" + verifier
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.Token(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp["error"] != "invalid_grant" {
+		t.Errorf("error = %q, want invalid_grant", resp["error"])
+	}
+}
+
+func TestTokenUserNotFoundAfterCodeExchange(t *testing.T) {
+	orgID := uuid.New()
+	verifier := testVerifier
+	challenge := oauth.ComputeS256Challenge(verifier)
+
+	store := &mockTokenStore{
+		oauthClient: newTestOAuthClient(orgID),
+		authCode: &model.AuthorizationCode{
+			ID:            uuid.New(),
+			ClientID:      "test-client",
+			UserID:        uuid.New(),
+			OrgID:         orgID,
+			RedirectURI:   "http://localhost:3002/callback",
+			CodeChallenge: challenge,
+			ExpiresAt:     time.Now().Add(10 * time.Minute),
+		},
+		userByID: nil, // user deleted between auth and token exchange
+	}
+	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
+
+	body := "grant_type=authorization_code&code=validcode&client_id=test-client&redirect_uri=http://localhost:3002/callback&code_verifier=" + verifier
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.Token(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestTokenUserFetchError(t *testing.T) {
+	orgID := uuid.New()
+	verifier := testVerifier
+	challenge := oauth.ComputeS256Challenge(verifier)
+
+	store := &mockTokenStore{
+		oauthClient: newTestOAuthClient(orgID),
+		authCode: &model.AuthorizationCode{
+			ID:            uuid.New(),
+			ClientID:      "test-client",
+			UserID:        uuid.New(),
+			OrgID:         orgID,
+			RedirectURI:   "http://localhost:3002/callback",
+			CodeChallenge: challenge,
+			ExpiresAt:     time.Now().Add(10 * time.Minute),
+		},
+		userByIDErr: fmt.Errorf("db error"),
+	}
+	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
+
+	body := "grant_type=authorization_code&code=validcode&client_id=test-client&redirect_uri=http://localhost:3002/callback&code_verifier=" + verifier
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.Token(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestTokenSessionCreateError(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	verifier := testVerifier
+	challenge := oauth.ComputeS256Challenge(verifier)
+
+	user := &model.User{
+		ID:       userID,
+		OrgID:    orgID,
+		Username: "testuser",
+		Email:    "test@test.com",
+		Enabled:  true,
+	}
+
+	store := &mockTokenStore{
+		oauthClient: newTestOAuthClient(orgID),
+		authCode: &model.AuthorizationCode{
+			ID:            uuid.New(),
+			ClientID:      "test-client",
+			UserID:        userID,
+			OrgID:         orgID,
+			RedirectURI:   "http://localhost:3002/callback",
+			CodeChallenge: challenge,
+			ExpiresAt:     time.Now().Add(10 * time.Minute),
+		},
+		userByID: user,
+	}
+	sessions := &mockSessionStore{createErr: fmt.Errorf("session store down")}
+	h := NewTokenHandler(store, sessions, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
+
+	body := "grant_type=authorization_code&code=validcode&client_id=test-client&redirect_uri=http://localhost:3002/callback&code_verifier=" + verifier
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.Token(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestTokenWithOrgSettings(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	verifier := testVerifier
+	challenge := oauth.ComputeS256Challenge(verifier)
+
+	user := &model.User{
+		ID:       userID,
+		OrgID:    orgID,
+		Username: "admin",
+		Email:    "admin@test.com",
+		Enabled:  true,
+	}
+
+	store := &mockTokenStore{
+		oauthClient: newTestOAuthClient(orgID),
+		authCode: &model.AuthorizationCode{
+			ID:            uuid.New(),
+			ClientID:      "test-client",
+			UserID:        userID,
+			OrgID:         orgID,
+			RedirectURI:   "http://localhost:3002/callback",
+			CodeChallenge: challenge,
+			ExpiresAt:     time.Now().Add(10 * time.Minute),
+		},
+		userByID: user,
+		orgSettings: &model.OrgSettings{
+			AccessTokenTTL:  30 * time.Minute,
+			RefreshTokenTTL: 14 * 24 * time.Hour,
+		},
+	}
+	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
+
+	body := "grant_type=authorization_code&code=validcode&client_id=test-client&redirect_uri=http://localhost:3002/callback&code_verifier=" + verifier
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.Token(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp TokenResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.ExpiresIn != 1800 {
+		t.Errorf("expires_in = %d, want 1800 (30 min org setting)", resp.ExpiresIn)
+	}
+}
+
+func TestFilterInternalRolesRemovesAdmin(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "removes admin role",
+			input:    []string{"user", "admin", "editor"},
+			expected: []string{"user", "editor"},
+		},
+		{
+			name:     "no admin role present",
+			input:    []string{"user", "editor"},
+			expected: []string{"user", "editor"},
+		},
+		{
+			name:     "only admin role",
+			input:    []string{"admin"},
+			expected: []string{},
+		},
+		{
+			name:     "empty roles",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "nil roles",
+			input:    nil,
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := filterInternalRoles(tc.input)
+			if len(result) != len(tc.expected) {
+				t.Errorf("len = %d, want %d; result = %v", len(result), len(tc.expected), result)
+				return
+			}
+			for i, r := range result {
+				if r != tc.expected[i] {
+					t.Errorf("result[%d] = %q, want %q", i, r, tc.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestTokenWithAdminClientIncludesAdminRole(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	verifier := testVerifier
+	challenge := oauth.ComputeS256Challenge(verifier)
+
+	user := &model.User{
+		ID:       userID,
+		OrgID:    orgID,
+		Username: "adminuser",
+		Email:    "adminuser@test.com",
+		Enabled:  true,
+	}
+
+	store := &mockTokenStore{
+		oauthClient: &model.OAuthClient{
+			ID:           adminClientID,
+			OrgID:        orgID,
+			Name:         "Rampart Admin",
+			ClientType:   "public",
+			RedirectURIs: []string{"http://localhost:3002/callback"},
+		},
+		authCode: &model.AuthorizationCode{
+			ID:            uuid.New(),
+			ClientID:      adminClientID,
+			UserID:        userID,
+			OrgID:         orgID,
+			RedirectURI:   "http://localhost:3002/callback",
+			CodeChallenge: challenge,
+			ExpiresAt:     time.Now().Add(10 * time.Minute),
+		},
+		userByID: user,
+		roles:    []string{"admin", "user"},
+	}
+	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
+
+	body := "grant_type=authorization_code&code=validcode&client_id=" + adminClientID + "&redirect_uri=http://localhost:3002/callback&code_verifier=" + verifier
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.Token(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
 	}
 }


### PR DESCRIPTION
## Summary
- New tests for critical uncovered paths
- Table-driven, idiomatic Go patterns

## Test plan
- [x] All tests pass