### PR TITLE
docs: marketing-grade README with visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/manimovassagh/rampart/main/docs-site/static/img/logo.svg" alt="Rampart" width="120" />
+  <img src="https://raw.githubusercontent.com/manimovassagh/rampart/main/docs-site/static/img/logo.svg" alt="Rampart" width="80" />
 </p>
 
 <h1 align="center">Rampart</h1>
 
 <p align="center">
-  <strong>Open-source Identity & Access Management server</strong><br />
-  OAuth 2.0 &bull; OpenID Connect &bull; SAML 2.0 &bull; SCIM 2.0
+  <strong>Open-source Identity & Access Management Server</strong><br />
+  A single-binary IAM platform for modern applications
 </p>
 
 <p align="center">
@@ -17,42 +17,150 @@
   <a href="https://manimovassagh.github.io/rampart/"><img src="https://img.shields.io/badge/docs-GitHub_Pages-blue?logo=github" alt="Documentation" /></a>
 </p>
 
+<br />
+
+<p align="center">
+  <img src="docs/images/hero-banner.svg" alt="Rampart — Open-source Identity & Access Management" width="100%" />
+</p>
+
+<br />
+
+<p align="center">
+  <a href="#why-rampart">Why Rampart</a> ·
+  <a href="#features">Features</a> ·
+  <a href="#admin-console">Admin Console</a> ·
+  <a href="#architecture">Architecture</a> ·
+  <a href="#quick-start">Quick Start</a> ·
+  <a href="#how-it-works">How It Works</a> ·
+  <a href="#configuration">Configuration</a> ·
+  <a href="#documentation">Documentation</a> ·
+  <a href="#contributing">Contributing</a>
+</p>
+
 ---
 
-Rampart is a **single-binary** IAM server written in Go. Deploy it anywhere — Docker, bare metal, or Kubernetes — and get a complete identity platform out of the box.
+## Why Rampart
 
-## Highlights
+Most IAM solutions are either **too complex** to self-host or **too limited** to use in production. Rampart is different — it ships as a **single Go binary** that gives you a complete identity platform out of the box. No microservice sprawl, no JVM overhead, no vendor lock-in.
 
-| | Feature | Details |
-|---|---|---|
-| **Auth** | OAuth 2.0 / OIDC | Authorization Code + PKCE, Client Credentials, Device Flow, JWKS |
-| **Enterprise** | SAML 2.0 & SCIM 2.0 | SP bridge for SSO, user & group provisioning |
-| **MFA** | WebAuthn & TOTP | Passkeys, time-based OTP with backup codes |
-| **Social** | Google, GitHub, Apple | One-click social login with automatic account linking |
-| **RBAC** | Roles & Permissions | Fine-grained role-based access control with group support |
-| **Compliance** | SOC 2, GDPR, HIPAA | Built-in compliance dashboards and audit trail export |
-| **Ops** | Webhooks & Plugins | HMAC-signed event delivery, custom plugin extensions |
-| **HA** | Clustering | PostgreSQL-based leader election for high availability |
-| **Observability** | Metrics & Audit | Prometheus `/metrics` endpoint, full audit logging |
-| **Admin** | Built-in Console | Server-side rendered with htmx + Tailwind CSS |
+Deploy it on Docker, bare metal, or Kubernetes — and get OAuth 2.0, OpenID Connect, MFA, RBAC, and a built-in admin console in under a minute.
+
+---
+
+## Features
+
+<table>
+<tr>
+<td width="50%" valign="top">
+
+### 🔐 Authentication
+**OAuth 2.0 & OpenID Connect** — Authorization Code + PKCE, Client Credentials, Device Flow, and full JWKS rotation.
+
+### 🏢 Enterprise SSO
+**SAML 2.0 & SCIM 2.0** — Service Provider bridge for single sign-on, automated user and group provisioning.
+
+### 🛡️ Multi-Factor Auth
+**WebAuthn & TOTP** — Passkeys, hardware keys, and time-based OTP with backup codes.
+
+### 🌐 Social Login
+**Google, GitHub, Apple** — One-click social sign-in with automatic account linking.
+
+</td>
+<td width="50%" valign="top">
+
+### 👥 Access Control
+**Roles & Permissions** — Fine-grained RBAC with group support and scope-based authorization.
+
+### 📊 Observability
+**Metrics & Audit** — Prometheus `/metrics` endpoint, structured audit logging, and compliance dashboards.
+
+### 🔗 Extensibility
+**Webhooks & Plugins** — HMAC-signed event delivery and custom plugin extensions.
+
+### ⚡ High Availability
+**Clustering** — PostgreSQL-based leader election. No Redis, no external dependencies.
+
+</td>
+</tr>
+</table>
+
+---
+
+## Admin Console
+
+Rampart includes a **built-in admin dashboard** — server-side rendered with htmx + Tailwind CSS. Manage users, applications, roles, sessions, and audit logs from a single interface.
+
+<p align="center">
+  <img src="docs/images/admin-console-preview.svg" alt="Rampart Admin Console" width="100%" />
+</p>
+
+---
+
+## Architecture
+
+Rampart sits between your application and your database, handling all identity concerns so you don't have to.
+
+<p align="center">
+  <img src="docs/images/architecture.svg" alt="Rampart Architecture" width="100%" />
+</p>
+
+---
 
 ## Quick Start
 
+### Docker Compose (recommended)
+
 ```bash
-# Docker Compose (recommended)
 git clone https://github.com/manimovassagh/rampart.git
 cd rampart
 docker compose up -d --build
 ```
 
