### PR TITLE
feat: add rate limiting to auth endpoints

### DIFF
--- a/cmd/rampart/main.go
+++ b/cmd/rampart/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/manimovassagh/rampart/internal/audit"
 	"github.com/manimovassagh/rampart/internal/config"
@@ -71,13 +72,26 @@ func run(_ *slog.Logger) error {
 	healthHandler := handler.NewHealthHandler(db)
 	server.RegisterHealthRoutes(router, healthHandler.Liveness, healthHandler.Readiness)
 
+	// Rate limiters for auth endpoints
+	loginRL := middleware.NewRateLimiter(cfg.RateLimit.LoginPerMinute, time.Minute)
+	defer loginRL.Close()
+	registerRL := middleware.NewRateLimiter(cfg.RateLimit.RegisterPerMinute, time.Minute)
+	defer registerRL.Close()
+	tokenRL := middleware.NewRateLimiter(cfg.RateLimit.TokenPerMinute, time.Minute)
+	defer tokenRL.Close()
+	logger.Info("rate limiting enabled",
+		"login_per_min", cfg.RateLimit.LoginPerMinute,
+		"register_per_min", cfg.RateLimit.RegisterPerMinute,
+		"token_per_min", cfg.RateLimit.TokenPerMinute,
+	)
+
 	registerHandler := handler.NewRegisterHandler(db, logger)
-	server.RegisterAuthRoutes(router, registerHandler.Register)
+	server.RegisterAuthRoutes(router, registerHandler.Register, registerRL)
 
 	sessionStore := session.NewPGStore(db.Pool)
 	auditLogger := audit.NewLogger(db, logger)
 	loginHandler := handler.NewLoginHandler(db, sessionStore, logger, auditLogger, kp.PrivateKey, kp.KID, cfg.Issuer, cfg.AccessTokenTTL, cfg.RefreshTokenTTL)
-	server.RegisterLoginRoutes(router, loginHandler.Login, loginHandler.Refresh, loginHandler.Logout)
+	server.RegisterLoginRoutes(router, loginHandler.Login, loginHandler.Refresh, loginHandler.Logout, loginRL)
 
 	meHandler := handler.NewMeHandler(db)
 	server.RegisterProtectedRoutes(router, kp.PublicKey, meHandler.Me)
@@ -116,7 +130,7 @@ func run(_ *slog.Logger) error {
 	// OAuth 2.0 Authorization Code + PKCE endpoints
 	authorizeHandler := handler.NewAuthorizeHandler(db, logger, auditLogger, socialRegistry)
 	tokenHandler := handler.NewTokenHandler(db, sessionStore, logger, kp.PrivateKey, kp.KID, cfg.Issuer, cfg.AccessTokenTTL, cfg.RefreshTokenTTL)
-	server.RegisterOAuthRoutes(router, authorizeHandler.Authorize, tokenHandler.Token)
+	server.RegisterOAuthRoutes(router, authorizeHandler.Authorize, tokenHandler.Token, tokenRL)
 
 	// OIDC Discovery + JWKS (public endpoints, no auth)
 	discoveryHandler := handler.DiscoveryHandler(cfg.Issuer, logger)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,18 @@ const (
 	defaultRefreshTokenTTL = 604800 // 7 days
 	defaultSigningKeyPath  = "rampart-signing-key.pem"
 	defaultIssuer          = "http://localhost:8080"
+
+	defaultLoginRateLimit    = 10 // requests per minute
+	defaultRegisterRateLimit = 5  // requests per minute
+	defaultTokenRateLimit    = 10 // requests per minute
 )
+
+// RateLimitConfig holds rate limiting settings for auth endpoints.
+type RateLimitConfig struct {
+	LoginPerMinute    int
+	RegisterPerMinute int
+	TokenPerMinute    int
+}
 
 // Config holds all server configuration loaded from environment variables.
 type Config struct {
@@ -52,6 +63,9 @@ type Config struct {
 
 	// Security
 	HSTSEnabled bool
+
+	// Rate limiting (requests per minute per IP)
+	RateLimit RateLimitConfig
 
 	// Social login providers
 	GoogleClientID     string
@@ -159,6 +173,46 @@ func Load() (*Config, error) {
 	// Security
 	if v := os.Getenv("RAMPART_HSTS_ENABLED"); strings.EqualFold(v, "true") || v == "1" {
 		cfg.HSTSEnabled = true
+	}
+
+	// Rate limiting
+	cfg.RateLimit = RateLimitConfig{
+		LoginPerMinute:    defaultLoginRateLimit,
+		RegisterPerMinute: defaultRegisterRateLimit,
+		TokenPerMinute:    defaultTokenRateLimit,
+	}
+
+	if v := os.Getenv("RAMPART_RATE_LIMIT_LOGIN"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid RAMPART_RATE_LIMIT_LOGIN %q: %w", v, err)
+		}
+		if n < 1 {
+			return nil, fmt.Errorf("RAMPART_RATE_LIMIT_LOGIN must be positive")
+		}
+		cfg.RateLimit.LoginPerMinute = n
+	}
+
+	if v := os.Getenv("RAMPART_RATE_LIMIT_REGISTER"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid RAMPART_RATE_LIMIT_REGISTER %q: %w", v, err)
+		}
+		if n < 1 {
+			return nil, fmt.Errorf("RAMPART_RATE_LIMIT_REGISTER must be positive")
+		}
+		cfg.RateLimit.RegisterPerMinute = n
+	}
+
+	if v := os.Getenv("RAMPART_RATE_LIMIT_TOKEN"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid RAMPART_RATE_LIMIT_TOKEN %q: %w", v, err)
+		}
+		if n < 1 {
+			return nil, fmt.Errorf("RAMPART_RATE_LIMIT_TOKEN must be positive")
+		}
+		cfg.RateLimit.TokenPerMinute = n
 	}
 
 	// Social login providers

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,0 +1,201 @@
+package middleware
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	rateLimitCleanupInterval = 5 * time.Minute
+	rateLimitEntryTTL        = 2 * time.Minute
+)
+
+// rateLimitEntry tracks request timestamps for a single IP.
+type rateLimitEntry struct {
+	timestamps []time.Time
+	lastSeen   time.Time
+}
+
+// RateLimiter provides per-IP rate limiting using a sliding window.
+type RateLimiter struct {
+	mu       sync.Mutex
+	entries  map[string]*rateLimitEntry
+	limit    int
+	window   time.Duration
+	stopOnce sync.Once
+	stop     chan struct{}
+}
+
+// NewRateLimiter creates a rate limiter that allows `limit` requests per `window` per IP.
+// It starts a background goroutine to clean up stale entries.
+func NewRateLimiter(limit int, window time.Duration) *RateLimiter {
+	rl := &RateLimiter{
+		entries: make(map[string]*rateLimitEntry),
+		limit:   limit,
+		window:  window,
+		stop:    make(chan struct{}),
+	}
+	go rl.cleanup()
+	return rl
+}
+
+// Close stops the background cleanup goroutine.
+func (rl *RateLimiter) Close() {
+	rl.stopOnce.Do(func() {
+		close(rl.stop)
+	})
+}
+
+// Allow checks whether a request from the given IP should be allowed.
+func (rl *RateLimiter) Allow(ip string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-rl.window)
+
+	entry, exists := rl.entries[ip]
+	if !exists {
+		rl.entries[ip] = &rateLimitEntry{
+			timestamps: []time.Time{now},
+			lastSeen:   now,
+		}
+		return true
+	}
+
+	// Remove timestamps outside the window
+	valid := entry.timestamps[:0]
+	for _, ts := range entry.timestamps {
+		if ts.After(cutoff) {
+			valid = append(valid, ts)
+		}
+	}
+	entry.timestamps = valid
+	entry.lastSeen = now
+
+	if len(entry.timestamps) >= rl.limit {
+		return false
+	}
+
+	entry.timestamps = append(entry.timestamps, now)
+	return true
+}
+
+// cleanup periodically removes stale entries to prevent memory leaks.
+func (rl *RateLimiter) cleanup() {
+	ticker := time.NewTicker(rateLimitCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-rl.stop:
+			return
+		case <-ticker.C:
+			rl.removeStale()
+		}
+	}
+}
+
+func (rl *RateLimiter) removeStale() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	cutoff := time.Now().Add(-rateLimitEntryTTL)
+	for ip, entry := range rl.entries {
+		if entry.lastSeen.Before(cutoff) {
+			delete(rl.entries, ip)
+		}
+	}
+}
+
+// Middleware returns an HTTP middleware that enforces the rate limit.
+func (rl *RateLimiter) Middleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := clientIP(r)
+			if !rl.Allow(ip) {
+				writeRateLimitError(w)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// clientIP extracts the client IP address from the request.
+// It checks X-Forwarded-For first (for proxied environments), then falls
+// back to X-Real-Ip, and finally RemoteAddr.
+func clientIP(r *http.Request) string {
+	// chi's RealIP middleware sets RemoteAddr from X-Forwarded-For/X-Real-Ip,
+	// but we also handle it here for defense in depth.
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// Take the first (leftmost) IP — the original client
+		if i := indexOf(xff, ','); i >= 0 {
+			xff = xff[:i]
+		}
+		if ip := trimSpace(xff); ip != "" {
+			return ip
+		}
+	}
+
+	if xri := r.Header.Get("X-Real-Ip"); xri != "" {
+		return trimSpace(xri)
+	}
+
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// indexOf returns the index of the first occurrence of sep in s, or -1.
+func indexOf(s string, sep byte) int {
+	for i := range len(s) {
+		if s[i] == sep {
+			return i
+		}
+	}
+	return -1
+}
+
+// rateLimitErrorResponse matches the apierror.Error structure to avoid import cycles.
+type rateLimitErrorResponse struct {
+	Code        string `json:"error"`
+	Description string `json:"error_description"`
+	Status      int    `json:"status"`
+	RequestID   string `json:"request_id,omitempty"`
+}
+
+func writeRateLimitError(w http.ResponseWriter) {
+	reqID := w.Header().Get(HeaderRequestID)
+	resp := &rateLimitErrorResponse{
+		Code:        "rate_limit_exceeded",
+		Description: "Rate limit exceeded. Try again later.",
+		Status:      http.StatusTooManyRequests,
+		RequestID:   reqID,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Retry-After", "60")
+	w.WriteHeader(http.StatusTooManyRequests)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		slog.Error("failed to encode rate limit error response", "error", err)
+	}
+}
+
+// trimSpace trims leading and trailing ASCII whitespace.
+func trimSpace(s string) string {
+	start := 0
+	for start < len(s) && s[start] == ' ' {
+		start++
+	}
+	end := len(s)
+	for end > start && s[end-1] == ' ' {
+		end--
+	}
+	return s[start:end]
+}

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -1,0 +1,230 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRateLimiterAllowsUnderLimit(t *testing.T) {
+	rl := NewRateLimiter(5, time.Minute)
+	defer rl.Close()
+
+	for i := range 5 {
+		if !rl.Allow("192.168.1.1") {
+			t.Errorf("request %d should be allowed", i+1)
+		}
+	}
+}
+
+func TestRateLimiterBlocksOverLimit(t *testing.T) {
+	rl := NewRateLimiter(3, time.Minute)
+	defer rl.Close()
+
+	for range 3 {
+		rl.Allow("10.0.0.1")
+	}
+
+	if rl.Allow("10.0.0.1") {
+		t.Error("4th request should be blocked")
+	}
+}
+
+func TestRateLimiterPerIPIsolation(t *testing.T) {
+	rl := NewRateLimiter(2, time.Minute)
+	defer rl.Close()
+
+	// Exhaust limit for IP A
+	rl.Allow("1.1.1.1")
+	rl.Allow("1.1.1.1")
+
+	if rl.Allow("1.1.1.1") {
+		t.Error("IP A should be blocked")
+	}
+
+	// IP B should still be allowed
+	if !rl.Allow("2.2.2.2") {
+		t.Error("IP B should not be affected by IP A")
+	}
+}
+
+func TestRateLimiterSlidingWindow(t *testing.T) {
+	rl := NewRateLimiter(2, 50*time.Millisecond)
+	defer rl.Close()
+
+	rl.Allow("10.0.0.1")
+	rl.Allow("10.0.0.1")
+
+	if rl.Allow("10.0.0.1") {
+		t.Error("should be blocked before window expires")
+	}
+
+	// Wait for window to pass
+	time.Sleep(60 * time.Millisecond)
+
+	if !rl.Allow("10.0.0.1") {
+		t.Error("should be allowed after window expires")
+	}
+}
+
+func TestRateLimiterMiddlewareReturns429(t *testing.T) {
+	rl := NewRateLimiter(1, time.Minute)
+	defer rl.Close()
+
+	handler := rl.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First request — allowed
+	req := httptest.NewRequest(http.MethodPost, "/login", http.NoBody)
+	req.RemoteAddr = "192.168.1.100:12345"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("first request status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	// Second request — blocked
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Errorf("second request status = %d, want %d", rec.Code, http.StatusTooManyRequests)
+	}
+
+	// Verify JSON error body
+	var errResp rateLimitErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&errResp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if errResp.Code != "rate_limit_exceeded" {
+		t.Errorf("error code = %q, want rate_limit_exceeded", errResp.Code)
+	}
+	if errResp.Status != http.StatusTooManyRequests {
+		t.Errorf("error status = %d, want %d", errResp.Status, http.StatusTooManyRequests)
+	}
+
+	// Verify Retry-After header
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("missing Retry-After header on 429 response")
+	}
+}
+
+func TestRateLimiterMiddlewareXForwardedFor(t *testing.T) {
+	rl := NewRateLimiter(1, time.Minute)
+	defer rl.Close()
+
+	handler := rl.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Two requests from different X-Forwarded-For IPs
+	req1 := httptest.NewRequest(http.MethodPost, "/login", http.NoBody)
+	req1.Header.Set("X-Forwarded-For", "203.0.113.1, 10.0.0.1")
+	req1.RemoteAddr = "10.0.0.1:9999"
+
+	req2 := httptest.NewRequest(http.MethodPost, "/login", http.NoBody)
+	req2.Header.Set("X-Forwarded-For", "203.0.113.2, 10.0.0.1")
+	req2.RemoteAddr = "10.0.0.1:9999"
+
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Errorf("req1 status = %d, want 200", rec1.Code)
+	}
+
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Errorf("req2 from different IP should be allowed, got %d", rec2.Code)
+	}
+}
+
+func TestRateLimiterStaleCleanup(t *testing.T) {
+	rl := NewRateLimiter(1, time.Minute)
+	defer rl.Close()
+
+	rl.Allow("stale-ip")
+
+	// Manually age the entry
+	rl.mu.Lock()
+	rl.entries["stale-ip"].lastSeen = time.Now().Add(-rateLimitEntryTTL - time.Second)
+	rl.mu.Unlock()
+
+	rl.removeStale()
+
+	rl.mu.Lock()
+	_, exists := rl.entries["stale-ip"]
+	rl.mu.Unlock()
+
+	if exists {
+		t.Error("stale entry should have been cleaned up")
+	}
+}
+
+func TestClientIPExtraction(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		xri        string
+		wantIP     string
+	}{
+		{
+			name:       "RemoteAddrOnly",
+			remoteAddr: "192.168.1.1:12345",
+			wantIP:     "192.168.1.1",
+		},
+		{
+			name:       "XForwardedForSingle",
+			remoteAddr: "10.0.0.1:9999",
+			xff:        "203.0.113.50",
+			wantIP:     "203.0.113.50",
+		},
+		{
+			name:       "XForwardedForMultiple",
+			remoteAddr: "10.0.0.1:9999",
+			xff:        "203.0.113.50, 70.41.3.18, 150.172.238.178",
+			wantIP:     "203.0.113.50",
+		},
+		{
+			name:       "XRealIP",
+			remoteAddr: "10.0.0.1:9999",
+			xri:        "198.51.100.1",
+			wantIP:     "198.51.100.1",
+		},
+		{
+			name:       "XForwardedForTakesPrecedence",
+			remoteAddr: "10.0.0.1:9999",
+			xff:        "203.0.113.50",
+			xri:        "198.51.100.1",
+			wantIP:     "203.0.113.50",
+		},
+		{
+			name:       "RemoteAddrNoPort",
+			remoteAddr: "192.168.1.1",
+			wantIP:     "192.168.1.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.xff != "" {
+				req.Header.Set("X-Forwarded-For", tt.xff)
+			}
+			if tt.xri != "" {
+				req.Header.Set("X-Real-Ip", tt.xri)
+			}
+
+			got := clientIP(req)
+			if got != tt.wantIP {
+				t.Errorf("clientIP() = %q, want %q", got, tt.wantIP)
+			}
+		})
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -50,13 +50,23 @@ func RegisterHealthRoutes(r *chi.Mux, healthHandler, readyHandler http.HandlerFu
 }
 
 // RegisterAuthRoutes mounts authentication-related endpoints.
