### PR TITLE
fix: enforce org password policy on password reset (#131)

### DIFF
--- a/internal/handler/password_reset.go
+++ b/internal/handler/password_reset.go
@@ -30,6 +30,7 @@ type PasswordResetHandlerStore interface {
 	store.UserReader
 	store.UserWriter
 	store.PasswordResetTokenStore
+	store.OrgSettingsReadWriter
 }
 
 // PasswordResetHandler handles forgot-password and reset-password flows.
@@ -148,16 +149,39 @@ func (h *PasswordResetHandler) ResetPassword(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if len(req.NewPassword) < 8 {
-		apierror.Write(w, http.StatusBadRequest, "invalid_request", "Password must be at least 8 characters.")
-		return
-	}
-
 	ctx := r.Context()
 
 	userID, err := h.store.ConsumePasswordResetToken(ctx, req.Token)
 	if err != nil {
 		apierror.Write(w, http.StatusBadRequest, "invalid_token", "Invalid, expired, or already-used reset token.")
+		return
+	}
+
+	// Look up user to determine their organization.
+	user, err := h.store.GetUserByID(ctx, userID)
+	if err != nil || user == nil {
+		h.logger.Error("failed to find user for password policy lookup", "error", err, "user_id", userID)
+		apierror.Write(w, http.StatusInternalServerError, "server_error", "Internal server error.")
+		return
+	}
+
+	// Fetch per-org password policy (fall back to defaults if settings not found).
+	passwordPolicy := auth.DefaultPasswordPolicy()
+	if settings, sErr := h.store.GetOrgSettings(ctx, user.OrgID); sErr != nil {
+		h.logger.Warn("failed to fetch org settings for password reset, using defaults", "error", sErr)
+	} else if settings != nil {
+		passwordPolicy = auth.PasswordPolicy{
+			MinLength:        settings.PasswordMinLength,
+			RequireUppercase: settings.PasswordRequireUppercase,
+			RequireLowercase: settings.PasswordRequireLowercase,
+			RequireNumbers:   settings.PasswordRequireNumbers,
+			RequireSymbols:   settings.PasswordRequireSymbols,
+		}
+	}
+
+	// Validate new password against org policy.
+	if fe := auth.ValidatePasswordWithPolicy(req.NewPassword, passwordPolicy); fe != nil {
+		apierror.WriteValidation(w, []apierror.FieldError{{Field: fe.Field, Message: fe.Message}})
 		return
 	}
 

--- a/internal/handler/password_reset_test.go
+++ b/internal/handler/password_reset_test.go
@@ -16,9 +16,10 @@ import (
 )
 
 type mockResetStore struct {
-	user     *model.User
-	tokenErr error
-	userID   uuid.UUID
+	user        *model.User
+	tokenErr    error
+	userID      uuid.UUID
+	orgSettings *model.OrgSettings
 }
 
 func (m *mockResetStore) FindUserByEmail(_ context.Context, _ string) (*model.User, error) {
@@ -40,10 +41,22 @@ func (m *mockResetStore) UpdatePassword(_ context.Context, _ uuid.UUID, _ []byte
 	return nil
 }
 
+// ── stub methods to satisfy store.OrgSettingsReadWriter ──
+
+func (m *mockResetStore) GetOrgSettings(_ context.Context, _ uuid.UUID) (*model.OrgSettings, error) {
+	return m.orgSettings, nil
+}
+func (m *mockResetStore) UpdateOrgSettings(_ context.Context, _ uuid.UUID, _ *model.UpdateOrgSettingsRequest) (*model.OrgSettings, error) {
+	return nil, nil
+}
+
 // ── stub methods to satisfy store.UserReader ──
 
-func (m *mockResetStore) GetUserByID(_ context.Context, _ uuid.UUID) (*model.User, error) {
-	return nil, nil
+func (m *mockResetStore) GetUserByID(_ context.Context, id uuid.UUID) (*model.User, error) {
+	if m.user != nil {
+		return m.user, nil
+	}
+	return &model.User{ID: id, OrgID: uuid.New(), Enabled: true}, nil
 }
 func (m *mockResetStore) GetUserByEmail(_ context.Context, _ string, _ uuid.UUID) (*model.User, error) {
 	return nil, nil
@@ -167,6 +180,55 @@ func TestResetPasswordInvalidToken(t *testing.T) {
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestResetPasswordRejectsWeakPasswordPerOrgPolicy(t *testing.T) {
+	uid := uuid.New()
+	orgID := uuid.New()
+
+	ms := &mockResetStore{
+		userID: uid,
+		orgSettings: &model.OrgSettings{
+			OrgID:                   orgID,
+			PasswordMinLength:       12,
+			PasswordRequireUppercase: true,
+			PasswordRequireLowercase: true,
+			PasswordRequireNumbers:   true,
+			PasswordRequireSymbols:   true,
+		},
+	}
+
+	// Override GetUserByID to return a user with our specific orgID.
+	ms.user = &model.User{ID: uid, OrgID: orgID, Enabled: true}
+
+	sender := &mockEmailSender{}
+	h := NewPasswordResetHandler(ms, sender, slog.Default(), "http://localhost:8080")
+
+	tests := []struct {
+		name     string
+		password string
+		wantCode int
+	}{
+		{"too short for org policy", "Abc1!", http.StatusBadRequest},
+		{"no uppercase", "abcdefgh1234!", http.StatusBadRequest},
+		{"no digit", "Abcdefghijklm!", http.StatusBadRequest},
+		{"no symbol", "Abcdefgh1234", http.StatusBadRequest},
+		{"meets org policy", "Abcdefgh123!", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"token":"valid-token","new_password":"` + tt.password + `"}`
+			req := httptest.NewRequest(http.MethodPost, "/reset-password", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			h.ResetPassword(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("password %q: expected %d, got %d: %s", tt.password, tt.wantCode, rr.Code, rr.Body.String())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Password reset now uses `auth.ValidatePasswordWithPolicy` instead of simple `len >= 8` check
- Looks up the user's org settings to apply the correct password policy (uppercase, digits, symbols)
- Prevents users from resetting to weak passwords that bypass org policy

## Test plan
- [x] Full test suite passes
- [x] Lint clean

Closes #131