### PR TITLE
docs: professional tone in competitor comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ## Why Rampart
 
-Most IAM solutions are either **too complex** to self-host or **too limited** to use in production. Rampart is different — it ships as a **single Go binary** that gives you a complete identity platform out of the box. No microservice sprawl, no JVM overhead, no vendor lock-in.
+Rampart ships as a **single Go binary** that gives you a complete identity platform out of the box. Lightweight, easy to deploy, and designed for both simplicity and production-grade security.
 
 Deploy it on Docker, bare metal, or Kubernetes — and get OAuth 2.0, OpenID Connect, MFA, RBAC, and a built-in admin console in under a minute.
 

--- a/docs-site/docs/comparison/vs-keycloak.md
+++ b/docs-site/docs/comparison/vs-keycloak.md
@@ -1,12 +1,14 @@
 ---
 sidebar_position: 1
 title: Rampart vs Keycloak
-description: Detailed comparison between Rampart and Keycloak — resource usage, deployment, extensibility, and migration considerations.
+description: A fair comparison between Rampart and Keycloak — resource usage, deployment, extensibility, and trade-offs.
 ---
 
 # Rampart vs Keycloak
 
-Keycloak is the most widely deployed open-source IAM server. Built on Java and WildFly (now Quarkus), it has been the default choice for organizations needing self-hosted identity management since 2014. Rampart aims to provide the same comprehensive feature set with a fundamentally more efficient and maintainable architecture.
+Keycloak is one of the most widely deployed open-source IAM servers, with over 10 years of production use. Rampart takes a different architectural approach — a single Go binary with PostgreSQL — optimizing for simplicity and resource efficiency.
+
+Both are excellent choices depending on your requirements. This page offers a factual comparison to help you decide.
 
 ## Comparison Table
 
@@ -18,11 +20,11 @@ Keycloak is the most widely deployed open-source IAM server. Built on Java and W
 | **Binary size** | ~20 MB single binary | 200+ MB (with dependencies) |
 | **Deployment** | Single binary, Docker, or systemd | Docker, Kubernetes, or application server |
 | **Database** | PostgreSQL | PostgreSQL, MySQL, Oracle, MSSQL |
-| **Admin UI** | React + Vite + Tailwind (modern SPA) | FreeMarker templates (legacy) → React (v22+, ongoing migration) |
-| **Login UI** | React SPA, CSS variable themes | FreeMarker templates |
-| **Theming** | CSS variables, instant switching | FreeMarker template overrides, server restart often required |
-| **Configuration** | YAML + REST API (GitOps-friendly) | Admin console, CLI, partial REST API |
-| **Extension model** | Plugin system (planned) | Java SPIs (requires Java knowledge, repackaging) |
+| **Admin UI** | React + Vite + Tailwind | React (PatternFly, v22+) |
+| **Login UI** | React SPA with CSS variable themes | FreeMarker templates |
+| **Theming** | CSS variables, instant switching | FreeMarker template overrides |
+| **Configuration** | Environment variables + REST API | Admin console, CLI, REST API |
+| **Extension model** | Plugin system (planned) | Java SPIs |
 | **Protocol support** | OAuth 2.0, OIDC, SAML (planned) | OAuth 2.0, OIDC, SAML, LDAP, Kerberos |
 | **Multi-tenancy** | Built-in (organizations) | Realms |
 | **License** | AGPL-3.0 | Apache 2.0 |
@@ -30,25 +32,17 @@ Keycloak is the most widely deployed open-source IAM server. Built on Java and W
 
 ## Resource Usage
 
-Keycloak's JVM-based architecture carries inherent overhead. Even a minimal Keycloak deployment requires significant memory allocation for the JVM heap, class loading, and garbage collection.
-
-```
-Idle Memory Comparison (approximate):
-
-Rampart:    ████ 30 MB
-Keycloak:   ████████████████████████████████████████████████████ 512 MB+
-```
+Go's compiled nature and lightweight goroutine model result in lower memory and faster startup compared to JVM-based servers.
 
 | Metric | Rampart | Keycloak |
 |--------|---------|----------|
 | Idle memory | ~30 MB | 512 MB – 1 GB |
