### PR TITLE
feat: configurable secure cookies and CSRF on login form

### DIFF
--- a/cmd/rampart/main.go
+++ b/cmd/rampart/main.go
@@ -36,6 +36,9 @@ func run(_ *slog.Logger) error {
 		return err
 	}
 
+	// Configure cookie security based on environment
+	middleware.SetSecureCookies(cfg.SecureCookies)
+
 	// Reconfigure logger with the loaded log level and format
 	logOpts := &slog.HandlerOptions{Level: parseLogLevel(string(cfg.LogLevel))}
 	var logHandler slog.Handler

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,10 @@ type Config struct {
 	// Security
 	HSTSEnabled bool
 
+	// SecureCookies enables the Secure flag on all cookies.
+	// MUST be true in production (requires HTTPS). Defaults to false for development.
+	SecureCookies bool
+
 	// Rate limiting (requests per minute per IP)
 	RateLimit RateLimitConfig
 
@@ -213,6 +217,17 @@ func Load() (*Config, error) {
 			return nil, fmt.Errorf("RAMPART_RATE_LIMIT_TOKEN must be positive")
 		}
 		cfg.RateLimit.TokenPerMinute = n
+	}
+
+	if v := os.Getenv("RAMPART_SECURE_COOKIES"); v != "" {
+		switch strings.ToLower(v) {
+		case "true", "1", "yes":
+			cfg.SecureCookies = true
+		case "false", "0", "no":
+			cfg.SecureCookies = false
+		default:
+			return nil, fmt.Errorf("invalid RAMPART_SECURE_COOKIES %q (valid: true, false)", v)
+		}
 	}
 
 	// Social login providers

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -240,6 +240,80 @@ func TestLoadSocialProviderConfigEmpty(t *testing.T) {
 	}
 }
 
+func TestLoadSecureCookiesTrue(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("RAMPART_SECURE_COOKIES", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.SecureCookies {
+		t.Error("SecureCookies = false, want true")
+	}
+}
+
+func TestLoadSecureCookiesFalse(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("RAMPART_SECURE_COOKIES", "false")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SecureCookies {
+		t.Error("SecureCookies = true, want false")
+	}
+}
+
+func TestLoadSecureCookiesDefaultFalse(t *testing.T) {
+	setRequiredEnv(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SecureCookies {
+		t.Error("SecureCookies should default to false")
+	}
+}
+
+func TestLoadSecureCookiesInvalid(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("RAMPART_SECURE_COOKIES", "maybe")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid RAMPART_SECURE_COOKIES value")
+	}
+}
+
+func TestLoadSecureCookiesAlternateValues(t *testing.T) {
+	setRequiredEnv(t)
+
+	for _, val := range []string{"1", "yes", "YES"} {
+		t.Setenv("RAMPART_SECURE_COOKIES", val)
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", val, err)
+		}
+		if !cfg.SecureCookies {
+			t.Errorf("SecureCookies = false for %q, want true", val)
+		}
+	}
+
+	for _, val := range []string{"0", "no", "NO"} {
+		t.Setenv("RAMPART_SECURE_COOKIES", val)
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", val, err)
+		}
+		if cfg.SecureCookies {
+			t.Errorf("SecureCookies = true for %q, want false", val)
+		}
+	}
+}
+
 func TestConfigAddr(t *testing.T) {
 	cfg := &Config{Port: 3000}
 	if got := cfg.Addr(); got != ":3000" {

--- a/internal/handler/admin_login.go
+++ b/internal/handler/admin_login.go
@@ -107,6 +107,7 @@ func (h *AdminLoginHandler) Login(w http.ResponseWriter, r *http.Request) {
 		MaxAge:   600, // 10 minutes
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
+		Secure:   middleware.SecureCookiesEnabled(),
 	})
 
 	redirectURI := h.issuer + "/admin/callback"
@@ -144,6 +145,8 @@ func (h *AdminLoginHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		Path:     middleware.AdminCookiePath,
 		MaxAge:   -1,
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   middleware.SecureCookiesEnabled(),
 	})
 
 	// Parse state.verifier

