### PR TITLE
perf: add composite indexes for dashboard queries

### DIFF
--- a/migrations/000031_add_dashboard_indexes.down.sql
+++ b/migrations/000031_add_dashboard_indexes.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_users_org_created;
+DROP INDEX IF EXISTS idx_audit_events_org_type_created;

--- a/migrations/000031_add_dashboard_indexes.up.sql
+++ b/migrations/000031_add_dashboard_indexes.up.sql
@@ -1,0 +1,5 @@
+-- Composite index for CountRecentUsers: filters by org_id + created_at range.
+CREATE INDEX IF NOT EXISTS idx_users_org_created ON users (org_id, created_at DESC);
+
+-- Composite index for LoginCountsByDay: filters by org_id, event_type, and created_at.
+CREATE INDEX IF NOT EXISTS idx_audit_events_org_type_created ON audit_events (org_id, event_type, created_at DESC);


### PR DESCRIPTION
## Summary
- **HIGH performance fix**: Dashboard SSE queries lacked optimal indexes, causing full table scans on large datasets
- Added `idx_users_org_created` for `CountRecentUsers` (org_id, created_at DESC)
- Added `idx_audit_events_org_type_created` for `LoginCountsByDay` (org_id, event_type, created_at DESC)
- Both use `IF NOT EXISTS` for safe re-running

## Test plan
- [x] `go build ./...` — compiles
- [x] `go test ./...` — all pass
- [x] Migration includes rollback (down migration)

Closes #128