-| Per-request overhead | Minimal (goroutines: ~8 KB each) | Significant (thread pools, GC pressure) |
 | Cold start | < 1 second | 10–30 seconds |
 | Docker image size | ~25 MB | ~400 MB |
 
-This difference matters for edge deployments, multi-tenant hosting, development environments, and CI/CD pipelines where fast startup and low overhead directly reduce cost and iteration time.
+This difference is most relevant for edge deployments, development environments, CI/CD pipelines, and multi-tenant hosting where resource efficiency matters.
 
-## Deployment Complexity
+## Deployment
 
 ### Rampart
 
@@ -56,72 +50,47 @@ This difference matters for edge deployments, multi-tenant hosting, development 
 # Option 1: Download and run
 curl -L https://github.com/manimovassagh/rampart/releases/latest/download/rampart-linux-amd64 -o rampart
 chmod +x rampart
-./rampart serve --config rampart.yaml
+./rampart serve
 
 # Option 2: Docker
 docker run -p 8080:8080 rampart/rampart:latest
 ```
 
-Single binary. No runtime dependencies beyond PostgreSQL and Redis. No JVM, no application server, no classpath management.
+Single binary with PostgreSQL as the only external dependency.
 
 ### Keycloak
 
-Keycloak requires a Java runtime, a database, and typically a reverse proxy. Production deployments involve configuring JVM heap sizes, GC tuning, clustering via Infinispan, and managing the Quarkus/WildFly runtime. Kubernetes deployments use the Keycloak Operator, which adds another layer of complexity.
+Keycloak requires a Java runtime and a database. Production deployments typically involve JVM tuning, clustering configuration via Infinispan, and a reverse proxy. Kubernetes deployments can use the Keycloak Operator.
 
-## Admin UI
+## Where Keycloak Excels
 
-Keycloak's admin console was historically built on AngularJS and FreeMarker templates. The Keycloak team has been migrating to React (PatternFly) since version 19, but the migration is ongoing and the developer experience reflects the transition.
+Keycloak has significant strengths:
 
-Rampart's admin UI is built from scratch with React, Vite, and Tailwind CSS. It is a modern single-page application with fast build times, hot module replacement during development, and a responsive design. The UI is embedded in the Go binary — no separate frontend deployment.
-
-## Login Page Theming
-
-Keycloak's theming system is one of its most frequently cited pain points. Customizing login pages requires:
-
-1. Creating FreeMarker template overrides
-2. Understanding Keycloak's template variable model
-3. Packaging themes into a JAR or Docker image layer
-4. Restarting the server to apply changes
-
-Rampart uses CSS variable-based themes. Admins select from built-in themes or create custom themes through the admin dashboard. Theme changes take effect immediately without server restarts. The login UI is a React SPA that reads theme configuration from the server and applies CSS variables at runtime.
-
-## Extensibility
-
-| Extension Type | Rampart | Keycloak |
-|---------------|---------|----------|
-| Custom auth flows | Plugin system (planned) | Java SPIs (AuthenticatorFactory) |
-| Custom user storage | Plugin system (planned) | Java SPIs (UserStorageProvider) |
-| Event listeners | Webhooks + plugins (planned) | Java SPIs (EventListenerProvider) |
-| Custom endpoints | REST API extension (planned) | Java SPIs (RealmResourceProvider) |
-
-Keycloak's SPI (Service Provider Interface) system is powerful but requires Java development skills, compiling against Keycloak's internal APIs, and repackaging the server. API changes between Keycloak versions frequently break extensions.
-
-Rampart's plugin system (planned) will support Go plugins, webhooks for event-driven integrations, and potentially WASM-based extensions for language-agnostic customization.
-
-## Where Keycloak Wins
-
-Keycloak has meaningful advantages that should be acknowledged:
-
-- **Maturity.** 10+ years of production use across thousands of organizations. Edge cases, bugs, and security issues have been discovered and fixed at scale.
-- **Protocol breadth.** Native SAML 2.0, LDAP/AD integration, Kerberos support. Rampart's SAML and LDAP support is planned but not yet available.
-- **Database flexibility.** Keycloak supports PostgreSQL, MySQL, Oracle, and MSSQL. Rampart currently supports PostgreSQL only.
-- **Ecosystem.** Extensive documentation, community themes, third-party integrations, commercial support from Red Hat.
+- **Maturity.** 10+ years of production use across thousands of organizations. Edge cases and security issues have been discovered and addressed at scale.
+- **Protocol breadth.** Native SAML 2.0, LDAP/AD integration, and Kerberos support. Rampart's SAML support is planned but not yet available.
+- **Database flexibility.** Supports PostgreSQL, MySQL, Oracle, and MSSQL. Rampart currently supports PostgreSQL only.
+- **Ecosystem.** Extensive documentation, community themes, third-party integrations, and commercial support from Red Hat.
 - **Certification.** Keycloak is OIDC certified. Rampart aims for certification but has not yet achieved it.
+- **Extension system.** Keycloak's SPI system is mature and powerful for organizations with Java expertise.
+
+## Where Rampart Excels
+
+- **Resource efficiency.** Significantly lower memory and faster startup.
+- **Deployment simplicity.** Single binary, minimal configuration.
+- **Theming.** CSS variable-based themes with instant switching, no server restart needed.
+- **Modern stack.** Go backend, React admin UI, built-in observability with Prometheus metrics.
 
 ## Migration Considerations
 
-Organizations considering a migration from Keycloak to Rampart should evaluate:
+Organizations considering a migration should evaluate:
 
 1. **Feature gap analysis.** Verify that all protocols and features in use are supported by Rampart. SAML, LDAP, and Kerberos are not yet available.
-2. **User migration.** Rampart will provide tooling to import users from Keycloak exports. Password hashes may need re-hashing depending on the algorithm Keycloak was configured to use.
-3. **Client reconfiguration.** OAuth 2.0/OIDC clients will need to be re-registered in Rampart. The standard protocol endpoints may differ in URL structure.
-4. **Theme migration.** FreeMarker themes cannot be reused. Rampart's CSS variable system requires different customization, but the migration is typically simpler.
-5. **Extension migration.** Java SPIs must be reimplemented using Rampart's extension mechanisms.
-
-A detailed migration guide will be published when Rampart reaches feature parity for core OAuth 2.0/OIDC flows.
+2. **User migration.** Rampart will provide tooling to import users. Password hashes may need re-hashing depending on the configured algorithm.
+3. **Client reconfiguration.** OAuth 2.0/OIDC clients will need to be re-registered. Standard protocol endpoints may differ in URL structure.
+4. **Theme migration.** Rampart's CSS variable system is different from FreeMarker templates but typically simpler to set up.
 
 ## Summary
 
-Rampart is the right choice if you want a lightweight, modern IAM server that is easy to deploy, easy to theme, and efficient with resources. Keycloak is the safer choice today if you need battle-tested maturity, SAML/LDAP support, or Red Hat enterprise backing.
+Rampart is a strong choice if you value lightweight deployment, low resource usage, and a modern developer experience. Keycloak is the proven choice if you need broad protocol support (SAML, LDAP, Kerberos), extensive ecosystem integrations, or enterprise backing from Red Hat.
 
-As Rampart matures, the feature gap narrows while the architectural advantages remain permanent.
+Both projects serve the open-source IAM community well, and the right choice depends on your specific requirements.

--- a/docs-site/docs/getting-started/config-export.md
+++ b/docs-site/docs/getting-started/config-export.md
@@ -161,8 +161,6 @@ The seed file is applied once when the organization does not yet exist. Subseque
 | Sessions | No | Sessions are instance-specific |
 | Audit logs | No | Logs are append-only and instance-specific |
 
-## Comparison with Keycloak
+## Export Design
 
-Keycloak's realm export is notoriously fragile and does not include all configuration. It requires a running server, often misses client secrets and federated identity config, and the import can fail silently on version mismatches.
-
-**Rampart exports everything in one clean JSON file.** The format is stable, human-readable, and version-controlled. Import is deterministic — it either succeeds fully or returns clear errors.
+Rampart exports everything in one clean JSON file. The format is stable, human-readable, and version-controlled. Import is deterministic — it either succeeds fully or returns clear errors.

--- a/docs-site/docs/getting-started/login-themes.md
+++ b/docs-site/docs/getting-started/login-themes.md
@@ -130,15 +130,6 @@ curl -X PUT https://rampart.example.com/api/v1/admin/organizations/{org_id}/sett
   }'
 ```
 
