### PR TITLE
fix: set CSRF cookie to HttpOnly (#132)

### DIFF
--- a/internal/middleware/admin_session.go
+++ b/internal/middleware/admin_session.go
@@ -326,7 +326,7 @@ func ensureCSRFCookie(w http.ResponseWriter, r *http.Request) {
 		Value:    tok,
 		Path:     AdminCookiePath,
 		MaxAge:   3600,
-		HttpOnly: false, // Must be readable by forms via template
+		HttpOnly: true, // Token is injected server-side via Go templates
 		SameSite: http.SameSiteLaxMode,
 		Secure:   secureCookies,
 	})

--- a/internal/middleware/admin_session_test.go
+++ b/internal/middleware/admin_session_test.go
@@ -520,8 +520,8 @@ func TestCSRFProtectSetsCSRFCookieOnGET(t *testing.T) {
 	if found == nil {
 		t.Fatal("expected CSRF cookie to be set on GET")
 	}
-	if found.HttpOnly {
-		t.Error("CSRF cookie should not be HttpOnly")
+	if !found.HttpOnly {
+		t.Error("CSRF cookie should be HttpOnly")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Set admin CSRF cookie `HttpOnly: true` since the token is injected server-side via Go templates, not read by JavaScript
- XSS could previously steal the CSRF token; now the cookie is inaccessible to client-side scripts
- Updated existing test to verify the cookie is HttpOnly

## Changes
- `internal/middleware/admin_session.go`: `ensureCSRFCookie` now sets `HttpOnly: true`
- `internal/middleware/admin_session_test.go`: Updated assertion in `TestCSRFProtectSetsCSRFCookieOnGET`

## Test plan
- [x] All middleware tests pass
- [x] Lint clean

Closes #132