### PR TITLE
fix: prevent consent form user_id forgery (Critical #121)

### DIFF
--- a/internal/handler/authorize.go
+++ b/internal/handler/authorize.go
@@ -367,7 +367,8 @@ func (h *AuthorizeHandler) handlePost(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			middleware.SetOAuthCSRFCookie(w, consentCSRF)
-			h.renderConsentPage(w, client, user.ID, scope, state, codeChallenge, nonce, redirectURI, consentCSRF)
+			middleware.SetConsentUserCookie(w, user.ID)
+			h.renderConsentPage(w, client, scope, state, codeChallenge, nonce, redirectURI, consentCSRF)
 			return
 		}
 	}
@@ -456,7 +457,6 @@ type consentPageData struct {
 	State             string
 	CodeChallenge     string
 	Nonce             string
-	UserID            string
 	CSRFToken         string
 	ScopeDetails      []scopeDetail
 }
@@ -476,7 +476,7 @@ var knownScopes = map[string]scopeDetail{
 
 var consentTemplate = template.Must(template.ParseFS(consentFS, "templates/consent/consent.html"))
 
-func (h *AuthorizeHandler) renderConsentPage(w http.ResponseWriter, client *model.OAuthClient, userID uuid.UUID, scope, state, codeChallenge, nonce, redirectURI, csrfToken string) {
+func (h *AuthorizeHandler) renderConsentPage(w http.ResponseWriter, client *model.OAuthClient, scope, state, codeChallenge, nonce, redirectURI, csrfToken string) {
 	var details []scopeDetail
 	for _, s := range strings.Split(scope, " ") {
 		s = strings.TrimSpace(s)
@@ -499,7 +499,6 @@ func (h *AuthorizeHandler) renderConsentPage(w http.ResponseWriter, client *mode
 		State:             state,
 		CodeChallenge:     codeChallenge,
 		Nonce:             nonce,
-		UserID:            userID.String(),
 		CSRFToken:         csrfToken,
 		ScopeDetails:      details,
 	}
@@ -534,12 +533,20 @@ func (h *AuthorizeHandler) Consent(w http.ResponseWriter, r *http.Request) {
 	state := r.FormValue("state")
 	codeChallenge := r.FormValue("code_challenge")
 	nonce := r.FormValue("nonce")
-	userIDStr := r.FormValue("user_id")
 
-	if clientID == "" || redirectURI == "" || state == "" || userIDStr == "" {
+	if clientID == "" || redirectURI == "" || state == "" {
 		h.renderError(w, http.StatusBadRequest, "Missing required parameters.")
 		return
 	}
+
+	// Read user_id from server-set HttpOnly cookie — NOT from the form.
+	// This prevents user_id forgery via hidden form field manipulation.
+	userID := middleware.GetConsentUserID(r)
+	if userID == uuid.Nil {
+		h.renderError(w, http.StatusBadRequest, "Invalid or expired consent session.")
+		return
+	}
+	middleware.ClearConsentUserCookie(w)
 
 	// If user denied consent, redirect with access_denied error
 	if consent != "allow" {
@@ -562,12 +569,6 @@ func (h *AuthorizeHandler) Consent(w http.ResponseWriter, r *http.Request) {
 	}
 	if !database.ValidateRedirectURI(client, redirectURI) {
 		h.renderError(w, http.StatusBadRequest, "Invalid redirect_uri.")
-		return
-	}
-
-	userID, err := uuid.Parse(userIDStr)
-	if err != nil {
-		h.renderError(w, http.StatusBadRequest, "Invalid user.")
 		return
 	}
 

--- a/internal/handler/authorize_test.go
+++ b/internal/handler/authorize_test.go
@@ -493,6 +493,111 @@ func TestAuthorizePostReRenderIncludesCSRFToken(t *testing.T) {
 	}
 }
 
+func TestConsentRejectsWithoutConsentCookie(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockAuthorizeStore{
+		oauthClient: newTestOAuthClient(orgID),
+	}
+	h := NewAuthorizeHandler(store, noopLogger(), nil, nil)
+
+	form := url.Values{
+		"client_id":    {"test-client"},
+		"redirect_uri": {"http://localhost:3002/callback"},
+		"scope":        {"openid"},
+		"state":        {"abc"},
+		"consent":      {"allow"},
+	}
+
+	req := newPostRequestWithCSRF(t, "/oauth/consent", form)
+	w := httptest.NewRecorder()
+
+	h.Consent(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(w.Body.String(), "Invalid or expired consent session") {
+		t.Error("expected consent session error when no cookie is present")
+	}
+}
+
+func TestConsentRejectsForgedUserID(t *testing.T) {
+	orgID := uuid.New()
+	store := &mockAuthorizeStore{
+		oauthClient: newTestOAuthClient(orgID),
+	}
+	h := NewAuthorizeHandler(store, noopLogger(), nil, nil)
+
+	form := url.Values{
+		"client_id":    {"test-client"},
+		"redirect_uri": {"http://localhost:3002/callback"},
+		"scope":        {"openid"},
+		"state":        {"abc"},
+		"consent":      {"allow"},
+		"user_id":      {uuid.New().String()}, // attacker tries to inject user_id via form
+	}
+
+	req := newPostRequestWithCSRF(t, "/oauth/consent", form)
+	w := httptest.NewRecorder()
+
+	h.Consent(w, req)
+
+	// Without the consent cookie, the handler must reject — even with user_id in form
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(w.Body.String(), "Invalid or expired consent session") {
+		t.Error("expected consent session error; form-based user_id must be ignored")
+	}
+}
+
+func TestConsentAcceptsValidCookie(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	hash, _ := auth.HashPassword("Str0ng!Pass")
+	user := &model.User{
+		ID:           userID,
+		OrgID:        orgID,
+		Username:     "testuser",
+		Email:        "test@example.com",
+		PasswordHash: []byte(hash),
+		Enabled:      true,
+	}
+	store := &mockAuthorizeStore{
+		oauthClient: newTestOAuthClient(orgID),
+		emailUser:   user,
+	}
+	h := NewAuthorizeHandler(store, noopLogger(), nil, nil)
+
+	form := url.Values{
+		"client_id":      {"test-client"},
+		"redirect_uri":   {"http://localhost:3002/callback"},
+		"scope":          {"openid"},
+		"state":          {"mystate"},
+		"code_challenge": {"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"},
+		"consent":        {"allow"},
+	}
+
+	req := newPostRequestWithCSRF(t, "/oauth/consent", form)
+	// Add the consent user cookie (simulating server-side flow)
+	req.AddCookie(&http.Cookie{Name: "rampart_consent_uid", Value: userID.String()})
+	w := httptest.NewRecorder()
+
+	h.Consent(w, req)
+
+	// Should redirect to callback with an authorization code
+	if w.Code != http.StatusFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusFound)
+	}
+	location := w.Header().Get("Location")
+	if !strings.HasPrefix(location, "http://localhost:3002/callback?code=") {
+		t.Errorf("Location = %q, want redirect to callback with code", location)
+	}
+	if !strings.Contains(location, "state=mystate") {
+		t.Error("expected state in redirect URL")
+	}
+}
+
 func TestAuthorizeGetMissingState(t *testing.T) {
 	orgID := uuid.New()
 	store := &mockAuthorizeStore{

--- a/internal/handler/templates/consent/consent.html
+++ b/internal/handler/templates/consent/consent.html
@@ -78,7 +78,7 @@
                 <input type="hidden" name="state" value="{{.State}}">
                 <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}">
                 <input type="hidden" name="nonce" value="{{.Nonce}}">
-                <input type="hidden" name="user_id" value="{{.UserID}}">
+
                 <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <input type="hidden" name="consent" value="deny">
                 <button type="submit" class="btn btn-deny">Deny</button>
@@ -90,7 +90,7 @@
                 <input type="hidden" name="state" value="{{.State}}">
                 <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}">
                 <input type="hidden" name="nonce" value="{{.Nonce}}">
-                <input type="hidden" name="user_id" value="{{.UserID}}">
+
                 <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <input type="hidden" name="consent" value="allow">
                 <button type="submit" class="btn btn-allow">Allow</button>

--- a/internal/middleware/admin_session.go
+++ b/internal/middleware/admin_session.go
@@ -250,6 +250,49 @@ func SetOAuthCSRFCookie(w http.ResponseWriter, csrfToken string) {
 	})
 }
 
+const oauthConsentUserCookie = "rampart_consent_uid"
+
+// SetConsentUserCookie stores the authenticated user's ID in an HttpOnly cookie
+// during the consent flow. This prevents user_id forgery via hidden form fields.
+func SetConsentUserCookie(w http.ResponseWriter, userID uuid.UUID) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthConsentUserCookie,
+		Value:    userID.String(),
+		Path:     "/oauth/",
+		MaxAge:   600, // 10 minutes
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   secureCookies,
+	})
+}
+
+// GetConsentUserID reads the authenticated user's ID from the consent cookie.
+// Returns uuid.Nil if the cookie is missing or invalid.
+func GetConsentUserID(r *http.Request) uuid.UUID {
+	cookie, err := r.Cookie(oauthConsentUserCookie)
+	if err != nil || cookie.Value == "" {
+		return uuid.Nil
+	}
+	id, err := uuid.Parse(cookie.Value)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
+}
+
+// ClearConsentUserCookie removes the consent user cookie.
+func ClearConsentUserCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthConsentUserCookie,
+		Value:    "",
+		Path:     "/oauth/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   secureCookies,
+	})
+}
+
 // ValidateOAuthCSRF checks the CSRF token from the form against the cookie.
 // Returns true if the tokens match.
 func ValidateOAuthCSRF(r *http.Request, formToken string) bool {


### PR DESCRIPTION
## Summary
- **CRITICAL security fix**: Replaced the hidden `user_id` form field in the OAuth consent flow with a server-side HttpOnly cookie (`rampart_consent_uid`)
- Prevents attackers from manipulating the user_id to impersonate other users during consent
- Added 3 new tests: reject without cookie, reject forged form user_id, accept valid cookie

## Changes
- `internal/middleware/admin_session.go`: Added `SetConsentUserCookie`, `GetConsentUserID`, `ClearConsentUserCookie` helpers
- `internal/handler/authorize.go`: Consent handler reads user_id from cookie instead of form; `renderConsentPage` sets cookie server-side
- `internal/handler/templates/consent/consent.html`: Removed `user_id` hidden fields from both forms
- `internal/handler/authorize_test.go`: 3 new consent forgery tests

## Test plan
- [x] `TestConsentRejectsWithoutConsentCookie` — verifies 400 when no cookie present
- [x] `TestConsentRejectsForgedUserID` — verifies form-injected user_id is ignored
- [x] `TestConsentAcceptsValidCookie` — verifies valid cookie produces redirect with auth code
- [x] Full test suite passes (`go test ./...`)
- [x] Lint clean (`golangci-lint run`)

Closes #121