### PR TITLE
fix: use tag-based refs for artifact actions in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           sha256sum "$output" > "${output}.sha256"
 
       - name: Upload release asset
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: rampart-${{ matrix.goos }}-${{ matrix.goarch }}
           path: |
@@ -90,7 +90,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
Fix upload/download-artifact SHA pinning issues causing release failures.