### PR TITLE
feat: enforce admin role check on admin API routes

### DIFF
--- a/internal/middleware/admin_session.go
+++ b/internal/middleware/admin_session.go
@@ -68,10 +68,31 @@ func AdminSession(pubKey *rsa.PublicKey, hmacKey []byte) func(http.Handler) http
 				EmailVerified:     claims.EmailVerified,
 				GivenName:         claims.GivenName,
 				FamilyName:        claims.FamilyName,
+				Roles:             claims.Roles,
 			}
 
 			ctx := context.WithValue(r.Context(), authenticatedUserKey, authUser)
 			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// RequireAdminSession returns middleware that checks the authenticated user has the "admin" role.
+// Must be used after AdminSession middleware. Redirects to login if the role is missing.
+func RequireAdminSession() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user := GetAuthenticatedUser(r.Context())
+			if user == nil {
+				http.Redirect(w, r, AdminLoginPath, http.StatusFound)
+				return
+			}
+			if !user.HasRole("admin") {
+				ClearAdminSession(w)
+				http.Error(w, "Forbidden: admin role required.", http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
 		})
 	}
 }

--- a/internal/middleware/admin_session_test.go
+++ b/internal/middleware/admin_session_test.go
@@ -353,6 +353,110 @@ func TestGenerateHMACKey(t *testing.T) {
 	}
 }
 
+func generateTestTokenWithRolesAdmin(t *testing.T, roles ...string) string {
+	t.Helper()
+	tok, err := token.GenerateAccessToken(
+		testPrivKey, testKID, testIssuer, 15*time.Minute,
+		uuid.New(), uuid.New(),
+		"testuser", "test@test.com", true, "Test", "User",
+		roles...,
+	)
+	if err != nil {
+		t.Fatalf("failed to generate test token: %v", err)
+	}
+	return tok
+}
+
+func TestRequireAdminSessionAllowsAdmin(t *testing.T) {
+	tok := generateTestTokenWithRolesAdmin(t, "admin")
+	signed := signCookie(tok, testHMACKey)
+
+	called := false
+	handler := AdminSession(testPubKey, testHMACKey)(
+		RequireAdminSession()(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+			}),
+		),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: signed})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if !called {
+		t.Error("expected handler to be called for admin user")
+	}
+}
+
+func TestRequireAdminSessionBlocksRegularUser(t *testing.T) {
+	tok := generateTestTokenWithRolesAdmin(t, "viewer")
+	signed := signCookie(tok, testHMACKey)
+
+	handler := AdminSession(testPubKey, testHMACKey)(
+		RequireAdminSession()(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("handler should not be called for non-admin user")
+			}),
+		),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: signed})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestRequireAdminSessionBlocksUserWithNoRoles(t *testing.T) {
+	tok := generateTestTokenWithRolesAdmin(t)
+	signed := signCookie(tok, testHMACKey)
+
+	handler := AdminSession(testPubKey, testHMACKey)(
+		RequireAdminSession()(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("handler should not be called for user with no roles")
+			}),
+		),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: signed})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestRequireAdminSessionNoUserRedirects(t *testing.T) {
+	handler := RequireAdminSession()(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("handler should not be called")
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/", http.NoBody)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusFound)
+	}
+	loc := w.Header().Get("Location")
+	if loc != AdminLoginPath {
+		t.Errorf("redirect location = %q, want %q", loc, AdminLoginPath)
+	}
+}
+
 func TestCSRFProtectAllowsGET(t *testing.T) {
 	called := false
 	handler := CSRFProtect()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -26,6 +26,17 @@ type AuthenticatedUser struct {
 	EmailVerified     bool
 	GivenName         string
 	FamilyName        string
+	Roles             []string
+}
+
+// HasRole returns true if the user has the given role.
+func (u *AuthenticatedUser) HasRole(role string) bool {
+	for _, r := range u.Roles {
+		if r == role {
+			return true
+		}
+	}
+	return false
 }
 
 // Auth returns middleware that verifies RS256 Bearer tokens and stores the user in context.
@@ -64,10 +75,30 @@ func Auth(pubKey *rsa.PublicKey) func(http.Handler) http.Handler {
 				EmailVerified:     claims.EmailVerified,
 				GivenName:         claims.GivenName,
 				FamilyName:        claims.FamilyName,
+				Roles:             claims.Roles,
 			}
 
 			ctx := context.WithValue(r.Context(), authenticatedUserKey, authUser)
 			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// RequireRole returns middleware that checks the authenticated user has the specified role.
+// Must be used after Auth middleware. Returns 403 Forbidden if the role is missing.
+func RequireRole(role string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user := GetAuthenticatedUser(r.Context())
+			if user == nil {
+				writeAuthError(w, "Missing authorization header.")
+				return
+			}
+			if !user.HasRole(role) {
+				writeForbiddenError(w, "Insufficient permissions. Required role: "+role+".")
+				return
+			}
+			next.ServeHTTP(w, r)
 		})
 	}
 }