--- a/internal/handler/authorize.go
+++ b/internal/handler/authorize.go
@@ -15,6 +15,7 @@ import (
 	"github.com/manimovassagh/rampart/internal/audit"
 	"github.com/manimovassagh/rampart/internal/auth"
 	"github.com/manimovassagh/rampart/internal/database"
+	"github.com/manimovassagh/rampart/internal/middleware"
 	"github.com/manimovassagh/rampart/internal/model"
 	"github.com/manimovassagh/rampart/internal/oauth"
 	"github.com/manimovassagh/rampart/internal/social"
@@ -99,6 +100,7 @@ type loginPageData struct {
 	SocialProviders        []string
 	ForgotPasswordEnabled  bool
 	RegistrationEnabled    bool
+	CSRFToken              string
 }
 
 // Authorize handles both GET (render login) and POST (authenticate + redirect).
@@ -164,6 +166,13 @@ func (h *AuthorizeHandler) handleGet(w http.ResponseWriter, r *http.Request) {
 		scope = scopeOpenID
 	}
 
+	csrfToken, err := middleware.GenerateCSRFToken()
+	if err != nil {
+		h.logger.Error("failed to generate CSRF token", "error", err)
+		h.renderError(w, http.StatusInternalServerError, msgUnexpectedErr)
+		return
+	}
+
 	data := &loginPageData{
 		ClientID:      clientID,
 		ClientName:    client.Name,
@@ -171,11 +180,13 @@ func (h *AuthorizeHandler) handleGet(w http.ResponseWriter, r *http.Request) {
 		Scope:         scope,
 		State:         state,
 		CodeChallenge: codeChallenge,
+		CSRFToken:     csrfToken,
 	}
 	if h.socialRegistry != nil {
 		data.SocialProviders = h.socialRegistry.Names()
 	}
 	h.applyOrgSettings(r.Context(), client.OrgID, data)
+	middleware.SetOAuthCSRFCookie(w, csrfToken)
 	h.renderLoginPage(w, data)
 }
 
@@ -190,6 +201,13 @@ func (h *AuthorizeHandler) handlePost(w http.ResponseWriter, r *http.Request) {
 
 	if err := r.ParseForm(); err != nil {
 		apierror.BadRequest(w, "Invalid form data.")
+		return
+	}
+
+	// Validate CSRF token before processing credentials
+	csrfFormToken := r.FormValue("csrf_token")
+	if !middleware.ValidateOAuthCSRF(r, csrfFormToken) {
+		h.renderError(w, http.StatusForbidden, "CSRF validation failed. Please reload the login page and try again.")
 		return
 	}
 
@@ -237,6 +255,12 @@ func (h *AuthorizeHandler) handlePost(w http.ResponseWriter, r *http.Request) {
 		pageData.SocialProviders = h.socialRegistry.Names()
 	}
 	h.applyOrgSettings(ctx, client.OrgID, &pageData)
+
+	// Generate a fresh CSRF token for any re-render of the login page
+	if newCSRF, csrfErr := middleware.GenerateCSRFToken(); csrfErr == nil {
+		pageData.CSRFToken = newCSRF
+		middleware.SetOAuthCSRFCookie(w, newCSRF)
+	}
 
 	if identifier == "" || password == "" {
 		pageData.Error = "Username/email and password are required."

--- a/internal/handler/authorize_test.go
+++ b/internal/handler/authorize_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/manimovassagh/rampart/internal/auth"
+	"github.com/manimovassagh/rampart/internal/middleware"
 	"github.com/manimovassagh/rampart/internal/model"
 )
 
@@ -172,6 +173,20 @@ func TestAuthorizeGetRendersLoginPage(t *testing.T) {
 	}
 }
 
+// newPostRequestWithCSRF creates a POST request with a matching CSRF cookie and form token.
+func newPostRequestWithCSRF(t *testing.T, target string, form url.Values) *http.Request {
+	t.Helper()
+	csrfToken, err := middleware.GenerateCSRFToken()
+	if err != nil {
+		t.Fatalf("failed to generate CSRF token: %v", err)
+	}
+	form.Set("csrf_token", csrfToken)
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: middleware.OAuthCSRFCookieName, Value: csrfToken})
+	return req
+}
+
 func TestAuthorizePostBadCredentials(t *testing.T) {
 	orgID := uuid.New()
 	store := &mockAuthorizeStore{
@@ -193,8 +208,7 @@ func TestAuthorizePostBadCredentials(t *testing.T) {
 		"password":              {"badpass"},
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize", strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req := newPostRequestWithCSRF(t, "/oauth/authorize", form)
 	w := httptest.NewRecorder()
 
 	h.Authorize(w, req)
@@ -237,8 +251,7 @@ func TestAuthorizePostValidCredentialsRedirects(t *testing.T) {
 		"password":              {"Str0ng!Pass"},
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize", strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req := newPostRequestWithCSRF(t, "/oauth/authorize", form)
 	w := httptest.NewRecorder()
 
 	h.Authorize(w, req)
@@ -257,6 +270,163 @@ func TestAuthorizePostValidCredentialsRedirects(t *testing.T) {
 
 	if !store.storedCode {
 		t.Error("expected authorization code to be stored")
+	}
+}
+
+func TestAuthorizeGetRendersCSRFToken(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockAuthorizeStore{
+		oauthClient: newTestOAuthClient(orgID),
+	}
+	h := NewAuthorizeHandler(store, noopLogger(), nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?client_id=test-client&redirect_uri=http://localhost:3002/callback&response_type=code&state=abc123&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256", http.NoBody)
+	w := httptest.NewRecorder()
+
+	h.Authorize(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "csrf_token") {
+		t.Error("expected csrf_token hidden field in login page")
+	}
+
+	// Verify the CSRF cookie is set
+	cookies := w.Result().Cookies()
+	var csrfCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == middleware.OAuthCSRFCookieName {
+			csrfCookie = c
+			break
+		}
+	}
+	if csrfCookie == nil {
+		t.Fatal("expected OAuth CSRF cookie to be set")
+	}
+	if !csrfCookie.HttpOnly {
+		t.Error("expected CSRF cookie to be HttpOnly")
+	}
+	if csrfCookie.Value == "" {
+		t.Error("expected non-empty CSRF cookie value")
+	}
+}
+
+func TestAuthorizePostMissingCSRFToken(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockAuthorizeStore{
+		oauthClient: newTestOAuthClient(orgID),
+	}
+	h := NewAuthorizeHandler(store, noopLogger(), nil, nil)
+
+	form := url.Values{
+		"client_id":             {"test-client"},
+		"redirect_uri":          {"http://localhost:3002/callback"},
+		"scope":                 {"openid"},
+		"state":                 {"abc"},
+		"code_challenge":        {"xyz"},
+		"code_challenge_method": {"S256"},
+		"identifier":            {"admin"},
+		"password":              {"secret"},
+	}
+
+	// POST without CSRF cookie or token
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.Authorize(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if !strings.Contains(w.Body.String(), "CSRF") {
+		t.Error("expected CSRF error message")
+	}
+}
+
+func TestAuthorizePostMismatchedCSRFToken(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockAuthorizeStore{
+		oauthClient: newTestOAuthClient(orgID),
+	}
+	h := NewAuthorizeHandler(store, noopLogger(), nil, nil)
+
+	form := url.Values{
+		"client_id":             {"test-client"},
+		"redirect_uri":          {"http://localhost:3002/callback"},
+		"scope":                 {"openid"},
+		"state":                 {"abc"},
+		"code_challenge":        {"xyz"},
+		"code_challenge_method": {"S256"},
+		"identifier":            {"admin"},
+		"password":              {"secret"},
+		"csrf_token":            {"wrong-token"},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: middleware.OAuthCSRFCookieName, Value: "correct-token"})
+	w := httptest.NewRecorder()
+
+	h.Authorize(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestAuthorizePostReRenderIncludesCSRFToken(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockAuthorizeStore{
+		oauthClient:  newTestOAuthClient(orgID),
+		emailUser:    nil,
+		usernameUser: nil,
+	}
+	h := NewAuthorizeHandler(store, noopLogger(), nil, nil)
+
+	form := url.Values{
+		"client_id":             {"test-client"},
+		"redirect_uri":          {"http://localhost:3002/callback"},
+		"scope":                 {"openid"},
+		"state":                 {"abc"},
+		"code_challenge":        {"xyz"},
+		"code_challenge_method": {"S256"},
+		"identifier":            {"baduser"},
+		"password":              {"badpass"},
+	}
+
+	req := newPostRequestWithCSRF(t, "/oauth/authorize", form)
+	w := httptest.NewRecorder()
+
+	h.Authorize(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	// The re-rendered page should contain a fresh CSRF token
+	body := w.Body.String()
+	if !strings.Contains(body, "csrf_token") {
+		t.Error("expected csrf_token in re-rendered login page")
+	}
+
+	// Check that a new CSRF cookie was set
+	cookies := w.Result().Cookies()
+	var csrfCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == middleware.OAuthCSRFCookieName {
+			csrfCookie = c
+			break
+		}
+	}
+	if csrfCookie == nil {
+		t.Fatal("expected new OAuth CSRF cookie on re-render")
+	}
+	if csrfCookie.Value == "" {
+		t.Error("expected non-empty CSRF cookie value on re-render")
 	}
 }
 

--- a/internal/handler/templates/login/corporate.html
+++ b/internal/handler/templates/login/corporate.html
@@ -179,6 +179,7 @@
                 <input type="hidden" name="state" value="{{.State}}">
                 <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}">
                 <input type="hidden" name="code_challenge_method" value="S256">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
 
                 <div class="field">
                     <label for="identifier">Username or Email</label>

--- a/internal/handler/templates/login/dark.html
+++ b/internal/handler/templates/login/dark.html
@@ -180,6 +180,7 @@
             <input type="hidden" name="state" value="{{.State}}">
             <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}">
             <input type="hidden" name="code_challenge_method" value="S256">
+            <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
 
             <div class="field">
                 <label for="identifier">Username or Email</label>

--- a/internal/handler/templates/login/default.html
+++ b/internal/handler/templates/login/default.html
@@ -156,6 +156,7 @@
             <input type="hidden" name="state" value="{{.State}}">
             <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}">
             <input type="hidden" name="code_challenge_method" value="S256">
+            <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
 
             <div class="field">
                 <label for="identifier">Username or Email</label>

--- a/internal/handler/templates/login/gradient.html
+++ b/internal/handler/templates/login/gradient.html
@@ -193,6 +193,7 @@
             <input type="hidden" name="state" value="{{.State}}">
             <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}">
             <input type="hidden" name="code_challenge_method" value="S256">
+            <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
 
             <div class="field">
                 <label for="identifier">Username or Email</label>

--- a/internal/handler/templates/login/minimal.html
+++ b/internal/handler/templates/login/minimal.html
@@ -141,6 +141,7 @@
             <input type="hidden" name="state" value="{{.State}}">
             <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}">
             <input type="hidden" name="code_challenge_method" value="S256">
+            <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
 
             <div class="field">
                 <label for="identifier">Username or Email</label>

--- a/internal/middleware/admin_session.go
+++ b/internal/middleware/admin_session.go
@@ -28,6 +28,21 @@ const (
 	AdminCookiePath = "/admin/"
 )
 
+// secureCookies controls whether cookies are sent with the Secure flag.
+// Must be true in production (requires HTTPS). Defaults to false for development.
+var secureCookies bool
+
+// SetSecureCookies configures whether all cookies should have the Secure flag set.
+// Call this at startup before serving requests.
+func SetSecureCookies(secure bool) {
+	secureCookies = secure
+}
+
+// SecureCookiesEnabled returns whether cookies should have the Secure flag set.
+func SecureCookiesEnabled() bool {
+	return secureCookies
+}
+
 // AdminSession returns middleware that validates admin session cookies.
 // Unauthenticated requests are redirected to the admin login page.
 func AdminSession(pubKey *rsa.PublicKey, hmacKey []byte) func(http.Handler) http.Handler {
@@ -146,7 +161,7 @@ func SetAdminSession(w http.ResponseWriter, accessToken string, hmacKey []byte, 
 		MaxAge:   maxAge,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
-		Secure:   false, // Set true in production via config
+		Secure:   secureCookies,
 	})
 }
 
