### PR TITLE
fix: reduce authorization code TTL to 60s per RFC 6749 (#138)

### DIFF
--- a/internal/handler/admin_login_test.go
+++ b/internal/handler/admin_login_test.go
@@ -317,7 +317,7 @@ func TestAdminCallbackClientIDMismatch(t *testing.T) {
 			OrgID:         uuid.New(),
 			RedirectURI:   testIssuer + "/admin/callback",
 			CodeChallenge: "test-challenge",
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 	}
 	sessions := &mockSessionStore{}
@@ -348,7 +348,7 @@ func TestAdminCallbackRedirectURIMismatch(t *testing.T) {
 			OrgID:         uuid.New(),
 			RedirectURI:   "http://wrong.example.com/callback",
 			CodeChallenge: "test-challenge",
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 	}
 	sessions := &mockSessionStore{}
@@ -383,7 +383,7 @@ func TestAdminCallbackPKCEFailure(t *testing.T) {
 			OrgID:         uuid.New(),
 			RedirectURI:   testIssuer + "/admin/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 	}
 	sessions := &mockSessionStore{}
@@ -417,7 +417,7 @@ func TestAdminCallbackUserNotFound(t *testing.T) {
 			OrgID:         uuid.New(),
 			RedirectURI:   testIssuer + "/admin/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 		userByID: nil,
 	}
@@ -454,7 +454,7 @@ func TestAdminCallbackDisabledUser(t *testing.T) {
 			OrgID:         user.OrgID,
 			RedirectURI:   testIssuer + "/admin/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 		userByID: user,
 	}
@@ -490,7 +490,7 @@ func TestAdminCallbackSuccess(t *testing.T) {
 			OrgID:         user.OrgID,
 			RedirectURI:   testIssuer + "/admin/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 		userByID: user,
 	}

--- a/internal/handler/authorize.go
+++ b/internal/handler/authorize.go
@@ -30,7 +30,7 @@ var loginThemeFS embed.FS
 var consentFS embed.FS
 
 const (
-	authCodeTTL       = 10 * time.Minute
+	authCodeTTL       = 60 * time.Second
 	scopeOpenID       = "openid"
 	themeDefault      = "default"
 	themeDark         = "dark"

--- a/internal/handler/token_test.go
+++ b/internal/handler/token_test.go
@@ -176,7 +176,7 @@ func TestTokenWrongClientID(t *testing.T) {
 			OrgID:         orgID,
 			RedirectURI:   "http://localhost:3002/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 	}
 	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
@@ -207,7 +207,7 @@ func TestTokenWrongRedirectURI(t *testing.T) {
 			OrgID:         orgID,
 			RedirectURI:   "http://localhost:3002/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 	}
 	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
@@ -239,7 +239,7 @@ func TestTokenWrongCodeVerifier(t *testing.T) {
 			OrgID:         orgID,
 			RedirectURI:   "http://localhost:3002/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 	}
 	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
@@ -288,7 +288,7 @@ func TestTokenValidExchange(t *testing.T) {
 			OrgID:         orgID,
 			RedirectURI:   "http://localhost:3002/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 		userByID: user,
 	}
@@ -430,7 +430,7 @@ func TestTokenUserDisabledAfterCodeExchange(t *testing.T) {
 			OrgID:         orgID,
 			RedirectURI:   "http://localhost:3002/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 		userByID: disabledUser,
 	}
@@ -470,7 +470,7 @@ func TestTokenUserNotFoundAfterCodeExchange(t *testing.T) {
 			OrgID:         orgID,
 			RedirectURI:   "http://localhost:3002/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 		userByID: nil, // user deleted between auth and token exchange
 	}
@@ -502,7 +502,7 @@ func TestTokenUserFetchError(t *testing.T) {
 			OrgID:         orgID,
 			RedirectURI:   "http://localhost:3002/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 		userByIDErr: fmt.Errorf("db error"),
 	}
@@ -543,7 +543,7 @@ func TestTokenSessionCreateError(t *testing.T) {
 			OrgID:         orgID,
 			RedirectURI:   "http://localhost:3002/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 		userByID: user,
 	}
@@ -585,7 +585,7 @@ func TestTokenWithOrgSettings(t *testing.T) {
 			OrgID:         orgID,
 			RedirectURI:   "http://localhost:3002/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 		userByID: user,
 		orgSettings: &model.OrgSettings{
@@ -644,7 +644,7 @@ func TestTokenWithAdminClientIncludesAdminRole(t *testing.T) {
 			OrgID:         orgID,
 			RedirectURI:   "http://localhost:3002/callback",
 			CodeChallenge: challenge,
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 		userByID: user,
 		roles:    []string{"admin", "user"},
@@ -757,7 +757,7 @@ func TestTokenValidExchangeReturnsIDToken(t *testing.T) {
 			RedirectURI:   "http://localhost:3002/callback",
 			CodeChallenge: challenge,
 			Scope:         "openid",
-			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			ExpiresAt:     time.Now().Add(60 * time.Second),
 		},
 		userByID: user,
 	}


### PR DESCRIPTION
## Summary
- Reduced `authCodeTTL` from 10 minutes to 60 seconds per RFC 6749 recommendation
- Defense in depth — PKCE mitigates code interception but shorter TTL is better
- Updated 17 test references to match new TTL

## Test plan
- [x] All handler tests pass
- [x] Lint clean

Closes #138