### PR TITLE
fix: validate org membership for X-Org-Context header

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -461,11 +461,11 @@ func (h *AdminHandler) RevokeSessions(w http.ResponseWriter, r *http.Request) {
 // --- Helpers ---
 
 // resolveOrgID returns the org context for this request.
-// If the X-Org-Context header is set to a valid UUID, that is used (org switching).
-// Otherwise falls back to the authenticated user's own org from the JWT.
+// Only super_admin users may switch orgs via the X-Org-Context header.
+// All other users are restricted to their own organization.
 func resolveOrgID(r *http.Request, authUser *middleware.AuthenticatedUser) uuid.UUID {
 	if header := r.Header.Get("X-Org-Context"); header != "" {
-		if parsed, err := uuid.Parse(header); err == nil {
+		if parsed, err := uuid.Parse(header); err == nil && authUser.HasRole("super_admin") {
 			return parsed
 		}
 	}

--- a/internal/handler/admin_test.go
+++ b/internal/handler/admin_test.go
@@ -43,6 +43,7 @@ type mockAdminUserStore struct {
 	countOrgsErr   error
 	orgSettings    *model.OrgSettings
 	orgSettingsErr error
+	lastOrgID      uuid.UUID
 }
 
 func (m *mockAdminUserStore) GetUserByID(_ context.Context, _ uuid.UUID) (*model.User, error) {
@@ -78,7 +79,8 @@ func (m *mockAdminUserStore) DeleteUser(_ context.Context, _ uuid.UUID) error {
 func (m *mockAdminUserStore) UpdatePassword(_ context.Context, _ uuid.UUID, _ []byte) error {
 	return m.updatePwErr
 }
-func (m *mockAdminUserStore) CountUsers(_ context.Context, _ uuid.UUID) (int, error) {
+func (m *mockAdminUserStore) CountUsers(_ context.Context, orgID uuid.UUID) (int, error) {
+	m.lastOrgID = orgID
 	return m.countUsers, m.countUsersErr
 }
 func (m *mockAdminUserStore) CountRecentUsers(_ context.Context, _ uuid.UUID, _ int) (int, error) {
@@ -913,14 +915,15 @@ func TestAdminRevokeSessionsError(t *testing.T) {
 	}
 }
 
-func TestAdminResolveOrgIDWithHeader(t *testing.T) {
+func TestAdminResolveOrgIDIgnoresHeaderWithoutSuperAdmin(t *testing.T) {
 	orgID := uuid.New()
 	headerOrgID := uuid.New()
 	store := &mockAdminUserStore{countUsers: 5, countRecent: 1, countOrgs: 1}
 	sessions := &mockAdminSessionStore{countActive: 2}
 	h := newTestAdminHandler(store, sessions)
 
-	authUser := &middleware.AuthenticatedUser{UserID: uuid.New(), OrgID: orgID}
+	// User without super_admin role — header should be ignored
+	authUser := &middleware.AuthenticatedUser{UserID: uuid.New(), OrgID: orgID, Roles: []string{"admin"}}
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
 	req.Header.Set("X-Org-Context", headerOrgID.String())
 	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
@@ -931,6 +934,38 @@ func TestAdminResolveOrgIDWithHeader(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	// Verify the store was queried with the user's own org, not the header value
+	if store.lastOrgID != orgID {
+		t.Errorf("org = %s, want %s (user's own org, not header)", store.lastOrgID, orgID)
+	}
+}
+
+func TestAdminResolveOrgIDAllowsSuperAdmin(t *testing.T) {
+	orgID := uuid.New()
+	headerOrgID := uuid.New()
+	store := &mockAdminUserStore{countUsers: 5, countRecent: 1, countOrgs: 1}
+	sessions := &mockAdminSessionStore{countActive: 2}
+	h := newTestAdminHandler(store, sessions)
+
+	// User with super_admin role — header should be honored
+	authUser := &middleware.AuthenticatedUser{UserID: uuid.New(), OrgID: orgID, Roles: []string{"super_admin"}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/stats", http.NoBody)
+	req.Header.Set("X-Org-Context", headerOrgID.String())
+	ctx := middleware.SetAuthenticatedUser(req.Context(), authUser)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.Stats(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	// Verify the store was queried with the header org
+	if store.lastOrgID != headerOrgID {
+		t.Errorf("org = %s, want %s (header org for super_admin)", store.lastOrgID, headerOrgID)
 	}
 }
 

--- a/internal/handler/scim.go
+++ b/internal/handler/scim.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
+	"github.com/manimovassagh/rampart/internal/middleware"
 	"github.com/manimovassagh/rampart/internal/model"
 	"github.com/manimovassagh/rampart/internal/store"
 )
@@ -549,11 +550,15 @@ func (h *SCIMHandler) scimError(w http.ResponseWriter, status int, detail string
 	})
 }
 
-// scimOrgID extracts the organization ID from the X-Org-Context header or uses default.
+// scimOrgID extracts the organization ID for this SCIM request.
+// Only super_admin users may switch orgs via the X-Org-Context header.
 func scimOrgID(r *http.Request) uuid.UUID {
 	if orgStr := r.Header.Get("X-Org-Context"); orgStr != "" {
 		if id, err := uuid.Parse(orgStr); err == nil {
-			return id
+			authUser := middleware.GetAuthenticatedUser(r.Context())
+			if authUser != nil && authUser.HasRole("super_admin") {
+				return id
+			}
 		}
 	}
 	// Fall back to org ID from authenticated context


### PR DESCRIPTION
## Summary
- **CRITICAL security fix**: `resolveOrgID` and `scimOrgID` accepted any UUID from `X-Org-Context` without checking org membership, allowing any admin to access another tenant's data
- Now only `super_admin` users can switch org context via the header; regular admins are restricted to their own org
- Added tests verifying both the denial (non-super-admin) and allowance (super-admin) paths

## Test plan
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues
- [x] Existing tests updated to reflect new behavior
- [x] New test: non-super-admin header ignored, falls back to user's org
- [x] New test: super-admin header honored

Closes #122