### PR TITLE
feat: add security headers middleware

### DIFF
--- a/cmd/rampart/main.go
+++ b/cmd/rampart/main.go
@@ -67,7 +67,7 @@ func run(_ *slog.Logger) error {
 		return err
 	}
 
-	router := server.NewRouter(logger, cfg.AllowedOrigins)
+	router := server.NewRouter(logger, cfg.AllowedOrigins, cfg.HSTSEnabled)
 	healthHandler := handler.NewHealthHandler(db)
 	server.RegisterHealthRoutes(router, healthHandler.Liveness, healthHandler.Readiness)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,9 @@ type Config struct {
 	AccessTokenTTL  time.Duration
 	RefreshTokenTTL time.Duration
 
+	// Security
+	HSTSEnabled bool
+
 	// Social login providers
 	GoogleClientID     string
 	GoogleClientSecret string
@@ -151,6 +154,11 @@ func Load() (*Config, error) {
 			return nil, fmt.Errorf("RAMPART_REFRESH_TOKEN_TTL must be positive")
 		}
 		cfg.RefreshTokenTTL = time.Duration(secs) * time.Second
+	}
+
+	// Security
+	if v := os.Getenv("RAMPART_HSTS_ENABLED"); strings.EqualFold(v, "true") || v == "1" {
+		cfg.HSTSEnabled = true
 	}
 
 	// Social login providers