@@ -158,6 +173,8 @@ func ClearAdminSession(w http.ResponseWriter) {
 		Path:     AdminCookiePath,
 		MaxAge:   -1,
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   secureCookies,
 	})
 }
 
@@ -170,6 +187,7 @@ func SetFlash(w http.ResponseWriter, message string) {
 		MaxAge:   10,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
+		Secure:   secureCookies,
 	})
 }
 
@@ -187,6 +205,8 @@ func GetFlash(w http.ResponseWriter, r *http.Request) string {
 		Path:     AdminCookiePath,
 		MaxAge:   -1,
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   secureCookies,
 	})
 
 	decoded, err := base64.URLEncoding.DecodeString(cookie.Value)
@@ -203,6 +223,41 @@ func GetCSRFToken(r *http.Request) string {
 		return ""
 	}
 	return cookie.Value
+}
+
+// OAuthCSRFCookieName is the cookie name for CSRF on the OAuth login form.
+const OAuthCSRFCookieName = "rampart_oauth_csrf"
+
+// GenerateCSRFToken creates a new random CSRF token string.
+func GenerateCSRFToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating CSRF token: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// SetOAuthCSRFCookie sets a CSRF cookie scoped to /oauth/ for the login form.
+func SetOAuthCSRFCookie(w http.ResponseWriter, token string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     OAuthCSRFCookieName,
+		Value:    token,
+		Path:     "/oauth/",
+		MaxAge:   600, // 10 minutes
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   secureCookies,
+	})
+}
+
+// ValidateOAuthCSRF checks the CSRF token from the form against the cookie.
+// Returns true if the tokens match.
+func ValidateOAuthCSRF(r *http.Request, formToken string) bool {
+	cookie, err := r.Cookie(OAuthCSRFCookieName)
+	if err != nil || cookie.Value == "" || formToken == "" {
+		return false
+	}
+	return hmac.Equal([]byte(cookie.Value), []byte(formToken))
 }
 
 // GenerateHMACKey creates a random 32-byte HMAC key.
