### PR TITLE
fix: correct action SHAs in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           sha256sum "$output" > "${output}.sha256"
 
       - name: Upload release asset
-        uses: actions/upload-artifact@ea165f8d65b6db9a6b7c67862cd61e8cbc4d760b # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rampart-${{ matrix.goos }}-${{ matrix.goarch }}
           path: |
@@ -90,7 +90,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
## Summary
- Fix `actions/upload-artifact` SHA (was pointing to non-existent commit)
- Fix `actions/download-artifact` SHA (was pointing to non-existent commit)
- This was causing the v0.8.0-alpha release to fail

## Test plan
- [x] SHA verified via GitHub API