### PR TITLE
fix: remove plaintext tokens from log output

### DIFF
--- a/internal/handler/email_verification.go
+++ b/internal/handler/email_verification.go
@@ -110,10 +110,9 @@ func (h *EmailVerificationHandler) processVerificationRequest(email string) {
 
 	// Send email
 	if !h.email.Enabled() {
-		h.logger.Warn("SMTP not configured, logging verification token",
+		h.logger.Warn("SMTP not configured — email verification token generated but cannot be delivered",
 			"user_id", user.ID,
-			"token", token,
-			"expires_at", expiresAt,
+			"token_prefix", token[:8],
 		)
 		return
 	}
@@ -147,10 +146,9 @@ func (h *EmailVerificationHandler) SendVerificationForUser(user *model.User) {
 		}
 
 		if !h.email.Enabled() {
-			h.logger.Warn("SMTP not configured, logging verification token",
+			h.logger.Warn("SMTP not configured — email verification token generated but cannot be delivered",
 				"user_id", user.ID,
-				"token", token,
-				"expires_at", expiresAt,
+				"token_prefix", token[:8],
 			)
 			return
 		}

--- a/internal/handler/password_reset.go
+++ b/internal/handler/password_reset.go
@@ -118,10 +118,9 @@ func (h *PasswordResetHandler) processResetRequest(email string) {
 
 	// Send email
 	if !h.email.Enabled() {
-		h.logger.Warn("SMTP not configured, logging reset token",
+		h.logger.Warn("SMTP not configured — password reset token generated but cannot be delivered",
 			"user_id", user.ID,
-			"token", token,
-			"expires_at", expiresAt,
+			"token_prefix", token[:8],
 		)
 		return
 	}


### PR DESCRIPTION
## Summary
- **HIGH security fix**: Password reset and email verification tokens were logged in plaintext when SMTP was not configured
- Replaced full token with 8-character prefix for debugging
- Covers all 3 locations: password reset, email verification (standalone + registration flow)

## Test plan
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues
- [x] Verified no other `"token", token` patterns remain in logs

Closes #125