### PR TITLE
fix: implement refresh token rotation per RFC 6819

### DIFF
--- a/internal/handler/login.go
+++ b/internal/handler/login.go
@@ -64,9 +64,10 @@ type RefreshRequest struct {
 
 // RefreshResponse is returned on successful token refresh.
 type RefreshResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	ExpiresIn   int    `json:"expires_in"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
 }
 
 // LogoutRequest is the expected JSON body for POST /logout.
@@ -407,10 +408,24 @@ func (h *LoginHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Rotate refresh token: generate a new one and invalidate the old.
+	newRefreshToken, err := token.GenerateRefreshToken()
+	if err != nil {
+		h.logger.Error("failed to generate new refresh token", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+	if err := h.sessions.RotateRefreshToken(ctx, sess.ID, newRefreshToken); err != nil {
+		h.logger.Error("failed to rotate refresh token", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
 	resp := RefreshResponse{
-		AccessToken: accessToken,
-		TokenType:   tokenTypeBearer,
-		ExpiresIn:   int(h.accessTTL.Seconds()),
+		AccessToken:  accessToken,
+		RefreshToken: newRefreshToken,
+		TokenType:    tokenTypeBearer,
+		ExpiresIn:    int(h.accessTTL.Seconds()),
 	}
 
 	w.Header().Set("Content-Type", apierror.ContentTypeJSON)

--- a/internal/handler/login_test.go
+++ b/internal/handler/login_test.go
@@ -249,6 +249,10 @@ func (m *mockSessionStore) FindByRefreshToken(_ context.Context, _ string) (*ses
 	return m.found, m.findErr
 }
 
+func (m *mockSessionStore) RotateRefreshToken(_ context.Context, _ uuid.UUID, _ string) error {
+	return nil
+}
+
 func (m *mockSessionStore) Delete(_ context.Context, _ uuid.UUID) error {
 	return m.deleteErr
 }
@@ -509,6 +513,12 @@ func TestRefreshSuccess(t *testing.T) {
 	}
 	if resp.AccessToken == "" {
 		t.Error("expected non-empty access token")
+	}
+	if resp.RefreshToken == "" {
+		t.Error("expected non-empty rotated refresh token")
+	}
+	if resp.RefreshToken == "some-refresh-token" {
+		t.Error("rotated refresh token should differ from the original")
 	}
 }
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -35,6 +35,7 @@ type WithUser struct {
 type Store interface {
 	Create(ctx context.Context, userID uuid.UUID, refreshToken string, expiresAt time.Time) (*Session, error)
 	FindByRefreshToken(ctx context.Context, refreshToken string) (*Session, error)
+	RotateRefreshToken(ctx context.Context, sessionID uuid.UUID, newRefreshToken string) error
 	Delete(ctx context.Context, sessionID uuid.UUID) error
 	DeleteByUserID(ctx context.Context, userID uuid.UUID) error
 }
@@ -94,6 +95,19 @@ func (s *PGStore) FindByRefreshToken(ctx context.Context, refreshToken string) (
 		return nil, fmt.Errorf("finding session by refresh token: %w", err)
 	}
 	return &sess, nil
+}
+
+// RotateRefreshToken atomically replaces the refresh token hash for a session.
+func (s *PGStore) RotateRefreshToken(ctx context.Context, sessionID uuid.UUID, newRefreshToken string) error {
+	hash := HashToken(newRefreshToken)
+	_, err := s.pool.Exec(ctx,
+		"UPDATE sessions SET refresh_token_hash = $1 WHERE id = $2",
+		hash, sessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("rotating refresh token: %w", err)
+	}
+	return nil
 }
 
 // Delete removes a session by ID.

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -57,6 +57,13 @@ func (m *mockStore) FindByRefreshToken(ctx context.Context, refreshToken string)
 	return nil, nil
 }
 
+func (m *mockStore) RotateRefreshToken(_ context.Context, sessionID uuid.UUID, newRefreshToken string) error {
+	if sess, ok := m.sessions[sessionID]; ok {
+		sess.RefreshTokenHash = HashToken(newRefreshToken)
+	}
+	return nil
+}
+
 func (m *mockStore) Delete(ctx context.Context, sessionID uuid.UUID) error {
 	if m.deleteErr != nil {
 		return m.deleteErr


### PR DESCRIPTION
## Summary
- **HIGH security fix**: `POST /token/refresh` returned the same refresh token, allowing leaked tokens to give permanent access
- Now generates a new refresh token on each refresh and atomically rotates the hash in the database
- Old refresh tokens are immediately invalidated after use
- Response now includes `refresh_token` field with the new token

## Test plan
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues
- [x] Existing refresh test updated to verify token rotation
- [x] Session store interface updated with `RotateRefreshToken`
- [x] All mock implementations updated

Closes #124