### PR TITLE
fix: HTML-escape user names in email templates (#137)

### DIFF
--- a/internal/handler/email_verification.go
+++ b/internal/handler/email_verification.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"html"
 	"log/slog"
 	"net/http"
 	"time"
@@ -200,6 +201,7 @@ func buildVerificationEmail(name, verifyURL string) string {
 	if name == "" {
 		name = "there"
 	}
+	name = html.EscapeString(name)
 	return `<!DOCTYPE html>
 <html>
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">

--- a/internal/handler/email_verification_test.go
+++ b/internal/handler/email_verification_test.go
@@ -178,6 +178,37 @@ func TestSendVerification_AlwaysReturns200(t *testing.T) {
 	}
 }
 
+func TestBuildVerificationEmail_HTMLEscapesName(t *testing.T) {
+	body := buildVerificationEmail(`<script>alert("xss")</script>`, "https://example.com/verify?token=abc")
+
+	if strings.Contains(body, "<script>") {
+		t.Fatal("expected <script> tag to be HTML-escaped, but found raw <script> in email body")
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Fatal("expected HTML-escaped name (&lt;script&gt;) in email body")
+	}
+	if !strings.Contains(body, "Hi &lt;script&gt;") {
+		t.Fatal("expected escaped name after 'Hi ' greeting")
+	}
+}
+
+func TestBuildVerificationEmail_NormalNameUnchanged(t *testing.T) {
+	body := buildVerificationEmail("Alice", "https://example.com/verify?token=abc")
+	if !strings.Contains(body, "Hi Alice,") {
+		t.Fatal("expected normal name to appear unchanged in email body")
+	}
+}
+
+func TestBuildVerificationEmail_AmpersandEscaped(t *testing.T) {
+	body := buildVerificationEmail("Tom & Jerry", "https://example.com/verify?token=abc")
+	if strings.Contains(body, "Tom & Jerry") {
+		t.Fatal("expected ampersand to be escaped")
+	}
+	if !strings.Contains(body, "Tom &amp; Jerry") {
+		t.Fatal("expected &amp; in email body")
+	}
+}
+
 func TestSendVerification_MissingEmail(t *testing.T) {
 	h := NewEmailVerificationHandler(&mockEmailVerificationStore{}, &noopEmailSender{}, noopLogger(), "http://localhost")
 

--- a/internal/handler/password_reset.go
+++ b/internal/handler/password_reset.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"html"
 	"log/slog"
 	"net/http"
 	"time"
@@ -213,6 +214,7 @@ func buildResetEmail(name, resetURL string) string {
 	if name == "" {
 		name = "there"
 	}
+	name = html.EscapeString(name)
 	return `<!DOCTYPE html>
 <html>
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">

--- a/internal/handler/password_reset_test.go
+++ b/internal/handler/password_reset_test.go
@@ -232,6 +232,37 @@ func TestResetPasswordRejectsWeakPasswordPerOrgPolicy(t *testing.T) {
 	}
 }
 
+func TestBuildResetEmail_HTMLEscapesName(t *testing.T) {
+	body := buildResetEmail(`<script>alert("xss")</script>`, "https://example.com/reset?token=abc")
+
+	if strings.Contains(body, "<script>") {
+		t.Fatal("expected <script> tag to be HTML-escaped, but found raw <script> in email body")
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Fatal("expected HTML-escaped name (&lt;script&gt;) in email body")
+	}
+	if !strings.Contains(body, "Hi &lt;script&gt;") {
+		t.Fatal("expected escaped name after 'Hi ' greeting")
+	}
+}
+
+func TestBuildResetEmail_NormalNameUnchanged(t *testing.T) {
+	body := buildResetEmail("Alice", "https://example.com/reset?token=abc")
+	if !strings.Contains(body, "Hi Alice,") {
+		t.Fatal("expected normal name to appear unchanged in email body")
+	}
+}
+
+func TestBuildResetEmail_AmpersandEscaped(t *testing.T) {
+	body := buildResetEmail("Tom & Jerry", "https://example.com/reset?token=abc")
+	if strings.Contains(body, "Tom & Jerry") {
+		t.Fatal("expected ampersand to be escaped")
+	}
+	if !strings.Contains(body, "Tom &amp; Jerry") {
+		t.Fatal("expected &amp; in email body")
+	}
+}
+
 var errInvalidToken = &resetError{"invalid token"}
 
 type resetError struct{ msg string }


### PR DESCRIPTION
## Summary
- HTML-escape user's `GivenName` before embedding in password reset and email verification HTML emails
- Prevents potential XSS via script tags in email clients
- Added tests verifying `<script>` tags and `&` are properly escaped

## Test plan
- [x] All handler tests pass
- [x] Lint clean

Closes #137