@@ -230,6 +285,7 @@ func ensureCSRFCookie(w http.ResponseWriter, r *http.Request) {
 		MaxAge:   3600,
 		HttpOnly: false, // Must be readable by forms via template
 		SameSite: http.SameSiteLaxMode,
+		Secure:   secureCookies,
 	})
 }
 

--- a/internal/middleware/admin_session_test.go
+++ b/internal/middleware/admin_session_test.go
@@ -655,6 +655,135 @@ func TestCSRFProtectBlocksDELETE(t *testing.T) {
 	}
 }
 
+func TestGenerateCSRFToken(t *testing.T) {
+	tok, err := GenerateCSRFToken()
+	if err != nil {
+		t.Fatalf("GenerateCSRFToken error: %v", err)
+	}
+	if len(tok) != 64 { // 32 bytes hex-encoded = 64 chars
+		t.Errorf("token length = %d, want 64", len(tok))
+	}
+
+	// Two tokens should differ
+	tok2, err := GenerateCSRFToken()
+	if err != nil {
+		t.Fatalf("GenerateCSRFToken error: %v", err)
+	}
+	if tok == tok2 {
+		t.Error("two generated CSRF tokens should differ")
+	}
+}
+
+func TestSetOAuthCSRFCookie(t *testing.T) {
+	w := httptest.NewRecorder()
+	SetOAuthCSRFCookie(w, "test-csrf-value")
+
+	cookies := w.Result().Cookies()
+	var found *http.Cookie
+	for _, c := range cookies {
+		if c.Name == OAuthCSRFCookieName {
+			found = c
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected OAuth CSRF cookie to be set")
+	}
+	if found.Value != "test-csrf-value" {
+		t.Errorf("cookie value = %q, want test-csrf-value", found.Value)
+	}
+	if !found.HttpOnly {
+		t.Error("expected HttpOnly flag on OAuth CSRF cookie")
+	}
+	if found.Path != "/oauth/" {
+		t.Errorf("cookie path = %q, want /oauth/", found.Path)
+	}
+	if found.SameSite != http.SameSiteStrictMode {
+		t.Errorf("cookie SameSite = %v, want Strict", found.SameSite)
+	}
+}
+
+func TestValidateOAuthCSRFValid(t *testing.T) {
+	tok := "matching-csrf-token"
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: OAuthCSRFCookieName, Value: tok})
+
+	if !ValidateOAuthCSRF(req, tok) {
+		t.Error("expected validation to pass for matching tokens")
+	}
+}
+
+func TestValidateOAuthCSRFMismatch(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: OAuthCSRFCookieName, Value: "cookie-value"})
+
+	if ValidateOAuthCSRF(req, "form-value") {
+		t.Error("expected validation to fail for mismatched tokens")
+	}
+}
+
+func TestValidateOAuthCSRFNoCookie(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize", http.NoBody)
+
+	if ValidateOAuthCSRF(req, "some-token") {
+		t.Error("expected validation to fail when cookie is missing")
+	}
+}
+
+func TestValidateOAuthCSRFEmptyFormToken(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: OAuthCSRFCookieName, Value: "some-value"})
+
+	if ValidateOAuthCSRF(req, "") {
+		t.Error("expected validation to fail for empty form token")
+	}
+}
+
+func TestValidateOAuthCSRFEmptyCookieValue(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: OAuthCSRFCookieName, Value: ""})
+
+	if ValidateOAuthCSRF(req, "some-token") {
+		t.Error("expected validation to fail for empty cookie value")
+	}
+}
+
+func TestSetSecureCookiesToggle(t *testing.T) {
+	// Save original value and restore after test
+	original := SecureCookiesEnabled()
+	defer SetSecureCookies(original)
+
+	SetSecureCookies(true)
+	if !SecureCookiesEnabled() {
+		t.Error("expected SecureCookiesEnabled() = true after SetSecureCookies(true)")
+	}
+
+	SetSecureCookies(false)
+	if SecureCookiesEnabled() {
+		t.Error("expected SecureCookiesEnabled() = false after SetSecureCookies(false)")
+	}
+}
+
+func TestSetAdminSessionSecureFlagFollowsConfig(t *testing.T) {
+	original := SecureCookiesEnabled()
+	defer SetSecureCookies(original)
+
+	SetSecureCookies(true)
+	w := httptest.NewRecorder()
+	SetAdminSession(w, "test-token", testHMACKey, 3600)
+
+	cookies := w.Result().Cookies()
+	for _, c := range cookies {
+		if c.Name == sessionCookieName {
+			if !c.Secure {
+				t.Error("expected Secure flag when SecureCookies is true")
+			}
+			return
+		}
+	}
+	t.Fatal("session cookie not found")
+}
+
 func TestCSRFProtectBlocksPUT(t *testing.T) {
 	handler := CSRFProtect()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not be called")


### PR DESCRIPTION
## Summary
**Security fixes:**

**Secure cookies** — All cookies (admin session, flash, CSRF, OAuth state) now use configurable `Secure` flag via `RAMPART_SECURE_COOKIES` env var. Defaults to `false` for dev, MUST be `true` in production.

**CSRF on OAuth login form** — Added double-submit cookie pattern for the OAuth authorize/login form:
- GET renders CSRF token in hidden field + sets HttpOnly cookie
- POST validates token match before processing credentials
- Fresh token on every re-render (failed login)
- All 5 login themes updated with hidden CSRF field

**Tests:** 17 new tests covering config parsing, CSRF generation/validation, secure cookie toggle, and authorize handler CSRF enforcement.

## Test plan
- [x] Config: SecureCookies parsed from env (true/false/1/0/yes/no)
- [x] CSRF: valid token passes, mismatch returns 403, missing cookie returns 403
- [x] Secure flag propagates to all cookies
- [x] All tests pass