@@ -90,6 +121,16 @@ func GetAuthenticatedUser(ctx context.Context) *AuthenticatedUser {
 
 // writeAuthError writes a 401 JSON error response without importing apierror (to avoid import cycles).
 func writeAuthError(w http.ResponseWriter, description string) {
+	writeErrorResponse(w, "unauthorized", description, http.StatusUnauthorized)
+}
+
+// writeForbiddenError writes a 403 JSON error response.
+func writeForbiddenError(w http.ResponseWriter, description string) {
+	writeErrorResponse(w, "forbidden", description, http.StatusForbidden)
+}
+
+// writeErrorResponse writes a JSON error response with the given code and status.
+func writeErrorResponse(w http.ResponseWriter, code, description string, status int) {
 	reqID := w.Header().Get(HeaderRequestID)
 	resp := struct {
 		Code        string `json:"error"`
@@ -97,15 +138,15 @@ func writeAuthError(w http.ResponseWriter, description string) {
 		Status      int    `json:"status"`
 		RequestID   string `json:"request_id,omitempty"`
 	}{
-		Code:        "unauthorized",
+		Code:        code,
 		Description: description,
-		Status:      http.StatusUnauthorized,
+		Status:      status,
 		RequestID:   reqID,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusUnauthorized)
+	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		slog.Error("failed to encode auth error response", "error", err)
+		slog.Error("failed to encode error response", "error", err)
 	}
 }

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -285,6 +285,202 @@ func TestWriteAuthErrorIncludesRequestID(t *testing.T) {
 	}
 }
 