--- a/internal/middleware/security_headers.go
+++ b/internal/middleware/security_headers.go
@@ -1,0 +1,50 @@
+package middleware
+
+import "net/http"
+
+// Security header constants to avoid string duplication.
+const (
+	headerXContentTypeOptions = "X-Content-Type-Options"
+	headerXFrameOptions       = "X-Frame-Options"
+	headerXXSSProtection      = "X-XSS-Protection"
+	headerReferrerPolicy      = "Referrer-Policy"
+	headerCSP                 = "Content-Security-Policy"
+	headerPermissionsPolicy   = "Permissions-Policy"
+	headerHSTS                = "Strict-Transport-Security"
+
+	valueNosniff                      = "nosniff"
+	valueDeny                         = "DENY"
+	valueXSSBlock                     = "1; mode=block"
+	valueReferrerPolicy               = "strict-origin-when-cross-origin"
+	valueCSP                          = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+	valuePermissionsPolicy            = "camera=(), microphone=(), geolocation=()"
+	valueHSTS                         = "max-age=31536000; includeSubDomains"
+)
+
+// SecurityHeadersConfig controls the behavior of the SecurityHeaders middleware.
+type SecurityHeadersConfig struct {
+	// HSTSEnabled controls whether the Strict-Transport-Security header is set.
+	// Should only be true when TLS termination happens at this server.
+	HSTSEnabled bool
+}
+
+// SecurityHeaders is middleware that sets common security headers on all responses.
+func SecurityHeaders(cfg SecurityHeadersConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := w.Header()
+			h.Set(headerXContentTypeOptions, valueNosniff)
+			h.Set(headerXFrameOptions, valueDeny)
+			h.Set(headerXXSSProtection, valueXSSBlock)
+			h.Set(headerReferrerPolicy, valueReferrerPolicy)
+			h.Set(headerCSP, valueCSP)
+			h.Set(headerPermissionsPolicy, valuePermissionsPolicy)
+
+			if cfg.HSTSEnabled {
+				h.Set(headerHSTS, valueHSTS)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/security_headers_test.go
+++ b/internal/middleware/security_headers_test.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSecurityHeadersDefaultHeaders(t *testing.T) {
+	handler := SecurityHeaders(SecurityHeadersConfig{})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rr, req)
+
+	expected := map[string]string{
+		"X-Content-Type-Options": "nosniff",
+		"X-Frame-Options":       "DENY",
+		"X-Xss-Protection":      "1; mode=block",
+		"Referrer-Policy":       "strict-origin-when-cross-origin",
+		"Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'",
+		"Permissions-Policy":    "camera=(), microphone=(), geolocation=()",
+	}
+
+	for header, want := range expected {
+		got := rr.Header().Get(header)
+		if got != want {
+			t.Errorf("header %s = %q, want %q", header, got, want)
+		}
+	}
+
+	if hsts := rr.Header().Get("Strict-Transport-Security"); hsts != "" {
+		t.Errorf("HSTS header should not be set when disabled, got %q", hsts)
+	}
+}
+
+func TestSecurityHeadersHSTSEnabled(t *testing.T) {
+	handler := SecurityHeaders(SecurityHeadersConfig{HSTSEnabled: true})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rr, req)
+
+	want := "max-age=31536000; includeSubDomains"
+	got := rr.Header().Get("Strict-Transport-Security")
+	if got != want {
+		t.Errorf("HSTS header = %q, want %q", got, want)
+	}
+}
+
+func TestSecurityHeadersHSTSDisabled(t *testing.T) {
+	handler := SecurityHeaders(SecurityHeadersConfig{HSTSEnabled: false})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rr, req)
+
+	if hsts := rr.Header().Get("Strict-Transport-Security"); hsts != "" {
+		t.Errorf("HSTS header should not be set when disabled, got %q", hsts)
+	}
+}
+
+func TestSecurityHeadersCallsNext(t *testing.T) {
+	called := false
+	handler := SecurityHeaders(SecurityHeadersConfig{})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rr, req)
+
+	if !called {
+		t.Error("next handler was not called")
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -14,14 +14,17 @@ import (
 )
 
 // NewRouter creates and configures the chi router with middleware chain.
-// Middleware order: RequestID → RealIP → Recovery → CORS → Logging
-func NewRouter(logger *slog.Logger, allowedOrigins []string) *chi.Mux {
+// Middleware order: RequestID → RealIP → Recovery → SecurityHeaders → CORS → Logging
+func NewRouter(logger *slog.Logger, allowedOrigins []string, hstsEnabled bool) *chi.Mux {
 	r := chi.NewRouter()
 
 	// Middleware chain — order matters
 	r.Use(middleware.RequestID)
 	r.Use(chimw.RealIP)
 	r.Use(middleware.Recovery(logger))
+	r.Use(middleware.SecurityHeaders(middleware.SecurityHeadersConfig{
+		HSTSEnabled: hstsEnabled,
+	}))
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   allowedOrigins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -85,7 +85,7 @@ func apiTestLogger() *slog.Logger {
 
 func setupTestServer(db *mockDB) *httptest.Server {
 	logger := apiTestLogger()
-	router := NewRouter(logger, []string{"*"})
+	router := NewRouter(logger, []string{"*"}, false)
 
 	healthH := handler.NewHealthHandler(db)
 	RegisterHealthRoutes(router, healthH.Liveness, healthH.Readiness)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -57,7 +57,7 @@ func init() {
 
 func TestNewRouterMiddlewareChain(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	r := NewRouter(logger, []string{"http://localhost:3000"})
+	r := NewRouter(logger, []string{"http://localhost:3000"}, false)
 
 	RegisterHealthRoutes(r, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -82,7 +82,7 @@ func TestNewRouterMiddlewareChain(t *testing.T) {
 
 func TestNewRouterNotFound(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	r := NewRouter(logger, []string{"http://localhost:3000"})
+	r := NewRouter(logger, []string{"http://localhost:3000"}, false)
 
 	req := httptest.NewRequest(http.MethodGet, "/nonexistent", http.NoBody)
 	w := httptest.NewRecorder()
@@ -95,7 +95,7 @@ func TestNewRouterNotFound(t *testing.T) {
 
 func TestNewServer(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	r := NewRouter(logger, []string{"http://localhost:3000"})
+	r := NewRouter(logger, []string{"http://localhost:3000"}, false)
 	s := New(":0", r, logger)
 
 	if s.httpServer.ReadTimeout != readTimeout {
@@ -111,7 +111,7 @@ func TestNewServer(t *testing.T) {
 
 func TestServerStartAndShutdown(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"http://localhost:3000"})
+	r := NewRouter(logger, []string{"http://localhost:3000"}, false)
 
 	RegisterHealthRoutes(r, func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"status":"alive"}`))
@@ -143,7 +143,7 @@ func TestServerStartAndShutdown(t *testing.T) {
 
 func TestNewRouterCORSHeaders(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"http://localhost:3000"})
+	r := NewRouter(logger, []string{"http://localhost:3000"}, false)
 
 	RegisterHealthRoutes(r, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -165,7 +165,7 @@ func TestNewRouterCORSHeaders(t *testing.T) {
 
 func TestNewRouterReadyzEndpoint(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"http://localhost:3000"})
+	r := NewRouter(logger, []string{"http://localhost:3000"}, false)
 
 	RegisterHealthRoutes(r, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -184,7 +184,7 @@ func TestNewRouterReadyzEndpoint(t *testing.T) {
 
 func TestNewServerAddr(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, nil)
+	r := NewRouter(logger, nil, false)
 	s := New(":9090", r, logger)
 
 	if s.httpServer.Addr != ":9090" {
@@ -200,7 +200,7 @@ func TestNewServerAddr(t *testing.T) {
 
 func TestNewRouterMultipleOrigins(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"http://localhost:3000", "http://localhost:5173"})
+	r := NewRouter(logger, []string{"http://localhost:3000", "http://localhost:5173"}, false)
 
 	RegisterHealthRoutes(r, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -222,7 +222,7 @@ func TestNewRouterMultipleOrigins(t *testing.T) {
 
 func TestRegisterAuthRoutes(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"*"})
+	r := NewRouter(logger, []string{"*"}, false)
 
 	called := false
 	RegisterAuthRoutes(r, func(w http.ResponseWriter, _ *http.Request) {
@@ -244,7 +244,7 @@ func TestRegisterAuthRoutes(t *testing.T) {
 
 func TestRegisterLoginRoutes(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"*"})
+	r := NewRouter(logger, []string{"*"}, false)
 
 	routes := map[string]bool{}
 	loginH := func(w http.ResponseWriter, _ *http.Request) {
@@ -285,7 +285,7 @@ func TestRegisterLoginRoutes(t *testing.T) {
 
 func TestRegisterOAuthRoutes(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"*"})
+	r := NewRouter(logger, []string{"*"}, false)
 
 	authorizeCall := 0
 	tokenCall := 0
@@ -325,7 +325,7 @@ func TestRegisterOAuthRoutes(t *testing.T) {
 
 func TestRegisterOIDCRoutes(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"*"})
+	r := NewRouter(logger, []string{"*"}, false)
 
 	discoveryCall := 0
 	jwksCall := 0
@@ -355,7 +355,7 @@ func TestRegisterOIDCRoutes(t *testing.T) {
 
 func TestRegisterHealthRoutesWrongMethod(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"*"})
+	r := NewRouter(logger, []string{"*"}, false)
 
 	RegisterHealthRoutes(r, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -374,7 +374,7 @@ func TestRegisterHealthRoutesWrongMethod(t *testing.T) {
 
 func TestServerShutdownWithoutStart(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, nil)
+	r := NewRouter(logger, nil, false)
 	s := New(":0", r, logger)
 
 	// Shutdown without Start should not error — the underlying http.Server.Shutdown handles it
@@ -400,7 +400,7 @@ func TestTimeoutConstants(t *testing.T) {
 
 func TestRegisterProtectedRoutes(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"*"})
+	r := NewRouter(logger, []string{"*"}, false)
 
 	RegisterProtectedRoutes(r, testPubKey, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -450,7 +450,7 @@ func (s *stubAdminEndpoints) RevokeSessions(w http.ResponseWriter, _ *http.Reque
 
 func TestRegisterAdminRoutes(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"*"})
+	r := NewRouter(logger, []string{"*"}, false)
 
 	RegisterAdminRoutes(r, testPubKey, &stubAdminEndpoints{})
 
@@ -508,7 +508,7 @@ func (s *stubOrgEndpoints) UpdateOrgSettings(w http.ResponseWriter, _ *http.Requ
 
 func TestRegisterOrgRoutes(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"*"})
+	r := NewRouter(logger, []string{"*"}, false)
 
 	RegisterOrgRoutes(r, testPubKey, &stubOrgEndpoints{})
 
@@ -538,7 +538,7 @@ func TestRegisterOrgRoutes(t *testing.T) {
 
 func TestRegisterExportImportRoutes(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"*"})
+	r := NewRouter(logger, []string{"*"}, false)
 
 	RegisterExportImportRoutes(r, testPubKey,
 		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
@@ -736,7 +736,7 @@ func (s *stubAdminConsoleEndpoints) UpdateSocialProviderAction(w http.ResponseWr
 
 func TestRegisterAdminConsoleRoutes(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	r := NewRouter(logger, []string{"*"})
+	r := NewRouter(logger, []string{"*"}, false)
 
 	hmacKey := []byte("test-hmac-key-for-csrf-testing-only")
 	staticHandler := http.FileServer(http.Dir(t.TempDir()))


### PR DESCRIPTION
## Summary
Added global HTTP security headers middleware:
- X-Content-Type-Options: nosniff
- X-Frame-Options: DENY
- X-XSS-Protection: 1; mode=block
- Referrer-Policy: strict-origin-when-cross-origin
- Content-Security-Policy: default-src 'self'
- Permissions-Policy: camera=(), microphone=(), geolocation=()
- HSTS (configurable via RAMPART_HSTS_ENABLED)

## Test plan
- [x] 4 tests covering default headers, HSTS on/off, handler chain
- [x] All tests pass