-## Comparison with Keycloak
+## Theming Approach
 
-In Keycloak, theming the login page requires:
-
-1. Writing FreeMarker `.ftl` templates
-2. Packaging them into a JAR or WAR overlay
-3. Deploying the overlay to the server
-4. Restarting the server to pick up changes
-
-This process is widely cited as one of Keycloak's biggest pain points.
-
-**In Rampart, it is one API call.** Pick a built-in theme, set your logo and colors, and you are done. For deeper customization, override CSS variables — no server restart, no template language, no build step.
+Rampart makes theming simple — pick a built-in theme, set your logo and colors, and you are done. For deeper customization, override CSS variables. No server restart, no template language, no build step required.

--- a/docs-site/docs/intro.md
+++ b/docs-site/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: Introduction
-description: Rampart is a lightweight, modern identity and access management server — an open-source alternative to Keycloak built with Go, PostgreSQL, and Redis.
+description: Rampart is a lightweight, modern identity and access management server built with Go and PostgreSQL.
 ---
 
 # Introduction
@@ -28,7 +28,7 @@ Built in Go with PostgreSQL and Redis, Rampart starts in under 1 second and runs
 
 - **Application developers** who need authentication and authorization without building it from scratch
 - **Platform teams** who want a self-hosted identity provider that is easy to deploy and operate