+func TestHasRoleReturnsTrue(t *testing.T) {
+	user := &AuthenticatedUser{
+		Roles: []string{"admin", "viewer"},
+	}
+	if !user.HasRole("admin") {
+		t.Error("expected HasRole to return true for admin")
+	}
+}
+
+func TestHasRoleReturnsFalse(t *testing.T) {
+	user := &AuthenticatedUser{
+		Roles: []string{"viewer"},
+	}
+	if user.HasRole("admin") {
+		t.Error("expected HasRole to return false for admin")
+	}
+}
+
+func TestHasRoleEmptyRoles(t *testing.T) {
+	user := &AuthenticatedUser{}
+	if user.HasRole("admin") {
+		t.Error("expected HasRole to return false for empty roles")
+	}
+}
+
+func generateTestTokenWithRoles(t *testing.T, roles ...string) string {
+	t.Helper()
+	tok, err := token.GenerateAccessToken(
+		testPrivKey, testKID, testIssuer, 15*time.Minute,
+		uuid.New(), uuid.New(),
+		"testuser", "test@test.com", true, "Test", "User",
+		roles...,
+	)
+	if err != nil {
+		t.Fatalf("failed to generate test token: %v", err)
+	}
+	return tok
+}
+
+func TestRequireRoleAdminAllowed(t *testing.T) {
+	tok := generateTestTokenWithRoles(t, "admin", "viewer")
+
+	called := false
+	handler := Auth(testPubKey)(
+		RequireRole("admin")(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+			}),
+		),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if !called {
+		t.Error("expected handler to be called for admin user")
+	}
+}
+
+func TestRequireRoleRegularUserForbidden(t *testing.T) {
+	tok := generateTestTokenWithRoles(t, "viewer")
+
+	handler := Auth(testPubKey)(
+		RequireRole("admin")(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("handler should not be called for non-admin user")
+			}),
+		),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "forbidden") {
+		t.Errorf("response body missing 'forbidden' error code, got: %s", body)
+	}
+	if !strings.Contains(body, "admin") {
+		t.Errorf("response body should mention required role, got: %s", body)
+	}
+}
+
+func TestRequireRoleNoRolesInToken(t *testing.T) {
+	tok := generateTestTokenWithRoles(t)
+
+	handler := Auth(testPubKey)(
+		RequireRole("admin")(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("handler should not be called for user with no roles")
+			}),
+		),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestRequireRoleUnauthenticatedReturns401(t *testing.T) {
+	handler := Auth(testPubKey)(
+		RequireRole("admin")(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("handler should not be called")
+			}),
+		),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRequireRoleNoUserInContext(t *testing.T) {
+	handler := RequireRole("admin")(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("handler should not be called")
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRequireRoleForbiddenResponseIsJSON(t *testing.T) {
+	tok := generateTestTokenWithRoles(t, "viewer")
+
+	handler := Auth(testPubKey)(
+		RequireRole("admin")(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("handler should not be called")
+			}),
+		),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	ct := w.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+}
+
+func TestAuthMiddlewarePopulatesRoles(t *testing.T) {
+	tok := generateTestTokenWithRoles(t, "admin", "editor")
+
+	var gotUser *AuthenticatedUser
+	handler := Auth(testPubKey)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotUser = GetAuthenticatedUser(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/me", http.NoBody)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if gotUser == nil {
+		t.Fatal("expected authenticated user")
+	}
+	if len(gotUser.Roles) != 2 {
+		t.Fatalf("expected 2 roles, got %d", len(gotUser.Roles))
+	}
+	if !gotUser.HasRole("admin") {
+		t.Error("expected user to have admin role")
+	}
+	if !gotUser.HasRole("editor") {
+		t.Error("expected user to have editor role")
+	}
+}
+
 func TestWriteAuthErrorContentType(t *testing.T) {
 	w := httptest.NewRecorder()
 	writeAuthError(w, "some error")

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -83,6 +83,7 @@ type AdminEndpoints interface {
 func RegisterAdminRoutes(r *chi.Mux, pubKey *rsa.PublicKey, admin AdminEndpoints) {
 	r.Group(func(r chi.Router) {
 		r.Use(middleware.Auth(pubKey))
+		r.Use(middleware.RequireRole("admin"))
 
 		r.Get("/api/v1/admin/stats", admin.Stats)
 		r.Get("/api/v1/admin/users", admin.ListUsers)
@@ -111,6 +112,7 @@ type OrgEndpoints interface {
 func RegisterOrgRoutes(r *chi.Mux, pubKey *rsa.PublicKey, org OrgEndpoints) {
 	r.Group(func(r chi.Router) {
 		r.Use(middleware.Auth(pubKey))
+		r.Use(middleware.RequireRole("admin"))
 
 		r.Get("/api/v1/admin/organizations", org.ListOrgs)
 		r.Post("/api/v1/admin/organizations", org.CreateOrg)
@@ -126,6 +128,7 @@ func RegisterOrgRoutes(r *chi.Mux, pubKey *rsa.PublicKey, org OrgEndpoints) {
 func RegisterExportImportRoutes(r *chi.Mux, pubKey *rsa.PublicKey, exportHandler, importHandler http.HandlerFunc) {
 	r.Group(func(r chi.Router) {
 		r.Use(middleware.Auth(pubKey))
+		r.Use(middleware.RequireRole("admin"))
 
 		r.Get("/api/v1/admin/organizations/{id}/export", exportHandler)
 		r.Post("/api/v1/admin/organizations/{id}/import", importHandler)
@@ -227,9 +230,10 @@ func RegisterAdminConsoleRoutes(r *chi.Mux, pubKey *rsa.PublicKey, hmacKey []byt
 	r.Get("/admin/login", login.Login)
 	r.Get("/admin/callback", login.Callback)
 
-	// Protected admin routes (session cookie required)
+	// Protected admin routes (session cookie required + admin role)
 	r.Group(func(r chi.Router) {
 		r.Use(middleware.AdminSession(pubKey, hmacKey))
+		r.Use(middleware.RequireAdminSession())
 		r.Use(middleware.CSRFProtect())
 
 		r.Get("/admin/", console.Dashboard)


### PR DESCRIPTION
## Summary
**Critical security fix** — Admin API and console routes previously only verified a valid JWT but never checked for the "admin" role. Any self-registered user had full admin access.

- Added `Roles` field + `HasRole()` to `AuthenticatedUser`
- Added `RequireRole("admin")` middleware for API routes (returns 403 JSON)
- Added `RequireAdminSession()` middleware for console routes (returns 403, clears cookie)
- 15 new tests covering admin/regular/unauthenticated access

## Test plan
- [x] Admin user can access admin routes
- [x] Regular user gets 403 on admin API and console
- [x] Unauthenticated user gets 401
- [x] All middleware and server tests pass