### PR TITLE
fix: require email_verified for social login auto-linking (#136)

### DIFF
--- a/internal/handler/social.go
+++ b/internal/handler/social.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -27,6 +28,11 @@ import (
 	"github.com/manimovassagh/rampart/internal/social"
 	"github.com/manimovassagh/rampart/internal/store"
 )
+
+// errSocialEmailNotVerified is returned when a social provider reports an
+// unverified email that matches an existing user account. Auto-linking is
+// refused to prevent account takeover.
+var errSocialEmailNotVerified = errors.New("social provider email is not verified")
 
 const (
 	socialCookieName   = "_rampart_social"
@@ -240,6 +246,13 @@ func (h *SocialHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	// Resolve user via account linking logic
 	user, orgID, err := h.resolveUser(ctx, r, providerName, userInfo)
 	if err != nil {
+		if errors.Is(err, errSocialEmailNotVerified) {
+			h.logger.Warn("social login blocked: email not verified at provider", "provider", providerName, "email", userInfo.Email)
+			h.audit.Log(ctx, r, uuid.Nil, model.EventSocialLoginFailed, nil, "", "social", "", providerName, map[string]any{"reason": "email_not_verified", "provider": providerName})
+			metrics.AuthTotal.WithLabelValues("failure").Inc()
+			http.Error(w, "Your email address has not been verified by the social provider. Please verify your email and try again.", http.StatusForbidden)
+			return
+		}
 		h.logger.Error("failed to resolve social user", "error", err)
 		http.Error(w, msgUnexpectedErr, http.StatusInternalServerError)
 		return
@@ -312,6 +325,14 @@ func (h *SocialHandler) resolveUser(ctx context.Context, r *http.Request, provid
 	}
 
 	if user != nil {
+		// Prevent account takeover: only auto-link when the social provider
+		// has verified the email address. Without this check an attacker
+		// could register with a victim's email at a provider that does not
+		// verify emails and gain access to the victim's account.
+		if !userInfo.EmailVerified {
+			return nil, uuid.Nil, errSocialEmailNotVerified
+		}
+
 		// Link social account to existing user
 		socialAccount := &model.SocialAccount{
 			UserID:         user.ID,

--- a/internal/handler/social_test.go
+++ b/internal/handler/social_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -710,6 +711,160 @@ func TestSocialCallbackNewUserHasNonEmptyPasswordHash(t *testing.T) {
 	}
 	if !strings.HasPrefix(string(st.capturedUser.PasswordHash), "$argon2id$") {
 		t.Errorf("PasswordHash = %q, want argon2id-formatted hash", string(st.capturedUser.PasswordHash))
+	}
+}
+
+// mockExchangeProvider returns configurable UserInfo from Exchange.
+type mockExchangeProvider struct {
+	name     string
+	userInfo *social.UserInfo
+	err      error
+}
+
+func (p *mockExchangeProvider) Name() string { return p.name }
+func (p *mockExchangeProvider) AuthURL(state, redirectURL string) string {
+	return "https://provider.example.com/auth?state=" + state
+}
+func (p *mockExchangeProvider) Exchange(_ context.Context, _, _ string) (*social.UserInfo, error) {
+	return p.userInfo, p.err
+}
+
+func TestResolveUser_UnverifiedEmail_NoAutoLink(t *testing.T) {
+	orgID := uuid.New()
+	existingUser := &model.User{
+		ID:       uuid.New(),
+		OrgID:    orgID,
+		Username: "victim",
+		Email:    "victim@example.com",
+		Enabled:  true,
+	}
+
+	store := &mockSocialStore{
+		defaultOrgID: orgID,
+		emailUser:    existingUser, // existing user with this email
+	}
+
+	reg := social.NewRegistry()
+	h := NewSocialHandler(store, reg, noopLogger(), nil, []byte("test-hmac-key"), "http://localhost:8080")
+
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+
+	// Attempt to resolve with an UNVERIFIED email that matches an existing user.
+	userInfo := &social.UserInfo{
+		ProviderUserID: "attacker-123",
+		Email:          "victim@example.com",
+		EmailVerified:  false,
+		Name:           "Attacker",
+	}
+
+	_, _, err := h.resolveUser(r.Context(), r, "evil-provider", userInfo)
+	if !errors.Is(err, errSocialEmailNotVerified) {
+		t.Fatalf("expected errSocialEmailNotVerified, got: %v", err)
+	}
+}
+
+func TestResolveUser_VerifiedEmail_AutoLinks(t *testing.T) {
+	orgID := uuid.New()
+	existingUser := &model.User{
+		ID:       uuid.New(),
+		OrgID:    orgID,
+		Username: "alice",
+		Email:    "alice@example.com",
+		Enabled:  true,
+	}
+
+	store := &mockSocialStore{
+		defaultOrgID: orgID,
+		emailUser:    existingUser, // existing user with this email
+	}
+
+	reg := social.NewRegistry()
+	h := NewSocialHandler(store, reg, noopLogger(), nil, []byte("test-hmac-key"), "http://localhost:8080")
+
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+
+	userInfo := &social.UserInfo{
+		ProviderUserID: "alice-google-123",
+		Email:          "alice@example.com",
+		EmailVerified:  true,
+		Name:           "Alice",
+	}
+
+	user, returnedOrgID, err := h.resolveUser(r.Context(), r, "google", userInfo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user.ID != existingUser.ID {
+		t.Fatalf("expected user ID %s, got %s", existingUser.ID, user.ID)
+	}
+	if returnedOrgID != orgID {
+		t.Fatalf("expected org ID %s, got %s", orgID, returnedOrgID)
+	}
+}
+
+func TestCallback_UnverifiedEmail_Returns403(t *testing.T) {
+	orgID := uuid.New()
+	existingUser := &model.User{
+		ID:       uuid.New(),
+		OrgID:    orgID,
+		Username: "victim",
+		Email:    "victim@example.com",
+		Enabled:  true,
+	}
+
+	store := &mockSocialStore{
+		oauthClient:  newSocialTestOAuthClient(orgID),
+		defaultOrgID: orgID,
+		emailUser:    existingUser,
+	}
+
+	provider := &mockExchangeProvider{
+		name: "evil-provider",
+		userInfo: &social.UserInfo{
+			ProviderUserID: "attacker-456",
+			Email:          "victim@example.com",
+			EmailVerified:  false,
+			Name:           "Attacker",
+		},
+	}
+
+	reg := social.NewRegistry()
+	reg.Register(provider)
+
+	hmacKey := []byte("test-hmac-key")
+	h := NewSocialHandler(store, reg, noopLogger(), nil, hmacKey, "http://localhost:8080")
+
+	// Build a valid signed cookie
+	payload := socialCookiePayload{
+		ClientID:      "test-client",
+		RedirectURI:   "http://localhost:3002/callback",
+		Scope:         "openid",
+		State:         "original-state",
+		CodeChallenge: "challenge",
+		ProviderState: "provider-state-abc",
+	}
+	cookieValue, err := h.signCookiePayload(&payload)
+	if err != nil {
+		t.Fatalf("failed to sign cookie: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Get("/oauth/social/{provider}/callback", h.Callback)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/social/evil-provider/callback?code=authcode&state=provider-state-abc", http.NoBody)
+	req.AddCookie(&http.Cookie{
+		Name:  socialCookieName,
+		Value: cookieValue,
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403 Forbidden, got %d; body: %s", w.Code, w.Body.String())
+	}
+
+	if !strings.Contains(w.Body.String(), "not been verified") {
+		t.Fatalf("expected body to mention email not verified, got: %s", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Social login now requires `email_verified == true` before auto-linking to an existing account
- Prevents account takeover via unverified social provider email
- Returns error if social provider email is not verified

## Test plan
- [x] Full test suite passes
- [x] Lint clean

Closes #136