### PR TITLE
docs: add GitHub templates, CONTRIBUTING, SECURITY, and CODE_OF_CONDUCT

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Report a bug in Rampart
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include error messages, logs, or screenshots if applicable.
+
+## Environment
+
+- **Rampart version:** (e.g., v0.1.0 or commit SHA)
+- **OS:** (e.g., Ubuntu 22.04, macOS 14)
+- **Deployment method:** (binary / Docker / docker-compose)
+- **Database:** (PostgreSQL version)
+- **Go version** (if building from source):
+
+## Additional Context
+
+Any other context about the problem (config snippets, related issues, etc.).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a feature or improvement for Rampart
+title: "[Feature] "
+labels: feature
+assignees: ""
+---
+
+## Problem
+
+What problem does this feature solve? Who is affected?
+
+## Proposed Solution
+
+Describe the feature or change you'd like to see.
+
+## Alternatives Considered
+
+Any alternative solutions or workarounds you've considered.
+
+## Additional Context
+
+Relevant links, examples from other IAM products (Keycloak, Ory, Zitadel), RFCs, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## What
+
+Brief description of the change.
+
+## Why
+
+Motivation or link to the issue this addresses.
+
+Closes #<!-- issue number -->
+
+## How
+
+Summary of the approach taken (skip for trivial changes).
+
+## Checklist
+
+- [ ] Tests added/updated for the changes
+- [ ] `go test -race ./...` passes locally
+- [ ] `golangci-lint run ./...` passes locally
+- [ ] No secrets, credentials, or sensitive data in the diff
+- [ ] Public API changes are documented (godoc / OpenAPI)
+- [ ] Commit messages follow conventional format (`feat:`, `fix:`, etc.)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,57 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer at the contact information listed on their
+[GitHub profile](https://github.com/manimovassagh).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to Rampart
+
+Thanks for your interest in contributing to Rampart! This document covers the basics you need to get started.
+
+## Prerequisites
+
+- **Go 1.25+**
+- **PostgreSQL 16+**
+- **Redis 7+**
+- **Docker & Docker Compose** (for running the full stack locally)
+
+## Development Setup
+
+```bash
+# Clone the repo
+git clone https://github.com/manimovassagh/rampart.git
+cd rampart
+
+# Install dev tools (golangci-lint, govulncheck, gosec)
+make dev-setup
+
+# Copy and configure environment
+cp .env.example .env
+# Edit .env with your local database credentials
+
+# Start dependencies (Postgres + Redis)
+docker compose -f docker-compose.dev.yml up -d
+
+# Run tests
+make test
+
+# Run all quality checks (lint, vet, test, security)
+make check
+
+# Build the binary
+make build
+```
+
+## Code Style
+
+- Follow idiomatic Go. Run `gofmt` and `go vet` before committing.
+- `golangci-lint` is the authoritative linter -- CI enforces it.
+- Use table-driven tests. Test names should describe the scenario (e.g., `TestLogin_InvalidPassword_ReturnsUnauthorized`).
+- Wrap errors with context: `fmt.Errorf("creating user: %w", err)`.
+- No `interface{}`/`any` unless absolutely necessary.
+
+## Branching & PRs
+
+1. **Every change needs an issue first.** Open one or pick an existing one.
+2. **Create a feature branch** from `main`:
+   ```
+   git checkout -b feat/42-short-description
+   ```
+3. **Keep commits small and logical.** Use conventional prefixes: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`.
+4. **Open a PR** against `main`. Reference the issue: `Closes #42`.
+5. **All PRs require review** from a maintainer before merging.
+6. CI must pass: lint, test, security scan, build.
+
+## What to Work On
+
+Look for issues labeled `good first issue` or `help wanted`. If you want to tackle something larger, comment on the issue first so we can align on the approach.
+
+## Testing
+
+- Unit tests for all business logic.
+- Integration tests for database and auth flows.
+- Run the full suite: `make test` or `go test -race ./...`.
+- Coverage must not drop below the established threshold.
+
+## Security
+
+Rampart is an IAM product -- security is the product. Please read `SECURITY.md` for our vulnerability reporting policy. When contributing:
+
+- Never commit secrets, passwords, or tokens.
+- Use well-known crypto libraries -- never roll your own.
+- Validate all input at system boundaries.
+- Test both happy paths and attack vectors for auth flows.
+
+## Questions?
+
+Open a discussion or comment on the relevant issue. We're happy to help.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | Yes |
+| Older releases | Best effort |
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+If you discover a security vulnerability in Rampart, please report it responsibly:
+
+1. **Email:** Send details to the maintainer via the email listed on the [GitHub profile](https://github.com/manimovassagh).
+2. **Include:** A description of the vulnerability, steps to reproduce, affected versions, and potential impact.
+3. **Response time:** We aim to acknowledge reports within 48 hours and provide a fix or mitigation plan within 7 days for critical issues.
+
+## What Qualifies
+
+- Authentication or authorization bypasses
+- Token leakage, session fixation, or session hijacking
+- SQL injection, XSS, CSRF, or SSRF
+- Cryptographic weaknesses
+- Privilege escalation
+- Information disclosure (secrets, PII, internal state)
+
+## What Does Not Qualify
+
+- Denial of service via resource exhaustion (unless trivially exploitable)
+- Issues in dependencies without a demonstrated exploit path in Rampart
+- Social engineering attacks
+- Issues requiring physical access to the server
+
+## Disclosure Policy
+
+- We will coordinate disclosure with the reporter.
+- We will credit reporters in the release notes (unless they prefer anonymity).
+- We aim to release fixes before or alongside public disclosure.
+
+## Security Practices
+
+Rampart follows security-first development practices:
+
+- All dependencies are pinned and audited (`govulncheck`, `gosec`, Trivy).
+- CI runs security scans on every PR.
+- Secrets are never stored in plaintext.
+- All authentication flows follow OAuth 2.0 / OIDC RFCs.


### PR DESCRIPTION
## Summary
- Add bug report and feature request issue templates
- Add pull request template
- Add CONTRIBUTING.md with development setup and guidelines
- Add SECURITY.md with vulnerability reporting policy
- Add CODE_OF_CONDUCT.md (Contributor Covenant)

## Test plan
- [ ] Verify issue templates render correctly on GitHub
- [ ] Verify PR template auto-fills on new PRs
- [ ] Review CONTRIBUTING.md for accuracy