-This starts PostgreSQL, Redis, and Rampart. The admin console is available at `http://localhost:8080/admin/`.
+The admin console is available at **`http://localhost:8080/admin/`**
 
-**From source:**
+### From Source
 
 ```bash
 go build ./cmd/rampart
 ./rampart
 ```
+
+---
+
+## How It Works
+
+<p align="center">
+  <img src="docs/images/demo-flow.svg" alt="Authentication Flow" width="100%" />
+</p>
+
+**1. Register a user**
+```bash
+curl -X POST http://localhost:8080/register \
+  -H 'Content-Type: application/json' \
+  -d '{"email": "user@example.com", "password": "securepassword"}'
+```
+
+**2. Login and get tokens**
+```bash
+curl -X POST http://localhost:8080/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email": "user@example.com", "password": "securepassword"}'
+```
+
+**3. Call your API with the token**
+```bash
+curl http://localhost:8080/me \
+  -H 'Authorization: Bearer <access_token>'
+```
+
+**4. Refresh when expired**
+```bash
+curl -X POST http://localhost:8080/token \
+  -H 'Content-Type: application/json' \
+  -d '{"grant_type": "refresh_token", "refresh_token": "<refresh_token>"}'
+```
+
+---
 
 ## Configuration
 
@@ -65,6 +173,53 @@ go build ./cmd/rampart
 
 See `docker-compose.yml` and `.env.example` for the full set of environment variables.
 
