### PR TITLE
fix: validate redirect_uri before consent denial redirect (#130)

### DIFF
--- a/internal/handler/authorize.go
+++ b/internal/handler/authorize.go
@@ -539,6 +539,20 @@ func (h *AuthorizeHandler) Consent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ctx := r.Context()
+
+	// Re-validate client and redirect_uri BEFORE any redirect — including denial.
+	// This prevents open-redirect attacks via unvalidated redirect_uri (see #130).
+	client, err := h.store.GetOAuthClient(ctx, clientID)
+	if err != nil || client == nil {
+		h.renderError(w, http.StatusBadRequest, "Unknown client.")
+		return
+	}
+	if !database.ValidateRedirectURI(client, redirectURI) {
+		h.renderError(w, http.StatusBadRequest, "Invalid redirect_uri.")
+		return
+	}
+
 	// Read user_id from server-set HttpOnly cookie — NOT from the form.
 	// This prevents user_id forgery via hidden form field manipulation.
 	userID := middleware.GetConsentUserID(r)
@@ -556,19 +570,6 @@ func (h *AuthorizeHandler) Consent(w http.ResponseWriter, r *http.Request) {
 			"state":             {state},
 		}
 		http.Redirect(w, r, redirectURI+"?"+params.Encode(), http.StatusFound)
-		return
-	}
-
-	ctx := r.Context()
-
-	// Re-validate client
-	client, err := h.store.GetOAuthClient(ctx, clientID)
-	if err != nil || client == nil {
-		h.renderError(w, http.StatusBadRequest, "Unknown client.")
-		return
-	}
-	if !database.ValidateRedirectURI(client, redirectURI) {
-		h.renderError(w, http.StatusBadRequest, "Invalid redirect_uri.")
 		return
 	}
 

--- a/internal/handler/authorize_test.go
+++ b/internal/handler/authorize_test.go
@@ -598,6 +598,68 @@ func TestConsentAcceptsValidCookie(t *testing.T) {
 	}
 }
 
+func TestConsentDenialWithInvalidRedirectURI(t *testing.T) {
+	orgID := uuid.New()
+	userID := uuid.New()
+	store := &mockAuthorizeStore{
+		oauthClient: newTestOAuthClient(orgID),
+	}
+	h := NewAuthorizeHandler(store, noopLogger(), nil, nil)
+
+	form := url.Values{
+		"client_id":    {"test-client"},
+		"redirect_uri": {"http://evil.example.com/phish"}, // not in registered URIs
+		"scope":        {"openid"},
+		"state":        {"abc"},
+		"consent":      {"deny"},
+	}
+
+	req := newPostRequestWithCSRF(t, "/oauth/consent", form)
+	req.AddCookie(&http.Cookie{Name: "rampart_consent_uid", Value: userID.String()})
+	w := httptest.NewRecorder()
+
+	h.Consent(w, req)
+
+	// Must NOT redirect to the unvalidated URI — should render an error page instead
+	if w.Code == http.StatusFound {
+		t.Errorf("expected error page, got redirect to %s", w.Header().Get("Location"))
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(w.Body.String(), "Invalid redirect_uri") {
+		t.Error("expected 'Invalid redirect_uri' error message")
+	}
+}
+
+func TestConsentDenialWithUnknownClient(t *testing.T) {
+	store := &mockAuthorizeStore{
+		oauthClient: nil, // client not found
+	}
+	h := NewAuthorizeHandler(store, noopLogger(), nil, nil)
+
+	form := url.Values{
+		"client_id":    {"unknown-client"},
+		"redirect_uri": {"http://evil.example.com/phish"},
+		"scope":        {"openid"},
+		"state":        {"abc"},
+		"consent":      {"deny"},
+	}
+
+	req := newPostRequestWithCSRF(t, "/oauth/consent", form)
+	req.AddCookie(&http.Cookie{Name: "rampart_consent_uid", Value: uuid.New().String()})
+	w := httptest.NewRecorder()
+
+	h.Consent(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(w.Body.String(), "Unknown client") {
+		t.Error("expected 'Unknown client' error message")
+	}
+}
+
 func TestAuthorizeGetMissingState(t *testing.T) {
 	orgID := uuid.New()
 	store := &mockAuthorizeStore{


### PR DESCRIPTION
## Summary
- Moved client + redirect_uri validation before the consent denial redirect in the OAuth consent handler
- Previously, denying consent could redirect to an unvalidated URI (phishing vector)
- Added tests for denial with invalid redirect_uri and unknown client

## Changes
- `internal/handler/authorize.go`: Reordered validation in `Consent` method
- `internal/handler/authorize_test.go`: Added `TestConsentDenialWithInvalidRedirectURI` and `TestConsentDenialWithUnknownClient`

## Test plan
- [x] All handler tests pass
- [x] Lint clean

Closes #130