-- **Organizations** migrating away from Keycloak or other heavyweight IAM solutions
+- **Organizations** looking for a lightweight, self-hosted IAM solution
 - **Startups** that need production-grade auth from day one without the operational overhead
 
 ## How It Compares

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -4,7 +4,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'Rampart',
-  tagline: 'Modern Identity & Access Management — the lightweight Keycloak alternative',
+  tagline: 'Modern Identity & Access Management — lightweight, fast, and easy to deploy',
   favicon: 'img/favicon.ico',
   future: { v4: true },
 

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -368,7 +368,7 @@ function CTASection(): React.JSX.Element {
           marginBottom: '1rem',
           lineHeight: 1.2,
         }}>
-        Ready to ditch{' '}
+        Get Started with{' '}
         <span
           style={{
             background: 'linear-gradient(135deg, #8b5cf6, #ec4899)',
@@ -376,9 +376,8 @@ function CTASection(): React.JSX.Element {
             WebkitTextFillColor: 'transparent',
             backgroundClip: 'text',
           }}>
-          Keycloak
+          Rampart
         </span>
-        ?
       </h2>
       <p
         style={{
@@ -387,7 +386,7 @@ function CTASection(): React.JSX.Element {
           marginBottom: '2rem',
           lineHeight: 1.6,
         }}>
-        Deploy Rampart in under a minute. One binary, no JVM, no YAML nightmares.
+        Deploy in under a minute. One binary, simple configuration, production-ready.
       </p>
       <div style={{display: 'flex', gap: '1rem', justifyContent: 'center', flexWrap: 'wrap'}}>
         <Link
@@ -423,7 +422,7 @@ export default function Home(): React.JSX.Element {
   return (
     <Layout
       title={`${siteConfig.title} - Modern IAM Server`}
-      description="Modern, lightweight identity and access management server. The open-source Keycloak alternative with OAuth 2.0, OIDC, single binary deployment, and beautiful admin UI.">
+      description="Modern, lightweight identity and access management server with OAuth 2.0, OIDC, single binary deployment, and beautiful admin UI.">
       <main>
         <HeroSection />
         <MetricsSection />


### PR DESCRIPTION
## Summary
- Removed "Ready to ditch Keycloak?" and similar attack-style copy
- Rewrote vs-keycloak comparison page to be balanced and factual
- Acknowledge Keycloak's strengths (maturity, protocol breadth, ecosystem)
- Removed harsh language from config-export, login-themes, intro docs
- Updated tagline to focus on Rampart's strengths, not competitor weaknesses
- Updated README "Why Rampart" section to be positive rather than comparative

## Test plan
- [x] No code changes — docs only
- [x] Verified no harsh/unprofessional language remains