+---
+
+## Tech Stack
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Go-1.26-00ADD8?style=for-the-badge&logo=go&logoColor=white" alt="Go" />
+  <img src="https://img.shields.io/badge/PostgreSQL-16-4169E1?style=for-the-badge&logo=postgresql&logoColor=white" alt="PostgreSQL" />
+  <img src="https://img.shields.io/badge/Docker-Ready-2496ED?style=for-the-badge&logo=docker&logoColor=white" alt="Docker" />
+  <img src="https://img.shields.io/badge/htmx-1.9-3366CC?style=for-the-badge&logo=htmx&logoColor=white" alt="htmx" />
+  <img src="https://img.shields.io/badge/Tailwind_CSS-3.4-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white" alt="Tailwind CSS" />
+</p>
+
+---
+
+## Documentation
+
+Full documentation is available at **[manimovassagh.github.io/rampart](https://manimovassagh.github.io/rampart/)**
+
+<table>
+<tr>
+<td align="center" width="25%">
+  <a href="https://manimovassagh.github.io/rampart/"><strong>📖 Getting Started</strong></a><br />
+  <sub>Installation, configuration, and first steps</sub>
+</td>
+<td align="center" width="25%">
+  <a href="docs/api/overview.md"><strong>🔌 API Reference</strong></a><br />
+  <sub>REST endpoints, OAuth flows, and OIDC</sub>
+</td>
+<td align="center" width="25%">
+  <a href="docs/architecture/system-context.md"><strong>🏗️ Architecture</strong></a><br />
+  <sub>System design, data model, and deployment</sub>
+</td>
+<td align="center" width="25%">
+  <a href="docs/sdk/integration-guide.md"><strong>🧩 Integration</strong></a><br />
+  <sub>SDK guide, samples, and best practices</sub>
+</td>
+</tr>
+</table>
+
+<p align="center">
+  <a href="https://manimovassagh.github.io/rampart/">
+    <img src="https://img.shields.io/badge/Read_the_Docs-%E2%86%92-blue?style=for-the-badge&logo=github" alt="Documentation" />
+  </a>
+</p>
+
+---
+
 ## Development
 
 ```bash
@@ -73,20 +228,27 @@ golangci-lint run      # Lint
 make check             # Full quality check (lint + vet + test + security)
 ```
 
-## Tech Stack
-
-**Go 1.26** &bull; **PostgreSQL** &bull; **Redis** (optional) &bull; **htmx + Tailwind CSS** &bull; **Docker**
-
-## Documentation
-
-Full documentation is available at **[manimovassagh.github.io/rampart](https://manimovassagh.github.io/rampart/)** — including API reference, architecture guides, deployment instructions, and tutorials.
-
-[![Documentation Site](https://img.shields.io/badge/Read_the_Docs-%E2%86%92-blue?style=for-the-badge&logo=github)](https://manimovassagh.github.io/rampart/)
-
 ## CI/CD
 
-Automated pipelines run on every push: **CI** &bull; **Tests** &bull; **Lint** &bull; **Security scanning** (gosec, govulncheck) &bull; **Docker build** &bull; **Release** &bull; **GitHub Pages**
+Automated pipelines run on every push: **CI** · **Tests** · **Lint** · **Security scanning** (gosec, govulncheck) · **Docker build** · **Release** · **GitHub Pages**
 
-## License
+---
 
-Licensed under the [GNU Affero General Public License v3.0](LICENSE).
+## Contributing
+
+Contributions are welcome! Whether it's bug reports, feature requests, or pull requests — we'd love your help.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
+
+---
+
+<p align="center">
+  <sub>Licensed under the <a href="LICENSE">GNU Affero General Public License v3.0</a></sub><br />
+  <sub>Built with ❤️ by <a href="https://github.com/manimovassagh">Mani Movassagh</a></sub>
+</p>

--- a/docs/images/admin-console-preview.svg
+++ b/docs/images/admin-console-preview.svg
@@ -1,0 +1,234 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 600" width="1000" height="600">
+  <defs>
+    <clipPath id="round-corners">
+      <rect x="0" y="0" width="1000" height="600" rx="12"/>
+    </clipPath>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1000" height="600" rx="12" fill="#0f172a"/>
+
+  <!-- Top Bar -->
+  <rect x="0" y="0" width="1000" height="48" fill="#1e293b" rx="12"/>
+  <rect x="0" y="12" width="1000" height="36" fill="#1e293b"/>
+  <line x1="0" y1="48" x2="1000" y2="48" stroke="#334155" stroke-width="1"/>
+
+  <!-- Castle Icon -->
+  <g transform="translate(20, 10)">
+    <rect x="4" y="14" width="4" height="14" rx="1" fill="#8b5cf6"/>
+    <rect x="12" y="8" width="4" height="20" rx="1" fill="#8b5cf6"/>
+    <rect x="20" y="14" width="4" height="14" rx="1" fill="#8b5cf6"/>
+    <rect x="2" y="24" width="24" height="4" rx="1" fill="#8b5cf6"/>
+    <rect x="6" y="6" width="2" height="4" fill="#8b5cf6"/>
+    <rect x="13" y="0" width="2" height="4" fill="#8b5cf6"/>
+    <rect x="20" y="6" width="2" height="4" fill="#8b5cf6"/>
+  </g>
+
+  <!-- Title -->
+  <text x="52" y="30" fill="#f8fafc" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="700">Rampart Admin</text>
+
+  <!-- User avatar -->
+  <circle cx="968" cy="24" r="14" fill="#334155"/>
+  <circle cx="968" cy="20" r="5" fill="#94a3b8"/>
+  <ellipse cx="968" cy="32" rx="8" ry="5" fill="#94a3b8"/>
+
+  <!-- Search bar placeholder -->
+  <rect x="400" y="12" width="220" height="24" rx="6" fill="#0f172a" stroke="#334155" stroke-width="1"/>
+  <text x="416" y="28" fill="#64748b" font-family="system-ui, sans-serif" font-size="11">Search...</text>
+
+  <!-- Left Sidebar -->
+  <rect x="0" y="48" width="180" height="552" fill="#1e293b"/>
+  <line x1="180" y1="48" x2="180" y2="600" stroke="#334155" stroke-width="1"/>
+
+  <!-- Sidebar Menu Items -->
+  <!-- Dashboard (active) -->
+  <rect x="8" y="60" width="164" height="36" rx="8" fill="#8b5cf6" opacity="0.15"/>
+  <rect x="8" y="60" width="3" height="36" rx="1.5" fill="#8b5cf6"/>
+  <!-- Grid icon -->
+  <rect x="24" y="70" width="7" height="7" rx="1.5" fill="#8b5cf6"/>
+  <rect x="33" y="70" width="7" height="7" rx="1.5" fill="#8b5cf6"/>
+  <rect x="24" y="79" width="7" height="7" rx="1.5" fill="#8b5cf6"/>
+  <rect x="33" y="79" width="7" height="7" rx="1.5" fill="#8b5cf6"/>
+  <text x="50" y="83" fill="#8b5cf6" font-family="system-ui, sans-serif" font-size="13" font-weight="600">Dashboard</text>
+
+  <!-- Users -->
+  <g opacity="0.7">
+    <!-- Person icon -->
+    <circle cx="31" cy="110" r="4" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+    <path d="M24 124 Q31 118 38 124" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+    <text x="50" y="119" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="13">Users</text>
+  </g>
+
+  <!-- Applications -->
+  <g opacity="0.7">
+    <rect x="25" y="137" width="12" height="12" rx="2" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+    <line x1="25" y1="143" x2="37" y2="143" stroke="#94a3b8" stroke-width="1.5"/>
+    <text x="50" y="148" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="13">Applications</text>
+  </g>
+
+  <!-- Roles -->
+  <g opacity="0.7">
+    <circle cx="31" cy="172" r="6" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+    <path d="M29 172 L31 174 L34 170" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+    <text x="50" y="176" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="13">Roles</text>
+  </g>
+
+  <!-- Sessions -->
+  <g opacity="0.7">
+    <rect x="25" y="195" width="12" height="9" rx="2" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+    <line x1="28" y1="199" x2="34" y2="199" stroke="#94a3b8" stroke-width="1"/>
+    <text x="50" y="204" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="13">Sessions</text>
+  </g>
+
+  <!-- Audit Log -->
+  <g opacity="0.7">
+    <rect x="26" y="222" width="10" height="13" rx="2" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+    <line x1="29" y1="227" x2="33" y2="227" stroke="#94a3b8" stroke-width="1"/>
+    <line x1="29" y1="230" x2="33" y2="230" stroke="#94a3b8" stroke-width="1"/>
+    <text x="50" y="233" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="13">Audit Log</text>
+  </g>
+
+  <!-- Sidebar bottom section -->
+  <line x1="12" y1="540" x2="168" y2="540" stroke="#334155" stroke-width="1"/>
+  <text x="24" y="562" fill="#64748b" font-family="system-ui, sans-serif" font-size="10">Rampart v2.0.0</text>
+
+  <!-- ===== MAIN CONTENT AREA ===== -->
+
+  <!-- Page title -->
+  <text x="200" y="82" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="20" font-weight="700">Dashboard</text>
+  <text x="200" y="100" fill="#64748b" font-family="system-ui, sans-serif" font-size="12">Overview of your IAM server</text>
+
+  <!-- ===== STAT CARDS ROW ===== -->
+
+  <!-- Card 1: Total Users -->
+  <rect x="200" y="116" width="185" height="88" rx="10" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+  <text x="216" y="140" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11" font-weight="500">Total Users</text>
+  <text x="216" y="172" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="28" font-weight="700">1,247</text>
+  <!-- Up arrow + percentage -->
+  <polygon points="348,137 352,131 356,137" fill="#10b981"/>
+  <text x="358" y="140" fill="#10b981" font-family="system-ui, sans-serif" font-size="11" font-weight="600">+12%</text>
+  <!-- Sparkline -->
+  <polyline points="216,192 230,190 244,188 258,191 272,186 286,183 300,180 314,176 328,178 342,172 356,168 370,164" fill="none" stroke="#8b5cf6" stroke-width="1.5" opacity="0.4"/>
+
+  <!-- Card 2: Active Sessions -->
+  <rect x="395" y="116" width="185" height="88" rx="10" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+  <text x="411" y="140" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11" font-weight="500">Active Sessions</text>
+  <text x="411" y="172" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="28" font-weight="700">342</text>
+  <!-- Dot indicator -->
+  <circle cx="549" cy="136" r="4" fill="#8b5cf6" opacity="0.6"/>
+  <circle cx="549" cy="136" r="2" fill="#8b5cf6"/>
+  <polyline points="411,192 425,189 439,192 453,187 467,190 481,185 495,188 509,183 523,186 537,181 551,184 565,180" fill="none" stroke="#8b5cf6" stroke-width="1.5" opacity="0.4"/>
+
+  <!-- Card 3: Applications -->
+  <rect x="590" y="116" width="185" height="88" rx="10" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+  <text x="606" y="140" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11" font-weight="500">Applications</text>
+  <text x="606" y="172" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="28" font-weight="700">12</text>
+  <polyline points="606,192 620,190 634,191 648,189 662,190 676,188 690,189 704,187 718,188 732,186 746,187 760,185" fill="none" stroke="#8b5cf6" stroke-width="1.5" opacity="0.4"/>
+
+  <!-- Card 4: Failed Logins -->
+  <rect x="785" y="116" width="185" height="88" rx="10" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+  <text x="801" y="140" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11" font-weight="500">Failed Logins (24h)</text>
+  <text x="801" y="172" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="28" font-weight="700">8</text>
+  <!-- Down arrow (good) -->
+  <polygon points="933,133 937,139 929,139" fill="#10b981"/>
+  <text x="940" y="140" fill="#10b981" font-family="system-ui, sans-serif" font-size="11" font-weight="600">-24%</text>
+  <polyline points="801,192 815,186 829,188 843,185 857,189 871,192 885,190 899,193 913,191 927,194 941,192 955,195" fill="none" stroke="#10b981" stroke-width="1.5" opacity="0.4"/>
+
+  <!-- ===== BAR CHART SECTION ===== -->
+  <rect x="200" y="220" width="380" height="180" rx="10" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+  <text x="216" y="246" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="13" font-weight="600">Logins — Last 7 Days</text>
+
+  <!-- Y-axis labels -->
+  <text x="224" y="272" fill="#64748b" font-family="system-ui, sans-serif" font-size="9">400</text>
+  <text x="224" y="302" fill="#64748b" font-family="system-ui, sans-serif" font-size="9">200</text>
+  <text x="232" y="332" fill="#64748b" font-family="system-ui, sans-serif" font-size="9">0</text>
+
+  <!-- Grid lines -->
+  <line x1="248" y1="269" x2="560" y2="269" stroke="#334155" stroke-width="0.5"/>
+  <line x1="248" y1="299" x2="560" y2="299" stroke="#334155" stroke-width="0.5"/>
+  <line x1="248" y1="332" x2="560" y2="332" stroke="#334155" stroke-width="0.5"/>
+
+  <!-- Bars -->
+  <rect x="264" y="283" width="32" height="49" rx="3" fill="#8b5cf6" opacity="0.7"/>
+  <rect x="308" y="274" width="32" height="58" rx="3" fill="#8b5cf6" opacity="0.8"/>
+  <rect x="352" y="289" width="32" height="43" rx="3" fill="#8b5cf6" opacity="0.65"/>
+  <rect x="396" y="263" width="32" height="69" rx="3" fill="#8b5cf6" opacity="0.9"/>
+  <rect x="440" y="270" width="32" height="62" rx="3" fill="#8b5cf6" opacity="0.85"/>
+  <rect x="484" y="278" width="32" height="54" rx="3" fill="#8b5cf6" opacity="0.75"/>
+  <rect x="528" y="258" width="32" height="74" rx="3" fill="#8b5cf6"/>
+
+  <!-- Day labels -->
+  <text x="272" y="348" fill="#64748b" font-family="system-ui, sans-serif" font-size="9" text-anchor="middle">Mon</text>
+  <text x="316" y="348" fill="#64748b" font-family="system-ui, sans-serif" font-size="9" text-anchor="middle">Tue</text>
+  <text x="360" y="348" fill="#64748b" font-family="system-ui, sans-serif" font-size="9" text-anchor="middle">Wed</text>
+  <text x="404" y="348" fill="#64748b" font-family="system-ui, sans-serif" font-size="9" text-anchor="middle">Thu</text>
+  <text x="448" y="348" fill="#64748b" font-family="system-ui, sans-serif" font-size="9" text-anchor="middle">Fri</text>
+  <text x="492" y="348" fill="#64748b" font-family="system-ui, sans-serif" font-size="9" text-anchor="middle">Sat</text>
+  <text x="536" y="348" fill="#64748b" font-family="system-ui, sans-serif" font-size="9" text-anchor="middle">Sun</text>
+
+  <!-- ===== DONUT CHART SECTION ===== -->
+  <rect x="590" y="220" width="380" height="180" rx="10" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+  <text x="606" y="246" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="13" font-weight="600">Users by Role</text>
+
+  <!-- Donut chart -->
+  <circle cx="720" cy="320" r="45" fill="none" stroke="#334155" stroke-width="14"/>
+  <!-- Admin segment -->
+  <circle cx="720" cy="320" r="45" fill="none" stroke="#8b5cf6" stroke-width="14" stroke-dasharray="42 241" stroke-dashoffset="0" transform="rotate(-90 720 320)"/>
+  <!-- Editor segment -->
+  <circle cx="720" cy="320" r="45" fill="none" stroke="#6d28d9" stroke-width="14" stroke-dasharray="85 198" stroke-dashoffset="-42" transform="rotate(-90 720 320)"/>
+  <!-- Viewer segment -->
+  <circle cx="720" cy="320" r="45" fill="none" stroke="#a78bfa" stroke-width="14" stroke-dasharray="156 127" stroke-dashoffset="-127" transform="rotate(-90 720 320)"/>
+
+  <!-- Legend -->
+  <rect x="810" y="278" width="10" height="10" rx="2" fill="#8b5cf6"/>
+  <text x="826" y="288" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11">Admin (15%)</text>
+  <rect x="810" y="298" width="10" height="10" rx="2" fill="#6d28d9"/>
+  <text x="826" y="308" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11">Editor (30%)</text>
+  <rect x="810" y="318" width="10" height="10" rx="2" fill="#a78bfa"/>
+  <text x="826" y="328" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11">Viewer (55%)</text>
+
+  <!-- Center label -->
+  <text x="720" y="317" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="16" font-weight="700" text-anchor="middle">1,247</text>
+  <text x="720" y="332" fill="#64748b" font-family="system-ui, sans-serif" font-size="9" text-anchor="middle">total</text>
+
+  <!-- ===== TABLE SECTION ===== -->
+  <rect x="200" y="414" width="770" height="172" rx="10" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+  <text x="216" y="440" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="13" font-weight="600">Recent Users</text>
+
+  <!-- Table Header -->
+  <rect x="200" y="450" width="770" height="30" fill="#0f172a" opacity="0.5"/>
+  <text x="224" y="469" fill="#64748b" font-family="system-ui, sans-serif" font-size="11" font-weight="600">User</text>
+  <text x="400" y="469" fill="#64748b" font-family="system-ui, sans-serif" font-size="11" font-weight="600">Email</text>
+  <text x="640" y="469" fill="#64748b" font-family="system-ui, sans-serif" font-size="11" font-weight="600">Role</text>
+  <text x="800" y="469" fill="#64748b" font-family="system-ui, sans-serif" font-size="11" font-weight="600">Last Login</text>
+
+  <!-- Row 1 -->
+  <line x1="216" y1="480" x2="954" y2="480" stroke="#334155" stroke-width="0.5"/>
+  <circle cx="234" cy="500" r="12" fill="#8b5cf6" opacity="0.2"/>
+  <text x="234" y="504" fill="#8b5cf6" font-family="system-ui, sans-serif" font-size="10" font-weight="600" text-anchor="middle">AJ</text>
+  <text x="256" y="504" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="12">Alice Johnson</text>
+  <text x="400" y="504" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="12">alice@example.com</text>
+  <rect x="640" y="491" width="48" height="20" rx="10" fill="#8b5cf6" opacity="0.15"/>
+  <text x="652" y="505" fill="#8b5cf6" font-family="system-ui, sans-serif" font-size="11" font-weight="500">Admin</text>
+  <text x="800" y="504" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="12">2 min ago</text>
+
+  <!-- Row 2 -->
+  <line x1="216" y1="520" x2="954" y2="520" stroke="#334155" stroke-width="0.5"/>
+  <circle cx="234" cy="540" r="12" fill="#6d28d9" opacity="0.2"/>
+  <text x="234" y="544" fill="#6d28d9" font-family="system-ui, sans-serif" font-size="10" font-weight="600" text-anchor="middle">BS</text>
+  <text x="256" y="544" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="12">Bob Smith</text>
+  <text x="400" y="544" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="12">bob@example.com</text>
+  <rect x="640" y="531" width="48" height="20" rx="10" fill="#6d28d9" opacity="0.15"/>
+  <text x="650" y="545" fill="#a78bfa" font-family="system-ui, sans-serif" font-size="11" font-weight="500">Editor</text>
+  <text x="800" y="544" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="12">15 min ago</text>
+
+  <!-- Row 3 -->
+  <line x1="216" y1="560" x2="954" y2="560" stroke="#334155" stroke-width="0.5"/>
+  <circle cx="234" cy="575" r="12" fill="#a78bfa" opacity="0.2"/>
+  <text x="234" y="579" fill="#a78bfa" font-family="system-ui, sans-serif" font-size="10" font-weight="600" text-anchor="middle">CW</text>
+  <text x="256" y="579" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="12">Carol Williams</text>
+  <text x="400" y="579" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="12">carol@example.com</text>
+  <rect x="640" y="566" width="52" height="20" rx="10" fill="#334155" opacity="0.5"/>
+  <text x="650" y="580" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11" font-weight="500">Viewer</text>
+  <text x="800" y="579" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="12">1 hour ago</text>
+</svg>

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -1,0 +1,104 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 500" width="900" height="500">
+  <defs>
+    <filter id="shadow" x="-5%" y="-5%" width="115%" height="115%">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
+    <linearGradient id="purpleGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="greenArrow" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#10b981"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="900" height="500" rx="12" fill="#0f172a"/>
+
+  <!-- Title -->
+  <text x="450" y="38" text-anchor="middle" fill="#c4b5fd" font-family="system-ui, sans-serif" font-size="18" font-weight="700" letter-spacing="1">RAMPART ARCHITECTURE</text>
+
+  <!-- ========== Browser / Admin (top) ========== -->
+  <rect x="365" y="56" width="170" height="48" rx="10" fill="#1e293b" stroke="#334155" stroke-width="1.5" filter="url(#shadow)"/>
+  <!-- Globe icon -->
+  <circle cx="392" cy="80" r="10" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+  <line x1="382" y1="80" x2="402" y2="80" stroke="#94a3b8" stroke-width="1"/>
+  <ellipse cx="392" cy="80" rx="5" ry="10" fill="none" stroke="#94a3b8" stroke-width="1"/>
+  <text x="410" y="84" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="13" font-weight="600">Browser</text>
+
+  <!-- Arrow: Browser → Rampart -->
+  <line x1="450" y1="104" x2="450" y2="142" stroke="#c4b5fd" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <polygon points="445,140 450,150 455,140" fill="#c4b5fd"/>
+  <text x="468" y="132" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">Admin Console</text>
+
+  <!-- ========== Your Application (left) ========== -->
+  <rect x="30" y="210" width="190" height="90" rx="12" fill="#1e293b" stroke="#334155" stroke-width="1.5" filter="url(#shadow)"/>
+  <!-- Code icon: < / > -->
+  <text x="62" y="248" fill="#60a5fa" font-family="monospace" font-size="18" font-weight="700">&lt;/&gt;</text>
+  <text x="90" y="248" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="14" font-weight="600">Your App</text>
+  <text x="125" y="270" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11">React, Express, etc.</text>
+
+  <!-- ========== Rampart Server (center) ========== -->
+  <rect x="290" y="150" width="320" height="230" rx="14" fill="url(#purpleGrad)" opacity="0.15" stroke="#8b5cf6" stroke-width="2" filter="url(#shadow)"/>
+  <rect x="290" y="150" width="320" height="230" rx="14" fill="none" stroke="#8b5cf6" stroke-width="1.5"/>
+
+  <!-- Shield icon -->
+  <path d="M435,170 L435,185 Q435,198 450,205 Q465,198 465,185 L465,170 L450,164 Z" fill="none" stroke="#c4b5fd" stroke-width="1.8"/>
+  <path d="M445,180 L449,184 L457,176" fill="none" stroke="#10b981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <text x="450" y="225" text-anchor="middle" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="16" font-weight="700">Rampart Server</text>
+
+  <!-- Sub-components inside Rampart -->
+  <!-- OAuth 2.0 / OIDC -->
+  <rect x="305" y="240" width="130" height="32" rx="6" fill="#1e1b4b" stroke="#6d28d9" stroke-width="1"/>
+  <text x="370" y="261" text-anchor="middle" fill="#c4b5fd" font-family="system-ui, sans-serif" font-size="11" font-weight="600">OAuth 2.0 / OIDC</text>
+
+  <!-- Token Service -->
+  <rect x="305" y="280" width="130" height="32" rx="6" fill="#1e1b4b" stroke="#6d28d9" stroke-width="1"/>
+  <text x="370" y="301" text-anchor="middle" fill="#f59e0b" font-family="system-ui, sans-serif" font-size="11" font-weight="600">Token Service</text>
+  <text x="370" y="312" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="8">(JWT / JWKS)</text>
+
+  <!-- Admin Console -->
+  <rect x="465" y="240" width="130" height="32" rx="6" fill="#1e1b4b" stroke="#6d28d9" stroke-width="1"/>
+  <text x="530" y="261" text-anchor="middle" fill="#c4b5fd" font-family="system-ui, sans-serif" font-size="11" font-weight="600">Admin Console</text>
+
+  <!-- MFA Engine -->
+  <rect x="465" y="280" width="130" height="32" rx="6" fill="#1e1b4b" stroke="#6d28d9" stroke-width="1"/>
+  <text x="530" y="301" text-anchor="middle" fill="#c4b5fd" font-family="system-ui, sans-serif" font-size="11" font-weight="600">MFA Engine</text>
+
+  <!-- Session Manager -->
+  <rect x="385" y="330" width="130" height="32" rx="6" fill="#1e1b4b" stroke="#6d28d9" stroke-width="1"/>
+  <text x="450" y="351" text-anchor="middle" fill="#c4b5fd" font-family="system-ui, sans-serif" font-size="11" font-weight="600">Session Manager</text>
+
+  <!-- ========== PostgreSQL (bottom-right) ========== -->
+  <rect x="680" y="350" width="185" height="90" rx="12" fill="#1e293b" stroke="#334155" stroke-width="1.5" filter="url(#shadow)"/>
+  <!-- DB icon (cylinder) -->
+  <ellipse cx="720" cy="380" rx="14" ry="6" fill="none" stroke="#60a5fa" stroke-width="1.5"/>
+  <line x1="706" y1="380" x2="706" y2="400" stroke="#60a5fa" stroke-width="1.5"/>
+  <line x1="734" y1="380" x2="734" y2="400" stroke="#60a5fa" stroke-width="1.5"/>
+  <ellipse cx="720" cy="400" rx="14" ry="6" fill="none" stroke="#60a5fa" stroke-width="1.5"/>
+  <text x="745" y="392" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="14" font-weight="600">PostgreSQL</text>
+  <text x="772" y="412" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">Users, Sessions, Keys</text>
+
+  <!-- ========== Arrows ========== -->
+
+  <!-- App → Rampart: Auth Request -->
+  <line x1="220" y1="240" x2="285" y2="240" stroke="#94a3b8" stroke-width="1.5"/>
+  <polygon points="283,235 293,240 283,245" fill="#94a3b8"/>
+  <text x="252" y="232" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">Auth</text>
+  <text x="252" y="243" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">Request</text>
+
+  <!-- Rampart → App: JWT Token (green, below) -->
+  <line x1="288" y1="270" x2="222" y2="270" stroke="#10b981" stroke-width="1.5"/>
+  <polygon points="224,265 214,270 224,275" fill="#10b981"/>
+  <text x="252" y="286" text-anchor="middle" fill="#10b981" font-family="system-ui, sans-serif" font-size="10" font-weight="600">JWT Token</text>
+
+  <!-- Rampart → PostgreSQL -->
+  <line x1="610" y1="340" x2="678" y2="380" stroke="#94a3b8" stroke-width="1.5"/>
+  <polygon points="673,373 680,382 671,381" fill="#94a3b8"/>
+  <text x="660" y="345" text-anchor="end" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="10">Store</text>
+
+  <!-- ========== Footer ========== -->
+  <text x="450" y="480" text-anchor="middle" fill="#475569" font-family="system-ui, sans-serif" font-size="10">Open-source IAM / OAuth 2.0 server with OIDC support</text>
+</svg>

--- a/docs/images/demo-flow.svg
+++ b/docs/images/demo-flow.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 180" width="1000" height="180">
+  <defs>
+    <linearGradient id="circleGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#c4b5fd"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#8b5cf6"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1000" height="180" rx="12" fill="#0f172a"/>
+
+  <!-- Step 1: Register -->
+  <circle cx="100" cy="60" r="28" fill="url(#circleGrad)"/>
+  <text x="100" y="67" text-anchor="middle" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="18" font-weight="700">1</text>
+  <text x="100" y="112" text-anchor="middle" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="14" font-weight="600">Register</text>
+  <text x="100" y="130" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11">POST /register</text>
+
+  <!-- Arrow 1→2 -->
+  <line x1="132" y1="60" x2="168" y2="60" stroke="#8b5cf6" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Step 2: Login -->
+  <circle cx="300" cy="60" r="28" fill="url(#circleGrad)"/>
+  <text x="300" y="67" text-anchor="middle" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="18" font-weight="700">2</text>
+  <text x="300" y="112" text-anchor="middle" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="14" font-weight="600">Login</text>
+  <text x="300" y="130" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11">POST /login</text>
+
+  <!-- Arrow 2→3 -->
+  <line x1="332" y1="60" x2="368" y2="60" stroke="#8b5cf6" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Step 3: Get Token -->
+  <circle cx="500" cy="60" r="28" fill="url(#circleGrad)"/>
+  <text x="500" y="67" text-anchor="middle" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="18" font-weight="700">3</text>
+  <text x="500" y="112" text-anchor="middle" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="14" font-weight="600">Get Token</text>
+  <text x="500" y="130" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11">JWT + Refresh</text>
+
+  <!-- Arrow 3→4 -->
+  <line x1="532" y1="60" x2="568" y2="60" stroke="#8b5cf6" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Step 4: Call API -->
+  <circle cx="700" cy="60" r="28" fill="url(#circleGrad)"/>
+  <text x="700" y="67" text-anchor="middle" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="18" font-weight="700">4</text>
+  <text x="700" y="112" text-anchor="middle" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="14" font-weight="600">Call API</text>
+  <text x="700" y="130" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11">Bearer Token</text>
+
+  <!-- Arrow 4→5 -->
+  <line x1="732" y1="60" x2="768" y2="60" stroke="#8b5cf6" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Step 5: Refresh -->
+  <circle cx="900" cy="60" r="28" fill="url(#circleGrad)"/>
+  <text x="900" y="67" text-anchor="middle" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="18" font-weight="700">5</text>
+  <text x="900" y="112" text-anchor="middle" fill="#f8fafc" font-family="system-ui, sans-serif" font-size="14" font-weight="600">Refresh</text>
+  <text x="900" y="130" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="11">POST /token</text>
+</svg>

--- a/docs/images/hero-banner.svg
+++ b/docs/images/hero-banner.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 400" width="1200" height="400">
+  <defs>
+    <!-- Purple radial glow behind center text -->
+    <radialGradient id="centerGlow" cx="50%" cy="50%" r="35%" fx="50%" fy="50%">
+      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.15"/>
+      <stop offset="60%" stop-color="#7c3aed" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#0f172a" stop-opacity="0"/>
+    </radialGradient>
+
+    <!-- Grid pattern -->
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <circle cx="20" cy="20" r="0.8" fill="#1e293b" opacity="0.6"/>
+    </pattern>
+
+    <!-- Subtle line grid -->
+    <pattern id="lineGrid" width="60" height="60" patternUnits="userSpaceOnUse">
+      <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#1e293b" stroke-width="0.5" opacity="0.4"/>
+    </pattern>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="400" fill="#0f172a"/>
+
+  <!-- Grid patterns -->
+  <rect width="1200" height="400" fill="url(#lineGrid)"/>
+  <rect width="1200" height="400" fill="url(#grid)"/>
+
+  <!-- Purple glow behind center -->
+  <ellipse cx="600" cy="180" rx="400" ry="160" fill="url(#centerGlow)"/>
+
+  <!-- === LEFT SIDE: Castle/Fortress Silhouette === -->
+  <g transform="translate(100, 100)" fill="#8b5cf6" opacity="0.25">
+    <!-- Castle base -->
+    <rect x="0" y="120" width="140" height="80" rx="2"/>
+    <!-- Left tower -->
+    <rect x="0" y="60" width="30" height="140" rx="2"/>
+    <!-- Right tower -->
+    <rect x="110" y="60" width="30" height="140" rx="2"/>
+    <!-- Center tower (tallest) -->
+    <rect x="45" y="30" width="50" height="170" rx="2"/>
+    <!-- Battlements left tower -->
+    <rect x="0" y="50" width="8" height="15" rx="1"/>
+    <rect x="11" y="50" width="8" height="15" rx="1"/>
+    <rect x="22" y="50" width="8" height="15" rx="1"/>
+    <!-- Battlements right tower -->
+    <rect x="110" y="50" width="8" height="15" rx="1"/>
+    <rect x="121" y="50" width="8" height="15" rx="1"/>
+    <rect x="132" y="50" width="8" height="15" rx="1"/>
+    <!-- Battlements center tower -->
+    <rect x="45" y="18" width="10" height="16" rx="1"/>
+    <rect x="58" y="18" width="10" height="16" rx="1"/>
+    <rect x="71" y="18" width="10" height="16" rx="1"/>
+    <rect x="84" y="18" width="10" height="16" rx="1"/>
+    <!-- Gate arch -->
+    <rect x="55" y="150" width="30" height="50" rx="15" fill="#0f172a"/>
+    <!-- Windows -->
+    <rect x="58" y="80" width="8" height="12" rx="4" fill="#0f172a"/>
+    <rect x="74" y="80" width="8" height="12" rx="4" fill="#0f172a"/>
+    <rect x="58" y="110" width="8" height="12" rx="4" fill="#0f172a"/>
+    <rect x="74" y="110" width="8" height="12" rx="4" fill="#0f172a"/>
+  </g>
+
+  <!-- Castle accent glow -->
+  <ellipse cx="170" cy="200" rx="100" ry="80" fill="#8b5cf6" opacity="0.04"/>
+
+  <!-- === RIGHT SIDE: Shield with Keyhole === -->
+  <g transform="translate(960, 110)" fill="none" opacity="0.25">
+    <!-- Shield shape -->
+    <path d="M 70 0 L 140 30 L 140 100 Q 140 170 70 200 Q 0 170 0 100 L 0 30 Z"
+          fill="#8b5cf6" stroke="#c4b5fd" stroke-width="1.5"/>
+    <!-- Inner shield border -->
+    <path d="M 70 15 L 127 40 L 127 100 Q 127 158 70 185 Q 13 158 13 100 L 13 40 Z"
+          fill="none" stroke="#c4b5fd" stroke-width="0.8" opacity="0.5"/>
+    <!-- Keyhole circle -->
+    <circle cx="70" cy="85" r="20" fill="#0f172a" stroke="#c4b5fd" stroke-width="1.5"/>
+    <!-- Keyhole slot -->
+    <path d="M 63 95 L 70 130 L 77 95 Z" fill="#0f172a"/>
+    <!-- Keyhole inner highlight -->
+    <circle cx="70" cy="85" r="12" fill="none" stroke="#c4b5fd" stroke-width="0.5" opacity="0.6"/>
+  </g>
+
+  <!-- Shield accent glow -->
+  <ellipse cx="1030" cy="210" rx="100" ry="80" fill="#8b5cf6" opacity="0.04"/>
+
+  <!-- === CENTER TEXT === -->
+
+  <!-- "RAMPART" main title -->
+  <text x="600" y="175" text-anchor="middle"
+        font-family="'SF Pro Display', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif"
+        font-size="72" font-weight="800" letter-spacing="12" fill="white">
+    RAMPART
+  </text>
+
+  <!-- Subtle underline accent -->
+  <line x1="440" y1="195" x2="760" y2="195" stroke="#8b5cf6" stroke-width="2" opacity="0.4"/>
+
+  <!-- Subtitle -->
+  <text x="600" y="235" text-anchor="middle"
+        font-family="'SF Pro Display', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif"
+        font-size="20" font-weight="400" letter-spacing="1" fill="#94a3b8">
+    Open-source Identity &amp; Access Management
+  </text>
+
+  <!-- Feature tags -->
+  <text x="600" y="275" text-anchor="middle"
+        font-family="'SF Mono', 'JetBrains Mono', 'Fira Code', monospace"
+        font-size="14" font-weight="500" letter-spacing="2" fill="#c4b5fd" opacity="0.8">
+    OAuth 2.0  ·  OpenID Connect  ·  MFA  ·  RBAC
+  </text>
+
+  <!-- Decorative corner accents -->
+  <!-- Top-left -->
+  <line x1="30" y1="30" x2="80" y2="30" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+  <line x1="30" y1="30" x2="30" y2="80" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+  <!-- Top-right -->
+  <line x1="1120" y1="30" x2="1170" y2="30" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+  <line x1="1170" y1="30" x2="1170" y2="80" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+  <!-- Bottom-left -->
+  <line x1="30" y1="370" x2="80" y2="370" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+  <line x1="30" y1="320" x2="30" y2="370" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+  <!-- Bottom-right -->
+  <line x1="1120" y1="370" x2="1170" y2="370" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+  <line x1="1170" y1="320" x2="1170" y2="370" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+
+  <!-- Bottom edge gradient fade -->
+  <rect x="0" y="360" width="1200" height="40" fill="url(#centerGlow)" opacity="0.3"/>
+</svg>


### PR DESCRIPTION
## Summary
- Added 4 custom SVG visuals: hero banner, architecture diagram, admin console preview, and authentication demo flow
- Restructured README with internal navigation links, two-column feature grid, tech stack badges, and documentation cards
- Professional marketing-style layout inspired by Supabase/Appwrite/Infisical

## Test plan
- [ ] Verify all SVG images render correctly on GitHub
- [ ] Verify all internal anchor links work
- [ ] Verify badge images load
- [ ] Check responsive layout on mobile GitHub view