-func RegisterAuthRoutes(r *chi.Mux, registerHandler http.HandlerFunc) {
-	r.Post("/register", registerHandler)
+// If rl is non-nil, it is applied as rate limiting middleware.
+func RegisterAuthRoutes(r *chi.Mux, registerHandler http.HandlerFunc, rl *middleware.RateLimiter) {
+	if rl != nil {
+		r.With(rl.Middleware()).Post("/register", registerHandler)
+	} else {
+		r.Post("/register", registerHandler)
+	}
 }
 
 // RegisterLoginRoutes mounts login, token refresh, and logout endpoints.
-func RegisterLoginRoutes(r *chi.Mux, loginHandler, refreshHandler, logoutHandler http.HandlerFunc) {
-	r.Post("/login", loginHandler)
+// If rl is non-nil, it is applied as rate limiting middleware to /login.
+func RegisterLoginRoutes(r *chi.Mux, loginHandler, refreshHandler, logoutHandler http.HandlerFunc, rl *middleware.RateLimiter) {
+	if rl != nil {
+		r.With(rl.Middleware()).Post("/login", loginHandler)
+	} else {
+		r.Post("/login", loginHandler)
+	}
 	r.Post("/token/refresh", refreshHandler)
 	r.Post("/logout", logoutHandler)
 }
@@ -139,10 +149,15 @@ func RegisterExportImportRoutes(r *chi.Mux, pubKey *rsa.PublicKey, exportHandler
 }
 
 // RegisterOAuthRoutes mounts the OAuth 2.0 authorization and token endpoints.
-func RegisterOAuthRoutes(r *chi.Mux, authorize, token http.HandlerFunc) {
+// If rl is non-nil, it is applied as rate limiting middleware to /oauth/token.
+func RegisterOAuthRoutes(r *chi.Mux, authorize, token http.HandlerFunc, rl *middleware.RateLimiter) {
 	r.Get("/oauth/authorize", authorize)
 	r.Post("/oauth/authorize", authorize)
-	r.Post("/oauth/token", token)
+	if rl != nil {
+		r.With(rl.Middleware()).Post("/oauth/token", token)
+	} else {
+		r.Post("/oauth/token", token)
+	}
 }
 
 // RegisterSocialRoutes mounts social login initiation and callback endpoints.

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -91,7 +91,7 @@ func setupTestServer(db *mockDB) *httptest.Server {
 	RegisterHealthRoutes(router, healthH.Liveness, healthH.Readiness)
 
 	registerH := handler.NewRegisterHandler(db, logger)
-	RegisterAuthRoutes(router, registerH.Register)
+	RegisterAuthRoutes(router, registerH.Register, nil)
 
 	return httptest.NewServer(router)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -228,7 +228,7 @@ func TestRegisterAuthRoutes(t *testing.T) {
 	RegisterAuthRoutes(r, func(w http.ResponseWriter, _ *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusCreated)
-	})
+	}, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/register", http.NoBody)
 	w := httptest.NewRecorder()
@@ -260,7 +260,7 @@ func TestRegisterLoginRoutes(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}
 
-	RegisterLoginRoutes(r, loginH, refreshH, logoutH)
+	RegisterLoginRoutes(r, loginH, refreshH, logoutH, nil)
 
 	tests := []struct {
 		method string
@@ -296,7 +296,7 @@ func TestRegisterOAuthRoutes(t *testing.T) {
 	}, func(w http.ResponseWriter, _ *http.Request) {
 		tokenCall++
 		w.WriteHeader(http.StatusOK)
-	})
+	}, nil)
 
 	// GET /oauth/authorize
 	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize", http.NoBody)


### PR DESCRIPTION
## Summary
**Critical security fix** — No rate limiting existed on authentication endpoints, making brute-force attacks trivially possible.

- Per-IP sliding window rate limiter (in-memory, background cleanup)
- `/login` and `/oauth/token`: 10 req/min per IP (configurable)
- `/register`: 5 req/min per IP (configurable)
- Returns HTTP 429 with `Retry-After` header when exceeded
- Supports `X-Forwarded-For` and `X-Real-Ip` for proxied environments
- Config via env vars: `RAMPART_RATE_LIMIT_{LOGIN,REGISTER,TOKEN}`
- 8 tests covering allow/block, per-IP isolation, sliding window, cleanup

## Test plan
- [x] Rate limiter blocks after threshold
- [x] Different IPs tracked independently
- [x] Sliding window expires correctly
- [x] 429 response format matches API error schema
- [x] All tests pass