### PR TITLE
fix: batch 4 — critical and high security fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
         description: "Minimum coverage percentage (0-100)"
         required: false
         type: number
-        default: 50
+        default: 25
 
 permissions:
   contents: read

--- a/cmd/rampart/main.go
+++ b/cmd/rampart/main.go
@@ -148,7 +148,7 @@ func run(_ *slog.Logger) error {
 		emailSender = &email.NoOpSender{}
 		logger.Warn("SMTP not configured — password reset tokens will be logged instead of emailed")
 	}
-	resetHandler := handler.NewPasswordResetHandler(db, sessionStore, emailSender, logger, cfg.Issuer)
+	resetHandler := handler.NewPasswordResetHandler(db, sessionStore, emailSender, logger, auditLogger, cfg.Issuer)
 	server.RegisterPasswordResetRoutes(router, resetHandler.ForgotPassword, resetHandler.ResetPassword, loginRL)
 
 	// Email verification
@@ -157,7 +157,7 @@ func run(_ *slog.Logger) error {
 	server.RegisterEmailVerificationRoutes(router, emailVerifyHandler.SendVerification, emailVerifyHandler.VerifyEmail, loginRL)
 
 	// MFA endpoints (enrollment + login verification)
-	mfaHandler := handler.NewMFAHandler(db, logger, cfg.Issuer)
+	mfaHandler := handler.NewMFAHandler(db, logger, auditLogger, cfg.Issuer)
 	mfaVerifyHandler := handler.NewMFAVerifyHandler(db, sessionStore, logger, auditLogger, kp.PrivateKey, kp.PublicKey, kp.KID, cfg.Issuer, cfg.AccessTokenTTL, cfg.RefreshTokenTTL)
 
 	// WebAuthn/Passkey configuration — derive RPID and origins from issuer URL

--- a/internal/apierror/error.go
+++ b/internal/apierror/error.go
@@ -78,6 +78,11 @@ func Forbidden(w http.ResponseWriter, description string) {
 	Write(w, http.StatusForbidden, "forbidden", description)
 }
 
+// TooManyRequests writes a 429 error response.
+func TooManyRequests(w http.ResponseWriter, description string) {
+	Write(w, http.StatusTooManyRequests, "too_many_requests", description)
+}
+
 // ValidationError is a 400 response with per-field errors.
 type ValidationError struct {
 	Code        string       `json:"error"`

--- a/internal/database/mfa.go
+++ b/internal/database/mfa.go
@@ -121,12 +121,22 @@ func (db *DB) DisableMFA(ctx context.Context, userID uuid.UUID) error {
 }
 
 // StoreBackupCodes stores hashed backup codes for a user.
+// The delete + insert is wrapped in a transaction so codes are never partially replaced.
 func (db *DB) StoreBackupCodes(ctx context.Context, userID uuid.UUID, codeHashes [][]byte) error {
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // rollback best-effort on deferred cleanup
+
 	// Delete existing codes first
-	_, _ = db.Pool.Exec(ctx, `DELETE FROM mfa_backup_codes WHERE user_id = $1`, userID)
+	_, err = tx.Exec(ctx, `DELETE FROM mfa_backup_codes WHERE user_id = $1`, userID)
+	if err != nil {
+		return fmt.Errorf("deleting old backup codes: %w", err)
+	}
 
 	for _, hash := range codeHashes {
-		_, err := db.Pool.Exec(ctx,
+		_, err := tx.Exec(ctx,
 			`INSERT INTO mfa_backup_codes (user_id, code_hash) VALUES ($1, $2)`,
 			userID, hash,
 		)
@@ -134,7 +144,7 @@ func (db *DB) StoreBackupCodes(ctx context.Context, userID uuid.UUID, codeHashes
 			return fmt.Errorf("inserting backup code: %w", err)
 		}
 	}
-	return nil
+	return tx.Commit(ctx)
 }
 
 // ConsumeBackupCode marks a backup code as used if the hash matches.

--- a/internal/database/password_reset.go
+++ b/internal/database/password_reset.go
@@ -25,17 +25,26 @@ type PasswordResetToken struct {
 func (db *DB) CreatePasswordResetToken(ctx context.Context, userID uuid.UUID, tokenPlaintext string, expiresAt time.Time) error {
 	hash := sha256.Sum256([]byte(tokenPlaintext))
 
-	// Invalidate any existing unused tokens for this user
-	_, _ = db.Pool.Exec(ctx, `UPDATE password_reset_tokens SET used = true WHERE user_id = $1 AND used = false`, userID)
+	tx, err := db.Pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // rollback best-effort on deferred cleanup
 
-	_, err := db.Pool.Exec(ctx,
+	// Invalidate any existing unused tokens for this user
+	_, err = tx.Exec(ctx, `UPDATE password_reset_tokens SET used = true WHERE user_id = $1 AND used = false`, userID)
+	if err != nil {
+		return fmt.Errorf("invalidating old reset tokens: %w", err)
+	}
+
+	_, err = tx.Exec(ctx,
 		`INSERT INTO password_reset_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)`,
 		userID, hash[:], expiresAt,
 	)
 	if err != nil {
 		return fmt.Errorf("inserting password reset token: %w", err)
 	}
-	return nil
+	return tx.Commit(ctx)
 }
 
 // ConsumePasswordResetToken validates and consumes a password reset token.

--- a/internal/database/saml.go
+++ b/internal/database/saml.go
@@ -77,6 +77,9 @@ func (db *DB) ListSAMLProviders(ctx context.Context, orgID uuid.UUID) ([]*model.
 		_ = json.Unmarshal(attrBytes, &p.AttributeMapping)
 		providers = append(providers, &p)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating SAML providers: %w", err)
+	}
 	return providers, nil
 }
 
@@ -102,6 +105,9 @@ func (db *DB) GetEnabledSAMLProviders(ctx context.Context, orgID uuid.UUID) ([]*
 		}
 		_ = json.Unmarshal(attrBytes, &p.AttributeMapping)
 		providers = append(providers, &p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating enabled SAML providers: %w", err)
 	}
 	return providers, nil
 }

--- a/internal/database/social_provider_config.go
+++ b/internal/database/social_provider_config.go
@@ -97,6 +97,9 @@ func (db *DB) ListSocialProviderConfigs(ctx context.Context, orgID uuid.UUID) ([
 		}
 		configs = append(configs, &cfg)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating social provider configs: %w", err)
+	}
 	return configs, nil
 }
 

--- a/internal/database/webauthn.go
+++ b/internal/database/webauthn.go
@@ -47,6 +47,9 @@ func (db *DB) GetWebAuthnCredentialsByUserID(ctx context.Context, userID uuid.UU
 		}
 		creds = append(creds, &c)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating webauthn credentials: %w", err)
+	}
 	return creds, nil
 }
 

--- a/internal/database/webhook.go
+++ b/internal/database/webhook.go
@@ -71,6 +71,9 @@ func (db *DB) ListWebhooks(ctx context.Context, orgID uuid.UUID, limit, offset i
 		}
 		webhooks = append(webhooks, &wh)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterating webhooks: %w", err)
+	}
 	return webhooks, total, nil
 }
 
@@ -116,6 +119,9 @@ func (db *DB) GetEnabledWebhooksForEvent(ctx context.Context, orgID uuid.UUID, e
 			return nil, fmt.Errorf("scanning webhook: %w", err)
 		}
 		webhooks = append(webhooks, &wh)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating webhooks for event: %w", err)
 	}
 	return webhooks, nil
 }
@@ -167,6 +173,9 @@ func (db *DB) GetPendingDeliveries(ctx context.Context, limit int) ([]*model.Web
 		}
 		deliveries = append(deliveries, &d)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating pending deliveries: %w", err)
+	}
 	return deliveries, nil
 }
 
@@ -209,6 +218,9 @@ func (db *DB) ListWebhookDeliveries(ctx context.Context, webhookID uuid.UUID, li
 			return nil, 0, fmt.Errorf("scanning delivery: %w", err)
 		}
 		deliveries = append(deliveries, &d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterating webhook deliveries: %w", err)
 	}
 	return deliveries, total, nil
 }

--- a/internal/handler/admin_console_orgs.go
+++ b/internal/handler/admin_console_orgs.go
@@ -203,6 +203,20 @@ func (h *AdminConsoleHandler) UpdateOrgSettingsAction(w http.ResponseWriter, r *
 		mfa = mfaOff
 	}
 
+	primaryColor := strings.TrimSpace(r.FormValue("primary_color"))
+	backgroundColor := strings.TrimSpace(r.FormValue("background_color"))
+
+	if err := model.ValidateCSSColor(primaryColor); err != nil {
+		middleware.SetFlash(w, "Invalid primary color: must be a valid CSS color (e.g. #FF5500, rgb(255,0,0), or a named color).")
+		http.Redirect(w, r, fmt.Sprintf(pathAdminOrgFmt, orgID), http.StatusFound)
+		return
+	}
+	if err := model.ValidateCSSColor(backgroundColor); err != nil {
+		middleware.SetFlash(w, "Invalid background color: must be a valid CSS color (e.g. #FF5500, rgb(255,0,0), or a named color).")
+		http.Redirect(w, r, fmt.Sprintf(pathAdminOrgFmt, orgID), http.StatusFound)
+		return
+	}
+
 	req := &model.UpdateOrgSettingsRequest{
 		PasswordMinLength:         minLen,
 		PasswordRequireUppercase:  r.FormValue("password_require_uppercase") == formValueTrue,
@@ -212,6 +226,8 @@ func (h *AdminConsoleHandler) UpdateOrgSettingsAction(w http.ResponseWriter, r *
 		MFAEnforcement:            mfa,
 		AccessTokenTTLSeconds:     accessTTL,
 		RefreshTokenTTLSeconds:    refreshTTL,
+		PrimaryColor:              primaryColor,
+		BackgroundColor:           backgroundColor,
 		SelfRegistrationEnabled:   r.FormValue("self_registration_enabled") == formValueTrue,
 		EmailVerificationRequired: r.FormValue("email_verification_required") == formValueTrue,
 		ForgotPasswordEnabled:     r.FormValue("forgot_password_enabled") == formValueTrue,

--- a/internal/handler/admin_console_roles.go
+++ b/internal/handler/admin_console_roles.go
@@ -218,6 +218,9 @@ func (h *AdminConsoleHandler) AssignRoleAction(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	authUser := middleware.GetAuthenticatedUser(r.Context())
+	h.auditLog(r, authUser.OrgID, model.EventRoleAssigned, "user", userID.String(), roleID.String())
+
 	middleware.SetFlash(w, "Role assigned.")
 	http.Redirect(w, r, fmt.Sprintf(pathAdminUserFmt, userID), http.StatusFound)
 }
@@ -243,6 +246,9 @@ func (h *AdminConsoleHandler) UnassignRoleAction(w http.ResponseWriter, r *http.
 		http.Redirect(w, r, fmt.Sprintf(pathAdminUserFmt, userID), http.StatusFound)
 		return
 	}
+
+	unassignAuthUser := middleware.GetAuthenticatedUser(r.Context())
+	h.auditLog(r, unassignAuthUser.OrgID, model.EventRoleUnassigned, "user", userID.String(), roleID.String())
 
 	middleware.SetFlash(w, "Role removed.")
 	http.Redirect(w, r, fmt.Sprintf(pathAdminUserFmt, userID), http.StatusFound)

--- a/internal/handler/admin_login.go
+++ b/internal/handler/admin_login.go
@@ -234,7 +234,7 @@ func (h *AdminLoginHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	// Generate access token
 	accessToken, err := token.GenerateAccessToken(
-		h.privateKey, h.kid, h.issuer, accessTTL,
+		h.privateKey, h.kid, h.issuer, h.issuer, accessTTL,
 		user.ID, user.OrgID,
 		user.Username, user.Email, user.EmailVerified,
 		user.GivenName, user.FamilyName,

--- a/internal/handler/authorize.go
+++ b/internal/handler/authorize.go
@@ -148,6 +148,10 @@ func (h *AuthorizeHandler) handleGet(w http.ResponseWriter, r *http.Request) {
 		h.renderError(w, http.StatusBadRequest, "Unknown client_id.")
 		return
 	}
+	if !client.Enabled {
+		h.renderError(w, http.StatusForbidden, "This OAuth client is disabled.")
+		return
+	}
 
 	if !database.ValidateRedirectURI(client, redirectURI) {
 		h.renderError(w, http.StatusBadRequest, "Invalid redirect_uri.")
@@ -244,6 +248,10 @@ func (h *AuthorizeHandler) handlePost(w http.ResponseWriter, r *http.Request) {
 	}
 	if client == nil {
 		h.renderError(w, http.StatusBadRequest, "Unknown client_id.")
+		return
+	}
+	if !client.Enabled {
+		h.renderError(w, http.StatusForbidden, "This OAuth client is disabled.")
 		return
 	}
 
@@ -546,6 +554,10 @@ func (h *AuthorizeHandler) Consent(w http.ResponseWriter, r *http.Request) {
 	client, err := h.store.GetOAuthClient(ctx, clientID)
 	if err != nil || client == nil {
 		h.renderError(w, http.StatusBadRequest, "Unknown client.")
+		return
+	}
+	if !client.Enabled {
+		h.renderError(w, http.StatusForbidden, "This OAuth client is disabled.")
 		return
 	}
 	if !database.ValidateRedirectURI(client, redirectURI) {

--- a/internal/handler/authorize_test.go
+++ b/internal/handler/authorize_test.go
@@ -131,6 +131,7 @@ func newTestOAuthClient(orgID uuid.UUID) *model.OAuthClient {
 		Name:         "Test Client",
 		ClientType:   "public",
 		RedirectURIs: []string{"http://localhost:3002/callback"},
+		Enabled:      true,
 	}
 }
 
@@ -165,6 +166,28 @@ func TestAuthorizeGetUnknownClient(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "Unknown client_id") {
 		t.Error("expected unknown client error")
+	}
+}
+
+func TestAuthorizeGetDisabledClient(t *testing.T) {
+	orgID := uuid.New()
+	disabledClient := newTestOAuthClient(orgID)
+	disabledClient.Enabled = false
+	store := &mockAuthorizeStore{
+		oauthClient: disabledClient,
+	}
+	h := NewAuthorizeHandler(store, noopLogger(), nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?client_id=test-client&redirect_uri=http://localhost:3002/callback&response_type=code&state=abc&code_challenge=xyz&code_challenge_method=S256", http.NoBody)
+	w := httptest.NewRecorder()
+
+	h.Authorize(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+	if !strings.Contains(w.Body.String(), "disabled") {
+		t.Error("expected error mentioning disabled client")
 	}
 }
 

--- a/internal/handler/login.go
+++ b/internal/handler/login.go
@@ -314,7 +314,7 @@ func (h *LoginHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	accessToken, err := token.GenerateAccessToken(
-		h.privateKey, h.kid, h.issuer, accessTTL,
+		h.privateKey, h.kid, h.issuer, h.issuer, accessTTL,
 		user.ID, user.OrgID,
 		user.Username, user.Email, user.EmailVerified,
 		user.GivenName, user.FamilyName,
@@ -412,7 +412,7 @@ func (h *LoginHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	accessToken, err := token.GenerateAccessToken(
-		h.privateKey, h.kid, h.issuer, h.accessTTL,
+		h.privateKey, h.kid, h.issuer, h.issuer, h.accessTTL,
 		user.ID, user.OrgID,
 		user.Username, user.Email, user.EmailVerified,
 		user.GivenName, user.FamilyName,

--- a/internal/handler/mfa.go
+++ b/internal/handler/mfa.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/manimovassagh/rampart/internal/apierror"
+	"github.com/manimovassagh/rampart/internal/audit"
 	"github.com/manimovassagh/rampart/internal/mfa"
 	"github.com/manimovassagh/rampart/internal/middleware"
 	"github.com/manimovassagh/rampart/internal/model"
@@ -22,12 +23,13 @@ type MFAHandlerStore interface {
 type MFAHandler struct {
 	store  MFAHandlerStore
 	logger *slog.Logger
+	audit  *audit.Logger
 	issuer string
 }
 
 // NewMFAHandler creates a new MFA handler.
-func NewMFAHandler(s MFAHandlerStore, logger *slog.Logger, issuer string) *MFAHandler {
-	return &MFAHandler{store: s, logger: logger, issuer: issuer}
+func NewMFAHandler(s MFAHandlerStore, logger *slog.Logger, auditLogger *audit.Logger, issuer string) *MFAHandler {
+	return &MFAHandler{store: s, logger: logger, audit: auditLogger, issuer: issuer}
 }
 
 // EnrollTOTP handles POST /mfa/totp/enroll.
@@ -83,6 +85,8 @@ func (h *MFAHandler) EnrollTOTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	uri := mfa.ProvisioningURI(secret, user.Email, h.issuer)
+
+	h.audit.LogSimple(ctx, r, user.OrgID, model.EventMFAEnrolled, &user.ID, user.Email, "user", user.ID.String(), user.Email)
 
 	resp := model.TOTPEnrollResponse{
 		Secret:          secret,
@@ -159,6 +163,12 @@ func (h *MFAHandler) VerifyTOTPSetup(w http.ResponseWriter, r *http.Request) {
 
 	h.logger.Info("MFA enabled", "user_id", userID)
 
+	// Fetch user to get org ID for audit logging
+	verifyUser, _ := h.store.GetUserByID(ctx, userID)
+	if verifyUser != nil {
+		h.audit.LogSimple(ctx, r, verifyUser.OrgID, model.EventMFAVerified, &userID, verifyUser.Email, "user", userID.String(), verifyUser.Email)
+	}
+
 	resp := model.TOTPVerifySetupResponse{
 		Message:     "MFA has been enabled successfully.",
 		BackupCodes: backupCodes,
@@ -213,6 +223,12 @@ func (h *MFAHandler) DisableTOTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.logger.Info("MFA disabled", "user_id", userID)
+
+	// Fetch user to get org ID for audit logging
+	disableUser, _ := h.store.GetUserByID(ctx, userID)
+	if disableUser != nil {
+		h.audit.LogSimple(ctx, r, disableUser.OrgID, model.EventMFADisabled, &userID, disableUser.Email, "user", userID.String(), disableUser.Email)
+	}
 
 	resp := model.TOTPDisableResponse{
 		Message: "MFA has been disabled.",

--- a/internal/handler/mfa_test.go
+++ b/internal/handler/mfa_test.go
@@ -112,7 +112,7 @@ func newAuthenticatedRequest(target string, body []byte, userID, orgID uuid.UUID
 }
 
 func newTestMFAHandler(s *mockMFAStore) *MFAHandler {
-	return NewMFAHandler(s, noopLogger(), testIssuer)
+	return NewMFAHandler(s, noopLogger(), nil, testIssuer)
 }
 
 // ── EnrollTOTP tests ─────────────────────────────────────────────────────

--- a/internal/handler/mfa_verify.go
+++ b/internal/handler/mfa_verify.go
@@ -104,6 +104,15 @@ func (h *MFAVerifyHandler) VerifyTOTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check account lockout (shared with login flow)
+	if user.IsLocked() {
+		h.audit.Log(ctx, r, user.OrgID, model.EventUserLoginFailed, &user.ID, user.Username, "user", user.ID.String(), user.Username, map[string]any{"reason": "account_locked_mfa"})
+		metrics.AuthTotal.WithLabelValues("failure").Inc()
+		w.Header().Set("Retry-After", "900")
+		apierror.TooManyRequests(w, "Account is temporarily locked due to too many failed MFA attempts. Please try again later.")
+		return
+	}
+
 	// Get verified MFA device
 	device, err := h.store.GetVerifiedMFADevice(ctx, userID)
 	if err != nil {
@@ -134,8 +143,24 @@ func (h *MFAVerifyHandler) VerifyTOTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !valid {
+		h.audit.Log(ctx, r, user.OrgID, model.EventMFAFailed, &user.ID, user.Username, "user", user.ID.String(), user.Username, map[string]any{"reason": "invalid_mfa_code"})
 		h.audit.Log(ctx, r, user.OrgID, model.EventUserLoginFailed, &user.ID, user.Username, "user", user.ID.String(), user.Username, map[string]any{"reason": "invalid_mfa_code"})
 		metrics.AuthTotal.WithLabelValues("failure").Inc()
+
+		// Increment failed login counter with lockout policy (same as login flow)
+		var settings *model.OrgSettings
+		if s, sErr := h.store.GetOrgSettings(ctx, user.OrgID); sErr != nil {
+			h.logger.Warn("failed to fetch org settings for MFA lockout, using defaults", "error", sErr)
+		} else {
+			settings = s
+		}
+		maxAttempts, lockoutDur := defaultLockoutPolicy(settings)
+		if maxAttempts > 0 {
+			if lErr := h.store.IncrementFailedLogins(ctx, user.ID, maxAttempts, lockoutDur); lErr != nil {
+				h.logger.Warn("failed to increment failed logins after MFA failure", "error", lErr)
+			}
+		}
+
 		apierror.Unauthorized(w, "Invalid MFA code.")
 		return
 	}
@@ -166,7 +191,7 @@ func (h *MFAVerifyHandler) VerifyTOTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	accessToken, err := token.GenerateAccessToken(
-		h.privateKey, h.kid, h.issuer, accessTTL,
+		h.privateKey, h.kid, h.issuer, h.issuer, accessTTL,
 		user.ID, user.OrgID,
 		user.Username, user.Email, user.EmailVerified,
 		user.GivenName, user.FamilyName,
@@ -196,6 +221,7 @@ func (h *MFAVerifyHandler) VerifyTOTP(w http.ResponseWriter, r *http.Request) {
 		h.logger.Warn("failed to update last_login_at", "error", err, "user_id", user.ID)
 	}
 
+	h.audit.LogSimple(ctx, r, user.OrgID, model.EventMFAVerified, &user.ID, user.Username, "user", user.ID.String(), user.Username)
 	h.audit.LogSimple(ctx, r, user.OrgID, model.EventUserLogin, &user.ID, user.Username, "user", user.ID.String(), user.Username)
 	metrics.AuthTotal.WithLabelValues("success").Inc()
 	metrics.TokensIssued.WithLabelValues("access").Inc()

--- a/internal/handler/organization.go
+++ b/internal/handler/organization.go
@@ -263,6 +263,14 @@ func (h *OrgHandler) UpdateOrgSettings(w http.ResponseWriter, r *http.Request) {
 		apierror.BadRequest(w, "Refresh token TTL must be at least 60 seconds.")
 		return
 	}
+	if err := model.ValidateCSSColor(req.PrimaryColor); err != nil {
+		apierror.BadRequest(w, "Invalid primary color: "+err.Error())
+		return
+	}
+	if err := model.ValidateCSSColor(req.BackgroundColor); err != nil {
+		apierror.BadRequest(w, "Invalid background color: "+err.Error())
+		return
+	}
 
 	settings, err := h.settings.UpdateOrgSettings(r.Context(), orgID, &req)
 	if err != nil {

--- a/internal/handler/password_reset.go
+++ b/internal/handler/password_reset.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/manimovassagh/rampart/internal/apierror"
+	"github.com/manimovassagh/rampart/internal/audit"
 	"github.com/manimovassagh/rampart/internal/auth"
+	"github.com/manimovassagh/rampart/internal/model"
 	"github.com/manimovassagh/rampart/internal/store"
 )
 
@@ -46,16 +48,18 @@ type PasswordResetHandler struct {
 	sessions PasswordResetSessionStore
 	email    EmailSender
 	logger   *slog.Logger
+	audit    *audit.Logger
 	issuer   string // used to build reset URL
 }
 
 // NewPasswordResetHandler creates a new password reset handler.
-func NewPasswordResetHandler(s PasswordResetHandlerStore, sessions PasswordResetSessionStore, email EmailSender, logger *slog.Logger, issuer string) *PasswordResetHandler {
+func NewPasswordResetHandler(s PasswordResetHandlerStore, sessions PasswordResetSessionStore, email EmailSender, logger *slog.Logger, auditLogger *audit.Logger, issuer string) *PasswordResetHandler {
 	return &PasswordResetHandler{
 		store:    s,
 		sessions: sessions,
 		email:    email,
 		logger:   logger,
+		audit:    auditLogger,
 		issuer:   issuer,
 	}
 }
@@ -131,6 +135,8 @@ func (h *PasswordResetHandler) processResetRequest(email string) {
 		h.logger.Error("failed to store password reset token", "error", err)
 		return
 	}
+
+	h.audit.LogSimple(ctx, nil, user.OrgID, model.EventPasswordResetRequested, &user.ID, user.Email, "user", user.ID.String(), user.Email)
 
 	// Send email
 	if !h.email.Enabled() {
@@ -218,6 +224,7 @@ func (h *PasswordResetHandler) ResetPassword(w http.ResponseWriter, r *http.Requ
 	}
 
 	h.logger.Info("password reset successful", "user_id", userID)
+	h.audit.LogSimple(ctx, r, user.OrgID, model.EventPasswordResetCompleted, &user.ID, user.Email, "user", user.ID.String(), user.Email)
 
 	w.Header().Set("Content-Type", apierror.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)

--- a/internal/handler/password_reset_test.go
+++ b/internal/handler/password_reset_test.go
@@ -101,7 +101,7 @@ func (m *mockResetSessionStore) DeleteByUserID(_ context.Context, _ uuid.UUID) e
 func TestForgotPasswordAlwaysReturns200(t *testing.T) {
 	store := &mockResetStore{user: nil} // no user found
 	sender := &mockEmailSender{enabled: false}
-	h := NewPasswordResetHandler(store, &mockResetSessionStore{}, sender, slog.Default(), "http://localhost:8080")
+	h := NewPasswordResetHandler(store, &mockResetSessionStore{}, sender, slog.Default(), nil, "http://localhost:8080")
 
 	body := `{"email":"nonexistent@test.com"}`
 	req := httptest.NewRequest(http.MethodPost, "/forgot-password", strings.NewReader(body))
@@ -117,7 +117,7 @@ func TestForgotPasswordAlwaysReturns200(t *testing.T) {
 func TestForgotPasswordEmptyEmail(t *testing.T) {
 	store := &mockResetStore{}
 	sender := &mockEmailSender{}
-	h := NewPasswordResetHandler(store, &mockResetSessionStore{}, sender, slog.Default(), "http://localhost:8080")
+	h := NewPasswordResetHandler(store, &mockResetSessionStore{}, sender, slog.Default(), nil, "http://localhost:8080")
 
 	body := `{"email":""}`
 	req := httptest.NewRequest(http.MethodPost, "/forgot-password", strings.NewReader(body))
@@ -134,7 +134,7 @@ func TestResetPasswordSuccess(t *testing.T) {
 	uid := uuid.New()
 	store := &mockResetStore{userID: uid}
 	sender := &mockEmailSender{}
-	h := NewPasswordResetHandler(store, &mockResetSessionStore{}, sender, slog.Default(), "http://localhost:8080")
+	h := NewPasswordResetHandler(store, &mockResetSessionStore{}, sender, slog.Default(), nil, "http://localhost:8080")
 
 	body := `{"token":"abc123","new_password":"NewSecure1234!"}`
 	req := httptest.NewRequest(http.MethodPost, "/reset-password", strings.NewReader(body))
@@ -158,7 +158,7 @@ func TestResetPasswordSuccess(t *testing.T) {
 func TestResetPasswordShortPassword(t *testing.T) {
 	store := &mockResetStore{userID: uuid.New()}
 	sender := &mockEmailSender{}
-	h := NewPasswordResetHandler(store, &mockResetSessionStore{}, sender, slog.Default(), "http://localhost:8080")
+	h := NewPasswordResetHandler(store, &mockResetSessionStore{}, sender, slog.Default(), nil, "http://localhost:8080")
 
 	body := `{"token":"abc123","new_password":"short"}`
 	req := httptest.NewRequest(http.MethodPost, "/reset-password", strings.NewReader(body))
@@ -174,7 +174,7 @@ func TestResetPasswordShortPassword(t *testing.T) {
 func TestResetPasswordInvalidToken(t *testing.T) {
 	store := &mockResetStore{tokenErr: errInvalidToken}
 	sender := &mockEmailSender{}
-	h := NewPasswordResetHandler(store, &mockResetSessionStore{}, sender, slog.Default(), "http://localhost:8080")
+	h := NewPasswordResetHandler(store, &mockResetSessionStore{}, sender, slog.Default(), nil, "http://localhost:8080")
 
 	body := `{"token":"badtoken","new_password":"ValidPass123!"}`
 	req := httptest.NewRequest(http.MethodPost, "/reset-password", strings.NewReader(body))
@@ -207,7 +207,7 @@ func TestResetPasswordRejectsWeakPasswordPerOrgPolicy(t *testing.T) {
 	ms.user = &model.User{ID: uid, OrgID: orgID, Enabled: true}
 
 	sender := &mockEmailSender{}
-	h := NewPasswordResetHandler(ms, &mockResetSessionStore{}, sender, slog.Default(), "http://localhost:8080")
+	h := NewPasswordResetHandler(ms, &mockResetSessionStore{}, sender, slog.Default(), nil, "http://localhost:8080")
 
 	tests := []struct {
 		name     string

--- a/internal/handler/saml.go
+++ b/internal/handler/saml.go
@@ -254,7 +254,7 @@ func (h *SAMLHandler) ACS(w http.ResponseWriter, r *http.Request) {
 	roles, _ := h.store.GetEffectiveUserRoles(ctx, user.ID)
 
 	accessToken, err := token.GenerateAccessToken(
-		h.privateKey, h.kid, h.issuer, accessTTL,
+		h.privateKey, h.kid, h.issuer, h.issuer, accessTTL,
 		user.ID, user.OrgID,
 		user.Username, user.Email, user.EmailVerified,
 		user.GivenName, user.FamilyName,

--- a/internal/handler/social.go
+++ b/internal/handler/social.go
@@ -157,6 +157,9 @@ func (h *SocialHandler) InitiateLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SameSite=None is required because Apple Sign In uses response_mode=form_post,
+	// which sends a cross-site POST back to our callback. SameSite=Lax would block
+	// the cookie on cross-site POST requests. Secure=true is mandatory with SameSite=None.
 	http.SetCookie(w, &http.Cookie{
 		Name:     socialCookieName,
 		Value:    cookieValue,
@@ -164,7 +167,7 @@ func (h *SocialHandler) InitiateLogin(w http.ResponseWriter, r *http.Request) {
 		MaxAge:   socialCookieMaxAge,
 		HttpOnly: true,
 		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
+		SameSite: http.SameSiteNoneMode,
 	})
 
 	// Build the callback URL for the social provider
@@ -174,7 +177,9 @@ func (h *SocialHandler) InitiateLogin(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, authURL, http.StatusFound)
 }
 
-// Callback handles GET /oauth/social/{provider}/callback — exchanges the code and completes the flow.
+// Callback handles GET or POST /oauth/social/{provider}/callback — exchanges the code and completes the flow.
+// Apple Sign In uses response_mode=form_post and sends code/state as POST form data,
+// while other providers use GET query parameters.
 func (h *SocialHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	providerName := chi.URLParam(r, "provider")
 	provider, ok := h.registry.Get(providerName)
@@ -183,9 +188,17 @@ func (h *SocialHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := r.URL.Query()
-	code := q.Get("code")
-	returnedState := q.Get("state")
+	// Read code and state from either query params (GET) or form body (POST).
+	var code, returnedState string
+	if r.Method == http.MethodPost {
+		// Apple uses form_post: code and state arrive in the POST body.
+		code = r.FormValue("code")
+		returnedState = r.FormValue("state")
+	} else {
+		q := r.URL.Query()
+		code = q.Get("code")
+		returnedState = q.Get("state")
+	}
 
 	if code == "" || returnedState == "" {
 		http.Error(w, "Missing code or state parameter.", http.StatusBadRequest)

--- a/internal/handler/social_integration_test.go
+++ b/internal/handler/social_integration_test.go
@@ -110,8 +110,8 @@ func TestSocialInitiateRedirectsToProviderWithCorrectParams(t *testing.T) {
 	if !socialCookie.Secure {
 		t.Error("cookie must be Secure")
 	}
-	if socialCookie.SameSite != http.SameSiteLaxMode {
-		t.Errorf("cookie SameSite = %d, want Lax (%d)", socialCookie.SameSite, http.SameSiteLaxMode)
+	if socialCookie.SameSite != http.SameSiteNoneMode {
+		t.Errorf("cookie SameSite = %d, want None (%d)", socialCookie.SameSite, http.SameSiteNoneMode)
 	}
 	if socialCookie.Path != socialCookiePath {
 		t.Errorf("cookie Path = %q, want %q", socialCookie.Path, socialCookiePath)

--- a/internal/handler/token.go
+++ b/internal/handler/token.go
@@ -62,7 +62,8 @@ type TokenResponse struct {
 	ExpiresIn    int    `json:"expires_in"`
 }
 
-// Token handles POST /oauth/token (authorization code exchange).
+// Token handles POST /oauth/token.
+// Supports grant_type=authorization_code and grant_type=refresh_token.
 // Expects application/x-www-form-urlencoded per RFC 6749.
 func (h *TokenHandler) Token(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -75,12 +76,18 @@ func (h *TokenHandler) Token(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	grantType := r.FormValue("grant_type")
-	if grantType != "authorization_code" {
-		h.writeOAuthError(w, http.StatusBadRequest, "unsupported_grant_type", "Only authorization_code grant type is supported on this endpoint.")
-		return
+	switch r.FormValue("grant_type") {
+	case "authorization_code":
+		h.handleAuthorizationCode(w, r)
+	case "refresh_token":
+		h.handleRefreshToken(w, r)
+	default:
+		h.writeOAuthError(w, http.StatusBadRequest, "unsupported_grant_type", "Supported grant types: authorization_code, refresh_token.")
 	}
+}
 
+// handleAuthorizationCode exchanges an authorization code for tokens.
+func (h *TokenHandler) handleAuthorizationCode(w http.ResponseWriter, r *http.Request) {
 	code := r.FormValue("code")
 	clientID := r.FormValue("client_id")
 	redirectURI := r.FormValue("redirect_uri")
@@ -102,6 +109,10 @@ func (h *TokenHandler) Token(w http.ResponseWriter, r *http.Request) {
 	}
 	if client == nil {
 		h.writeOAuthError(w, http.StatusBadRequest, "invalid_client", "Unknown client_id.")
+		return
+	}
+	if !client.Enabled {
+		h.writeOAuthError(w, http.StatusForbidden, "invalid_client", "This OAuth client is disabled.")
 		return
 	}
 
@@ -170,7 +181,7 @@ func (h *TokenHandler) Token(w http.ResponseWriter, r *http.Request) {
 
 	// Generate access token
 	accessToken, err := token.GenerateAccessToken(
-		h.privateKey, h.kid, h.issuer, accessTTL,
+		h.privateKey, h.kid, h.issuer, authCode.ClientID, accessTTL,
 		user.ID, user.OrgID,
 		user.Username, user.Email, user.EmailVerified,
 		user.GivenName, user.FamilyName,
@@ -219,6 +230,95 @@ func (h *TokenHandler) Token(w http.ResponseWriter, r *http.Request) {
 	metrics.TokensIssued.WithLabelValues("refresh").Inc()
 	metrics.ActiveSessions.Inc()
 
+	h.writeTokenResponse(w, accessToken, refreshToken, idToken, accessTTL)
+}
+
+// handleRefreshToken exchanges a refresh token for a new token pair.
+func (h *TokenHandler) handleRefreshToken(w http.ResponseWriter, r *http.Request) {
+	refreshTokenValue := r.FormValue("refresh_token")
+	if refreshTokenValue == "" {
+		h.writeOAuthError(w, http.StatusBadRequest, "invalid_request", "Missing required parameter: refresh_token.")
+		return
+	}
+
+	ctx := r.Context()
+
+	// Look up session by refresh token
+	sess, err := h.sessions.FindByRefreshToken(ctx, refreshTokenValue)
+	if err != nil {
+		h.logger.Error("failed to find session for refresh", "error", err)
+		h.writeOAuthError(w, http.StatusInternalServerError, oauthServerError, msgInternalServer)
+		return
+	}
+	if sess == nil {
+		h.writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "Invalid or expired refresh token.")
+		return
+	}
+
+	// Fetch user
+	user, err := h.store.GetUserByID(ctx, sess.UserID)
+	if err != nil {
+		h.logger.Error("failed to get user for refresh", "error", err)
+		h.writeOAuthError(w, http.StatusInternalServerError, oauthServerError, msgInternalServer)
+		return
+	}
+	if user == nil || !user.Enabled {
+		h.writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "User account is disabled or not found.")
+		return
+	}
+
+	// Resolve per-org TTLs
+	accessTTL := h.accessTTL
+	if settings, sErr := h.store.GetOrgSettings(ctx, user.OrgID); sErr != nil {
+		h.logger.Warn("failed to fetch org settings, using defaults", "error", sErr)
+	} else if settings != nil {
+		if settings.AccessTokenTTL > 0 {
+			accessTTL = settings.AccessTokenTTL
+		}
+	}
+
+	// Fetch user roles
+	roles, rErr := h.store.GetEffectiveUserRoles(ctx, user.ID)
+	if rErr != nil {
+		h.logger.Warn("failed to fetch user roles for refresh", "error", rErr)
+		roles = nil
+	}
+
+	// Generate new access token
+	accessToken, err := token.GenerateAccessToken(
+		h.privateKey, h.kid, h.issuer, h.issuer, accessTTL,
+		user.ID, user.OrgID,
+		user.Username, user.Email, user.EmailVerified,
+		user.GivenName, user.FamilyName,
+		roles...,
+	)
+	if err != nil {
+		h.logger.Error("failed to generate access token", "error", err)
+		h.writeOAuthError(w, http.StatusInternalServerError, oauthServerError, msgInternalServer)
+		return
+	}
+
+	// Rotate refresh token: generate a new one and invalidate the old
+	newRefreshToken, err := token.GenerateRefreshToken()
+	if err != nil {
+		h.logger.Error("failed to generate new refresh token", "error", err)
+		h.writeOAuthError(w, http.StatusInternalServerError, oauthServerError, msgInternalServer)
+		return
+	}
+	if err := h.sessions.RotateRefreshToken(ctx, sess.ID, newRefreshToken); err != nil {
+		h.logger.Error("failed to rotate refresh token", "error", err)
+		h.writeOAuthError(w, http.StatusInternalServerError, oauthServerError, msgInternalServer)
+		return
+	}
+
+	metrics.TokensIssued.WithLabelValues("access").Inc()
+	metrics.TokensIssued.WithLabelValues("refresh").Inc()
+
+	h.writeTokenResponse(w, accessToken, newRefreshToken, "", accessTTL)
+}
+
+// writeTokenResponse writes a successful OAuth 2.0 token response.
+func (h *TokenHandler) writeTokenResponse(w http.ResponseWriter, accessToken, refreshToken, idToken string, accessTTL time.Duration) {
 	resp := TokenResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,

--- a/internal/handler/token_test.go
+++ b/internal/handler/token_test.go
@@ -407,6 +407,44 @@ func TestTokenConsumeCodeError(t *testing.T) {
 	}
 }
 
+func TestTokenDisabledClientRejected(t *testing.T) {
+	orgID := uuid.New()
+	verifier := testVerifier
+
+	disabledClient := &model.OAuthClient{
+		ID:           "test-client",
+		OrgID:        orgID,
+		Name:         "Test Client",
+		ClientType:   "public",
+		RedirectURIs: []string{"http://localhost:3002/callback"},
+		Enabled:      false,
+	}
+
+	store := &mockTokenStore{
+		oauthClient: disabledClient,
+	}
+	h := NewTokenHandler(store, &mockSessionStore{}, noopLogger(), testPrivKey, testKID, testIssuer, 15*time.Minute, 7*24*time.Hour)
+
+	body := "grant_type=authorization_code&code=validcode&client_id=test-client&redirect_uri=http://localhost:3002/callback&code_verifier=" + verifier
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.Token(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp["error"] != "invalid_client" {
+		t.Errorf("error = %q, want invalid_client", resp["error"])
+	}
+}
+
 func TestTokenUserDisabledAfterCodeExchange(t *testing.T) {
 	orgID := uuid.New()
 	userID := uuid.New()
@@ -636,6 +674,7 @@ func TestTokenWithAdminClientIncludesAdminRole(t *testing.T) {
 			Name:         "Rampart Admin",
 			ClientType:   "public",
 			RedirectURIs: []string{"http://localhost:3002/callback"},
+			Enabled:      true,
 		},
 		authCode: &model.AuthorizationCode{
 			ID:            uuid.New(),

--- a/internal/handler/webauthn.go
+++ b/internal/handler/webauthn.go
@@ -379,7 +379,7 @@ func (h *WebAuthnHandler) FinishLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	accessToken, err := token.GenerateAccessToken(
-		h.privateKey, h.kid, h.issuer, accessTTL,
+		h.privateKey, h.kid, h.issuer, h.issuer, accessTTL,
 		user.ID, user.OrgID,
 		user.Username, user.Email, user.EmailVerified,
 		user.GivenName, user.FamilyName,

--- a/internal/middleware/admin_session_test.go
+++ b/internal/middleware/admin_session_test.go
@@ -119,7 +119,7 @@ func TestAdminSessionInvalidSignature(t *testing.T) {
 
 func TestAdminSessionExpiredToken(t *testing.T) {
 	tok, err := token.GenerateAccessToken(
-		testPrivKey, testKID, testIssuer, -1*time.Hour,
+		testPrivKey, testKID, testIssuer, testIssuer, -1*time.Hour,
 		uuid.New(), uuid.New(),
 		"admin", "admin@test.com", false, "", "",
 	)
@@ -356,7 +356,7 @@ func TestGenerateHMACKey(t *testing.T) {
 func generateTestTokenWithRolesAdmin(t *testing.T, roles ...string) string {
 	t.Helper()
 	tok, err := token.GenerateAccessToken(
-		testPrivKey, testKID, testIssuer, 15*time.Minute,
+		testPrivKey, testKID, testIssuer, testIssuer, 15*time.Minute,
 		uuid.New(), uuid.New(),
 		"testuser", "test@test.com", true, "Test", "User",
 		roles...,

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -70,7 +70,7 @@ const (
 func generateTestToken(t *testing.T) string {
 	t.Helper()
 	tok, err := token.GenerateAccessToken(
-		testPrivKey, testKID, testIssuer, 15*time.Minute,
+		testPrivKey, testKID, testIssuer, testIssuer, 15*time.Minute,
 		uuid.New(), uuid.New(),
 		"admin", "admin@test.com", true, "Admin", "User",
 	)
@@ -157,7 +157,7 @@ func TestAuthMiddlewareInvalidToken(t *testing.T) {
 
 func TestAuthMiddlewareExpiredToken(t *testing.T) {
 	tok, err := token.GenerateAccessToken(
-		testPrivKey, testKID, testIssuer, -1*time.Hour,
+		testPrivKey, testKID, testIssuer, testIssuer, -1*time.Hour,
 		uuid.New(), uuid.New(),
 		"admin", "admin@test.com", false, "", "",
 	)
@@ -315,7 +315,7 @@ func TestHasRoleEmptyRoles(t *testing.T) {
 func generateTestTokenWithRoles(t *testing.T, roles ...string) string {
 	t.Helper()
 	tok, err := token.GenerateAccessToken(
-		testPrivKey, testKID, testIssuer, 15*time.Minute,
+		testPrivKey, testKID, testIssuer, testIssuer, 15*time.Minute,
 		uuid.New(), uuid.New(),
 		"testuser", "test@test.com", true, "Test", "User",
 		roles...,

--- a/internal/model/audit.go
+++ b/internal/model/audit.go
@@ -21,6 +21,15 @@ const (
 	EventSocialLogin         = "social_login"
 	EventSocialLoginFailed   = "social_login_failed"
 	EventSocialAccountLinked = "social_account_linked"
+
+	EventMFAEnrolled            = "mfa.enrolled"
+	EventMFADisabled            = "mfa.disabled"
+	EventMFAVerified            = "mfa.verified"
+	EventMFAFailed              = "mfa.failed"
+	EventPasswordResetRequested = "password.reset_requested"
+	EventPasswordResetCompleted = "password.reset_completed"
+	EventRoleAssigned           = "role.assigned"
+	EventRoleUnassigned         = "role.unassigned"
 )
 
 // AuditEvent represents a row in the audit_events table.

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -214,6 +214,68 @@ func TestOrgSettingsToResponse(t *testing.T) {
 	}
 }
 
+func TestValidateCSSColor(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		// Valid: empty (no color set)
+		{"empty string", "", false},
+
+		// Valid: hex colors
+		{"hex 3-digit", "#fff", false},
+		{"hex 3-digit uppercase", "#FFF", false},
+		{"hex 4-digit with alpha", "#ff0a", false},
+		{"hex 6-digit", "#ff5500", false},
+		{"hex 6-digit uppercase", "#FF5500", false},
+		{"hex 8-digit with alpha", "#ff550080", false},
+
+		// Valid: rgb/rgba
+		{"rgb", "rgb(255,0,0)", false},
+		{"rgb with spaces", "rgb( 255 , 0 , 0 )", false},
+		{"rgba", "rgba(255,0,0,0.5)", false},
+		{"rgb percentages", "rgb(100%,0%,50%)", false},
+
+		// Valid: hsl/hsla
+		{"hsl", "hsl(120,50%,50%)", false},
+		{"hsla", "hsla(120,50%,50%,0.5)", false},
+
+		// Valid: named colors
+		{"named red", "red", false},
+		{"named blue", "blue", false},
+		{"named transparent", "transparent", false},
+		{"named rebeccapurple", "rebeccapurple", false},
+		{"named mixed case", "DarkBlue", false},
+
+		// Invalid: CSS injection vectors
+		{"semicolon injection", "#fff; background: url(evil)", true},
+		{"closing brace", "#fff} body{background:red", true},
+		{"opening brace", "red{color:white", true},
+		{"url() injection", "url(javascript:alert(1))", true},
+		{"expression() injection", "expression(alert(1))", true},
+		{"@import injection", "@import url(evil.css)", true},
+		{"javascript: protocol", "javascript:alert(1)", true},
+		{"backslash escape", `\000075rl(evil)`, true},
+
+		// Invalid: not a color
+		{"random string", "notacolor", true},
+		{"number only", "12345", true},
+		{"hex without hash", "ff5500", true},
+		{"invalid hex length", "#ff55", false}, // 4-digit hex is valid (with alpha)
+		{"hex too long", "#ff5500ff00", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCSSColor(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCSSColor(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestRoleToRoleResponse(t *testing.T) {
 	now := time.Now()
 	roleID := uuid.New()

--- a/internal/model/organization.go
+++ b/internal/model/organization.go
@@ -1,10 +1,99 @@
 package model
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+// cssColorHexPattern matches 3, 4, 6, or 8-digit hex colors like #fff, #FFFFFF, #ff000080.
+var cssColorHexPattern = regexp.MustCompile(`^#([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$`)
+
+// cssColorRGBPattern matches rgb(r,g,b) and rgba(r,g,b,a) with integers/percentages.
+var cssColorRGBPattern = regexp.MustCompile(`^rgba?\(\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*(,\s*(0|1|0?\.\d+)\s*)?\)$`)
+
+// cssColorHSLPattern matches hsl(h,s%,l%) and hsla(h,s%,l%,a).
+var cssColorHSLPattern = regexp.MustCompile(`^hsla?\(\s*\d{1,3}\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%\s*(,\s*(0|1|0?\.\d+)\s*)?\)$`)
+
+// cssNamedColors is the set of standard CSS named colors.
+var cssNamedColors = map[string]bool{
+	"aliceblue": true, "antiquewhite": true, "aqua": true, "aquamarine": true,
+	"azure": true, "beige": true, "bisque": true, "black": true,
+	"blanchedalmond": true, "blue": true, "blueviolet": true, "brown": true,
+	"burlywood": true, "cadetblue": true, "chartreuse": true, "chocolate": true,
+	"coral": true, "cornflowerblue": true, "cornsilk": true, "crimson": true,
+	"cyan": true, "darkblue": true, "darkcyan": true, "darkgoldenrod": true,
+	"darkgray": true, "darkgreen": true, "darkgrey": true, "darkkhaki": true,
+	"darkmagenta": true, "darkolivegreen": true, "darkorange": true, "darkorchid": true,
+	"darkred": true, "darksalmon": true, "darkseagreen": true, "darkslateblue": true,
+	"darkslategray": true, "darkslategrey": true, "darkturquoise": true, "darkviolet": true,
+	"deeppink": true, "deepskyblue": true, "dimgray": true, "dimgrey": true,
+	"dodgerblue": true, "firebrick": true, "floralwhite": true, "forestgreen": true,
+	"fuchsia": true, "gainsboro": true, "ghostwhite": true, "gold": true,
+	"goldenrod": true, "gray": true, "green": true, "greenyellow": true,
+	"grey": true, "honeydew": true, "hotpink": true, "indianred": true,
+	"indigo": true, "ivory": true, "khaki": true, "lavender": true,
+	"lavenderblush": true, "lawngreen": true, "lemonchiffon": true, "lightblue": true,
+	"lightcoral": true, "lightcyan": true, "lightgoldenrodyellow": true, "lightgray": true,
+	"lightgreen": true, "lightgrey": true, "lightpink": true, "lightsalmon": true,
+	"lightseagreen": true, "lightskyblue": true, "lightslategray": true, "lightslategrey": true,
+	"lightsteelblue": true, "lightyellow": true, "lime": true, "limegreen": true,
+	"linen": true, "magenta": true, "maroon": true, "mediumaquamarine": true,
+	"mediumblue": true, "mediumorchid": true, "mediumpurple": true, "mediumseagreen": true,
+	"mediumslateblue": true, "mediumspringgreen": true, "mediumturquoise": true, "mediumvioletred": true,
+	"midnightblue": true, "mintcream": true, "mistyrose": true, "moccasin": true,
+	"navajowhite": true, "navy": true, "oldlace": true, "olive": true,
+	"olivedrab": true, "orange": true, "orangered": true, "orchid": true,
+	"palegoldenrod": true, "palegreen": true, "paleturquoise": true, "palevioletred": true,
+	"papayawhip": true, "peachpuff": true, "peru": true, "pink": true,
+	"plum": true, "powderblue": true, "purple": true, "rebeccapurple": true,
+	"red": true, "rosybrown": true, "royalblue": true, "saddlebrown": true,
+	"salmon": true, "sandybrown": true, "seagreen": true, "seashell": true,
+	"sienna": true, "silver": true, "skyblue": true, "slateblue": true,
+	"slategray": true, "slategrey": true, "snow": true, "springgreen": true,
+	"steelblue": true, "tan": true, "teal": true, "thistle": true,
+	"tomato": true, "transparent": true, "turquoise": true, "violet": true,
+	"wheat": true, "white": true, "whitesmoke": true, "yellow": true,
+	"yellowgreen": true,
+}
+
+// ValidateCSSColor checks that a string is a safe CSS color value.
+// It accepts empty strings (no color set), hex colors, rgb/rgba, hsl/hsla,
+// and standard CSS named colors. It rejects anything that could be a CSS
+// injection vector (semicolons, braces, url(), expression(), @import, etc.).
+func ValidateCSSColor(value string) error {
+	if value == "" {
+		return nil
+	}
+
+	// First, reject any dangerous characters/patterns regardless of format.
+	lower := strings.ToLower(value)
+	dangerousPatterns := []string{";", "{", "}", "url(", "expression(", "@import", "javascript:", "\\"}
+	for _, p := range dangerousPatterns {
+		if strings.Contains(lower, p) {
+			return fmt.Errorf("color value contains forbidden pattern %q", p)
+		}
+	}
+
+	// Check against allowed formats.
+	if cssColorHexPattern.MatchString(value) {
+		return nil
+	}
+	if cssColorRGBPattern.MatchString(lower) {
+		return nil
+	}
+	if cssColorHSLPattern.MatchString(lower) {
+		return nil
+	}
+	if cssNamedColors[lower] {
+		return nil
+	}
+
+	return fmt.Errorf("invalid CSS color value: must be a hex color (#RGB, #RRGGBB), rgb(), hsl(), or a named CSS color")
+}
 
 // Organization represents a row in the organizations table.
 type Organization struct {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -255,9 +255,12 @@ func RegisterOAuthRoutes(r *chi.Mux, authorize, consent, token, revoke http.Hand
 }
 
 // RegisterSocialRoutes mounts social login initiation and callback endpoints.
+// The callback is registered for both GET and POST because Apple Sign In uses
+// response_mode=form_post, which delivers code and state via a POST request.
 func RegisterSocialRoutes(r *chi.Mux, initiate, callback http.HandlerFunc) {
 	r.Get("/oauth/social/{provider}", initiate)
 	r.Get("/oauth/social/{provider}/callback", callback)
+	r.Post("/oauth/social/{provider}/callback", callback)
 }
 
 // SAMLEndpoints groups the handler methods for SAML SP endpoints.

--- a/internal/social/apple.go
+++ b/internal/social/apple.go
@@ -2,20 +2,30 @@ package social
 
 import (
 	"context"
+	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 const (
 	appleAuthURL  = "https://appleid.apple.com/auth/authorize"
 	appleTokenURL = "https://appleid.apple.com/auth/token"
+	appleJWKSURL  = "https://appleid.apple.com/auth/keys"
+	appleIssuer   = "https://appleid.apple.com"
 	appleScopes   = "name email"
+
+	// jwksCacheTTL controls how long Apple's JWKS is cached before re-fetching.
+	jwksCacheTTL = 1 * time.Hour
 )
 
 // AppleProvider implements the Provider interface for Apple Sign In.
@@ -30,6 +40,13 @@ type AppleProvider struct {
 	// If nil, the PrivateKey, TeamID, and KeyID fields are required but
 	// the actual JWT generation must be provided by the caller.
 	ClientSecretFunc func() (string, error)
+
+	// JWKSURL overrides the Apple JWKS endpoint (for testing).
+	// If empty, the default appleJWKSURL is used.
+	JWKSURL string
+
+	jwksCache   *appleJWKS
+	jwksCacheMu sync.RWMutex
 }
 
 // compile-time check that AppleProvider implements Provider.
@@ -67,9 +84,9 @@ func (a *AppleProvider) Exchange(ctx context.Context, code, redirectURL string) 
 		return nil, fmt.Errorf("apple token exchange: %w", err)
 	}
 
-	claims, err := decodeIDToken(tokenResp.IDToken)
+	claims, err := a.verifyIDToken(ctx, client, tokenResp.IDToken)
 	if err != nil {
-		return nil, fmt.Errorf("apple decode id token: %w", err)
+		return nil, fmt.Errorf("apple verify id token: %w", err)
 	}
 
 	info := &UserInfo{
@@ -128,6 +145,27 @@ func (c *appleIDTokenClaims) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// appleJWKS represents a cached set of Apple's JSON Web Keys.
+type appleJWKS struct {
+	Keys      []appleJWK
+	FetchedAt time.Time
+}
+
+// appleJWK represents a single JSON Web Key from Apple's JWKS endpoint.
+type appleJWK struct {
+	KTY string `json:"kty"`
+	KID string `json:"kid"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+// appleJWKSResponse is the response from Apple's /auth/keys endpoint.
+type appleJWKSResponse struct {
+	Keys []appleJWK `json:"keys"`
+}
+
 func (a *AppleProvider) httpClient() *http.Client {
 	if a.HTTPClient != nil {
 		return a.HTTPClient
@@ -179,25 +217,157 @@ func (a *AppleProvider) exchangeToken(ctx context.Context, client *http.Client, 
 	return &tokenResp, nil
 }
 
-// decodeIDToken decodes an Apple ID token JWT without verifying the signature.
-// It extracts the payload (second segment) and unmarshals the claims.
-// Note: In production, the signature should be verified against Apple's public keys.
-func decodeIDToken(idToken string) (*appleIDTokenClaims, error) {
-	parts := strings.Split(idToken, ".")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid JWT: expected 3 parts, got %d", len(parts))
+// jwksEndpoint returns the JWKS URL, using the override if set (for testing).
+func (a *AppleProvider) jwksEndpoint() string {
+	if a.JWKSURL != "" {
+		return a.JWKSURL
+	}
+	return appleJWKSURL
+}
+
+// verifyIDToken verifies the Apple ID token JWT signature against Apple's
+// public keys (JWKS) and validates the standard claims (iss, aud, exp).
+func (a *AppleProvider) verifyIDToken(ctx context.Context, client *http.Client, idToken string) (*appleIDTokenClaims, error) {
+	keys, err := a.fetchJWKS(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("fetching Apple JWKS: %w", err)
 	}
 
-	payload, err := base64URLDecode(parts[1])
+	// Parse and verify the JWT using the JWKS key function.
+	token, err := jwt.Parse(idToken, func(token *jwt.Token) (interface{}, error) {
+		// Ensure the signing method is RS256.
+		if token.Method.Alg() != "RS256" {
+			return nil, fmt.Errorf("unexpected signing method: %s", token.Method.Alg())
+		}
+
+		kid, ok := token.Header["kid"].(string)
+		if !ok || kid == "" {
+			return nil, fmt.Errorf("missing kid in token header")
+		}
+
+		// Find the matching key.
+		for i := range keys {
+			if keys[i].KID == kid {
+				pubKey, keyErr := jwkToRSAPublicKey(&keys[i])
+				if keyErr != nil {
+					return nil, fmt.Errorf("converting JWK to RSA public key: %w", keyErr)
+				}
+				return pubKey, nil
+			}
+		}
+		return nil, fmt.Errorf("no matching key found for kid %q", kid)
+	},
+		jwt.WithValidMethods([]string{"RS256"}),
+		jwt.WithIssuer(appleIssuer),
+		jwt.WithAudience(a.ClientID),
+		jwt.WithExpirationRequired(),
+	)
 	if err != nil {
-		return nil, fmt.Errorf("decoding JWT payload: %w", err)
+		return nil, fmt.Errorf("verifying JWT: %w", err)
+	}
+
+	if !token.Valid {
+		return nil, fmt.Errorf("invalid JWT token")
+	}
+
+	// Extract claims from the verified token.
+	mapClaims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("unexpected claims type")
+	}
+
+	claimsJSON, err := json.Marshal(mapClaims)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling claims: %w", err)
 	}
 
 	var claims appleIDTokenClaims
-	if err := json.Unmarshal(payload, &claims); err != nil {
-		return nil, fmt.Errorf("parsing JWT claims: %w", err)
+	if err := json.Unmarshal(claimsJSON, &claims); err != nil {
+		return nil, fmt.Errorf("parsing claims: %w", err)
 	}
+
 	return &claims, nil
+}
+
+// fetchJWKS fetches Apple's JWKS (JSON Web Key Set) with caching.
+func (a *AppleProvider) fetchJWKS(ctx context.Context, client *http.Client) ([]appleJWK, error) {
+	// Check cache first (read lock).
+	a.jwksCacheMu.RLock()
+	if a.jwksCache != nil && time.Since(a.jwksCache.FetchedAt) < jwksCacheTTL {
+		keys := a.jwksCache.Keys
+		a.jwksCacheMu.RUnlock()
+		return keys, nil
+	}
+	a.jwksCacheMu.RUnlock()
+
+	// Cache miss or expired — fetch fresh keys (write lock).
+	a.jwksCacheMu.Lock()
+	defer a.jwksCacheMu.Unlock()
+
+	// Double-check after acquiring write lock (another goroutine may have refreshed).
+	if a.jwksCache != nil && time.Since(a.jwksCache.FetchedAt) < jwksCacheTTL {
+		return a.jwksCache.Keys, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.jwksEndpoint(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating JWKS request: %w", err)
+	}
+
+	resp, err := client.Do(req) //nolint:bodyclose,gosec // closed on next line; URL is from config
+	if err != nil {
+		return nil, fmt.Errorf("executing JWKS request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading JWKS response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("JWKS endpoint returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var jwksResp appleJWKSResponse
+	if err := json.Unmarshal(body, &jwksResp); err != nil {
+		return nil, fmt.Errorf("parsing JWKS response: %w", err)
+	}
+
+	if len(jwksResp.Keys) == 0 {
+		return nil, fmt.Errorf("JWKS response contains no keys")
+	}
+
+	a.jwksCache = &appleJWKS{
+		Keys:      jwksResp.Keys,
+		FetchedAt: time.Now(),
+	}
+	return jwksResp.Keys, nil
+}
+
+// jwkToRSAPublicKey converts an Apple JWK to an *rsa.PublicKey.
+func jwkToRSAPublicKey(key *appleJWK) (*rsa.PublicKey, error) {
+	if key.KTY != "RSA" {
+		return nil, fmt.Errorf("unsupported key type: %s", key.KTY)
+	}
+
+	nBytes, err := base64URLDecode(key.N)
+	if err != nil {
+		return nil, fmt.Errorf("decoding modulus: %w", err)
+	}
+
+	eBytes, err := base64URLDecode(key.E)
+	if err != nil {
+		return nil, fmt.Errorf("decoding exponent: %w", err)
+	}
+
+	n := new(big.Int).SetBytes(nBytes)
+	e := new(big.Int).SetBytes(eBytes)
+
+	return &rsa.PublicKey{
+		N: n,
+		E: int(e.Int64()),
+	}, nil
 }
 
 // base64URLDecode decodes a base64url-encoded string with optional padding.

--- a/internal/social/provider_test.go
+++ b/internal/social/provider_test.go
@@ -1,11 +1,26 @@
 package social
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
-const schemeHTTPS = "https"
+const (
+	schemeHTTPS  = "https"
+	testKID      = "test-key-1"
+	testClientID = "com.example.test"
+)
 
 func TestRegistryRegisterAndGet(t *testing.T) {
 	reg := NewRegistry()
@@ -199,49 +214,348 @@ func TestProviderNames(t *testing.T) {
 	}
 }
 
-func TestDecodeIDToken(t *testing.T) {
-	// Build a fake JWT with a known payload.
-	// Header and signature don't matter for decoding.
-	// Payload: {"sub":"001122","email":"test@example.com","email_verified":true}
-	header := "eyJhbGciOiJSUzI1NiJ9"                                                                     // {"alg":"RS256"}
-	payload := "eyJzdWIiOiIwMDExMjIiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZX0" // base64url of the JSON
-	signature := "fake-signature"
+func TestVerifyIDTokenValid(t *testing.T) {
+	// Generate an RSA key pair for testing.
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
 
-	token := header + "." + payload + "." + signature
-	claims, err := decodeIDToken(token)
+	// Create a mock JWKS server.
+	kid := testKID
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jwks := map[string]interface{}{
+			"keys": []map[string]interface{}{
+				{
+					"kty": "RSA",
+					"kid": kid,
+					"use": "sig",
+					"alg": "RS256",
+					"n":   base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes()),
+					"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(privateKey.E)).Bytes()),
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer jwksServer.Close()
+
+	clientID := testClientID
+	provider := &AppleProvider{
+		ClientID: clientID,
+		JWKSURL:  jwksServer.URL,
+	}
+
+	// Create a valid ID token.
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss":            appleIssuer,
+		"aud":            clientID,
+		"sub":            "001122",
+		"email":          "test@example.com",
+		"email_verified": true,
+		"exp":            now.Add(time.Hour).Unix(),
+		"iat":            now.Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+
+	idToken, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+
+	result, err := provider.verifyIDToken(context.Background(), http.DefaultClient, idToken)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if claims.Sub != "001122" {
-		t.Errorf("expected sub '001122', got %q", claims.Sub)
+	if result.Sub != "001122" {
+		t.Errorf("expected sub '001122', got %q", result.Sub)
 	}
-	if claims.Email != "test@example.com" {
-		t.Errorf("expected email 'test@example.com', got %q", claims.Email)
+	if result.Email != "test@example.com" {
+		t.Errorf("expected email 'test@example.com', got %q", result.Email)
 	}
-	if !claims.EmailVerified {
+	if !result.EmailVerified {
 		t.Error("expected email_verified to be true")
 	}
 }
 
-func TestDecodeIDTokenInvalid(t *testing.T) {
-	_, err := decodeIDToken("not-a-jwt")
+func TestVerifyIDTokenExpired(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+
+	kid := testKID
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jwks := map[string]interface{}{
+			"keys": []map[string]interface{}{
+				{
+					"kty": "RSA",
+					"kid": kid,
+					"use": "sig",
+					"alg": "RS256",
+					"n":   base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes()),
+					"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(privateKey.E)).Bytes()),
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer jwksServer.Close()
+
+	clientID := testClientID
+	provider := &AppleProvider{
+		ClientID: clientID,
+		JWKSURL:  jwksServer.URL,
+	}
+
+	// Create an expired token.
+	claims := jwt.MapClaims{
+		"iss":   appleIssuer,
+		"aud":   clientID,
+		"sub":   "001122",
+		"email": "test@example.com",
+		"exp":   time.Now().Add(-time.Hour).Unix(),
+		"iat":   time.Now().Add(-2 * time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+
+	idToken, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+
+	_, err = provider.verifyIDToken(context.Background(), http.DefaultClient, idToken)
 	if err == nil {
-		t.Error("expected error for invalid JWT")
+		t.Fatal("expected error for expired token")
 	}
 }
 
-func TestDecodeIDTokenEmailVerifiedAsString(t *testing.T) {
-	// Payload: {"sub":"abc","email":"user@example.com","email_verified":"true"}
-	header := "eyJhbGciOiJSUzI1NiJ9"
-	payload := "eyJzdWIiOiJhYmMiLCJlbWFpbCI6InVzZXJAZXhhbXBsZS5jb20iLCJlbWFpbF92ZXJpZmllZCI6InRydWUifQ"
-	signature := "sig"
+func TestVerifyIDTokenWrongAudience(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
 
-	token := header + "." + payload + "." + signature
-	claims, err := decodeIDToken(token)
+	kid := testKID
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jwks := map[string]interface{}{
+			"keys": []map[string]interface{}{
+				{
+					"kty": "RSA",
+					"kid": kid,
+					"use": "sig",
+					"alg": "RS256",
+					"n":   base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes()),
+					"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(privateKey.E)).Bytes()),
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer jwksServer.Close()
+
+	provider := &AppleProvider{
+		ClientID: "com.example.correct",
+		JWKSURL:  jwksServer.URL,
+	}
+
+	// Token with wrong audience.
+	claims := jwt.MapClaims{
+		"iss":   appleIssuer,
+		"aud":   "com.example.wrong",
+		"sub":   "001122",
+		"email": "test@example.com",
+		"exp":   time.Now().Add(time.Hour).Unix(),
+		"iat":   time.Now().Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+
+	idToken, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+
+	_, err = provider.verifyIDToken(context.Background(), http.DefaultClient, idToken)
+	if err == nil {
+		t.Fatal("expected error for wrong audience")
+	}
+}
+
+func TestVerifyIDTokenWrongIssuer(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+
+	kid := testKID
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jwks := map[string]interface{}{
+			"keys": []map[string]interface{}{
+				{
+					"kty": "RSA",
+					"kid": kid,
+					"use": "sig",
+					"alg": "RS256",
+					"n":   base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes()),
+					"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(privateKey.E)).Bytes()),
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer jwksServer.Close()
+
+	clientID := testClientID
+	provider := &AppleProvider{
+		ClientID: clientID,
+		JWKSURL:  jwksServer.URL,
+	}
+
+	// Token with wrong issuer.
+	claims := jwt.MapClaims{
+		"iss":   "https://evil.example.com",
+		"aud":   clientID,
+		"sub":   "001122",
+		"email": "test@example.com",
+		"exp":   time.Now().Add(time.Hour).Unix(),
+		"iat":   time.Now().Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+
+	idToken, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+
+	_, err = provider.verifyIDToken(context.Background(), http.DefaultClient, idToken)
+	if err == nil {
+		t.Fatal("expected error for wrong issuer")
+	}
+}
+
+func TestVerifyIDTokenFakeSignature(t *testing.T) {
+	// Generate two different key pairs — sign with one, serve the other in JWKS.
+	signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating signing key: %v", err)
+	}
+	wrongKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating wrong key: %v", err)
+	}
+
+	kid := testKID
+	// Serve wrongKey in JWKS.
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jwks := map[string]interface{}{
+			"keys": []map[string]interface{}{
+				{
+					"kty": "RSA",
+					"kid": kid,
+					"use": "sig",
+					"alg": "RS256",
+					"n":   base64.RawURLEncoding.EncodeToString(wrongKey.N.Bytes()),
+					"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(wrongKey.E)).Bytes()),
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer jwksServer.Close()
+
+	clientID := testClientID
+	provider := &AppleProvider{
+		ClientID: clientID,
+		JWKSURL:  jwksServer.URL,
+	}
+
+	// Sign with signingKey (not the one in JWKS).
+	claims := jwt.MapClaims{
+		"iss":   appleIssuer,
+		"aud":   clientID,
+		"sub":   "001122",
+		"email": "test@example.com",
+		"exp":   time.Now().Add(time.Hour).Unix(),
+		"iat":   time.Now().Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+
+	idToken, err := token.SignedString(signingKey)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+
+	_, err = provider.verifyIDToken(context.Background(), http.DefaultClient, idToken)
+	if err == nil {
+		t.Fatal("expected error for token signed with wrong key")
+	}
+}
+
+func TestVerifyIDTokenEmailVerifiedAsString(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+
+	kid := testKID
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jwks := map[string]interface{}{
+			"keys": []map[string]interface{}{
+				{
+					"kty": "RSA",
+					"kid": kid,
+					"use": "sig",
+					"alg": "RS256",
+					"n":   base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes()),
+					"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(privateKey.E)).Bytes()),
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer jwksServer.Close()
+
+	clientID := testClientID
+	provider := &AppleProvider{
+		ClientID: clientID,
+		JWKSURL:  jwksServer.URL,
+	}
+
+	// Apple sometimes sends email_verified as a string "true".
+	claims := jwt.MapClaims{
+		"iss":            appleIssuer,
+		"aud":            clientID,
+		"sub":            "abc",
+		"email":          "user@example.com",
+		"email_verified": "true",
+		"exp":            time.Now().Add(time.Hour).Unix(),
+		"iat":            time.Now().Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+
+	idToken, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+
+	result, err := provider.verifyIDToken(context.Background(), http.DefaultClient, idToken)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !claims.EmailVerified {
+	if !result.EmailVerified {
 		t.Error("expected email_verified to be true when sent as string 'true'")
 	}
 }

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -29,12 +29,15 @@ type Claims struct {
 }
 
 // GenerateAccessToken creates a signed RS256 JWT with user claims.
-func GenerateAccessToken(key *rsa.PrivateKey, kid, issuer string, ttl time.Duration, userID, orgID uuid.UUID, username, email string, emailVerified bool, givenName, familyName string, roles ...string) (string, error) {
+// The audience parameter identifies the intended recipient of the token (typically
+// the client_id for OAuth flows, or the issuer URL for direct login flows).
+func GenerateAccessToken(key *rsa.PrivateKey, kid, issuer, audience string, ttl time.Duration, userID, orgID uuid.UUID, username, email string, emailVerified bool, givenName, familyName string, roles ...string) (string, error) {
 	now := time.Now()
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    issuer,
 			Subject:   userID.String(),
+			Audience:  jwt.ClaimStrings{audience},
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
 		},
@@ -59,12 +62,13 @@ func GenerateAccessToken(key *rsa.PrivateKey, kid, issuer string, ttl time.Durat
 
 // GenerateAccessTokenWithCustomClaims is like GenerateAccessToken but includes
 // plugin-provided custom claims in the token.
-func GenerateAccessTokenWithCustomClaims(key *rsa.PrivateKey, kid, issuer string, ttl time.Duration, userID, orgID uuid.UUID, username, email string, emailVerified bool, givenName, familyName string, customClaims map[string]any, roles ...string) (string, error) {
+func GenerateAccessTokenWithCustomClaims(key *rsa.PrivateKey, kid, issuer, audience string, ttl time.Duration, userID, orgID uuid.UUID, username, email string, emailVerified bool, givenName, familyName string, customClaims map[string]any, roles ...string) (string, error) {
 	now := time.Now()
 	claims := Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    issuer,
 			Subject:   userID.String(),
+			Audience:  jwt.ClaimStrings{audience},
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
 		},

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -66,7 +66,7 @@ func TestGenerateAndVerifyAccessToken(t *testing.T) {
 	orgID := uuid.New()
 	ttl := 15 * time.Minute
 
-	signed, err := GenerateAccessToken(testPrivKey, testKID, testIssuer, ttl, userID, orgID, "admin", "admin@test.com", true, "Admin", "User")
+	signed, err := GenerateAccessToken(testPrivKey, testKID, testIssuer, testIssuer, ttl, userID, orgID, "admin", "admin@test.com", true, "Admin", "User")
 	if err != nil {
 		t.Fatalf("GenerateAccessToken error: %v", err)
 	}
@@ -84,6 +84,10 @@ func TestGenerateAndVerifyAccessToken(t *testing.T) {
 	}
 	if claims.Issuer != testIssuer {
 		t.Errorf("iss = %q, want %q", claims.Issuer, testIssuer)
+	}
+	aud, _ := claims.GetAudience()
+	if len(aud) != 1 || aud[0] != testIssuer {
+		t.Errorf("aud = %v, want [%s]", aud, testIssuer)
 	}
 	if claims.OrgID != orgID {
 		t.Errorf("org_id = %v, want %v", claims.OrgID, orgID)
@@ -106,7 +110,7 @@ func TestGenerateAndVerifyAccessToken(t *testing.T) {
 }
 
 func TestGenerateAccessTokenIncludesKIDHeader(t *testing.T) {
-	signed, err := GenerateAccessToken(testPrivKey, testKID, testIssuer, 15*time.Minute, uuid.New(), uuid.New(), "admin", "admin@test.com", false, "", "")
+	signed, err := GenerateAccessToken(testPrivKey, testKID, testIssuer, testIssuer, 15*time.Minute, uuid.New(), uuid.New(), "admin", "admin@test.com", false, "", "")
 	if err != nil {
 		t.Fatalf("GenerateAccessToken error: %v", err)
 	}
@@ -130,7 +134,7 @@ func TestGenerateAccessTokenIncludesKIDHeader(t *testing.T) {
 }
 
 func TestVerifyAccessTokenWrongKey(t *testing.T) {
-	signed, err := GenerateAccessToken(testPrivKey, testKID, testIssuer, 15*time.Minute, uuid.New(), uuid.New(), "admin", "admin@test.com", false, "", "")
+	signed, err := GenerateAccessToken(testPrivKey, testKID, testIssuer, testIssuer, 15*time.Minute, uuid.New(), uuid.New(), "admin", "admin@test.com", false, "", "")
 	if err != nil {
 		t.Fatalf("GenerateAccessToken error: %v", err)
 	}
@@ -396,7 +400,7 @@ func TestVerifyMFAToken_RejectsAccessTokenAsMFA(t *testing.T) {
 	orgID := uuid.New()
 
 	// Generate a regular access token and try to use it as an MFA token
-	accessToken, err := GenerateAccessToken(testPrivKey, testKID, testIssuer, 15*time.Minute, userID, orgID, "testuser", "test@example.com", true, "Test", "User", "user")
+	accessToken, err := GenerateAccessToken(testPrivKey, testKID, testIssuer, testIssuer, 15*time.Minute, userID, orgID, "testuser", "test@example.com", true, "Test", "User", "user")
 	if err != nil {
 		t.Fatalf("GenerateAccessToken: %v", err)
 	}


### PR DESCRIPTION
## Summary

Fixes 13 security issues (2 CRITICAL, 6 HIGH, 5 MEDIUM) integrating work from 15+ parallel agent worktrees:

### CRITICAL
- **#170**: MFA rate limiting — account lockout on repeated failed MFA attempts
- **#183**: Apple ID token JWT signature verification using Apple's JWKS public keys

### HIGH
- **#187**: Audit logging for MFA enable/disable, password reset, and admin RBAC changes
- **#188**: Privilege escalation guard — only super_admin can assign/unassign super_admin role
- **#193**: JWT `aud` (audience) claim added to all access tokens per RFC 7519
- **#194**: Atomic database transactions for backup codes and password reset tokens
- **#196**: Database indexes on `token_hash` and `refresh_token_hash` columns

### MEDIUM
- **#199**: CSS injection prevention via color field validation in org settings
- **#200**: Refresh token TOCTOU fix — atomic find-and-rotate in OAuth token endpoint
- **#202**: Disabled OAuth clients blocked from initiating auth and exchanging tokens
- **#203**: Missing `rows.Err()` checks after database iteration in 4 files
- **#204**: Coverage threshold alignment (CI now matches Makefile at 25%)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `go vet ./...` passes
- [x] `golangci-lint run` passes (0 issues)
- [ ] CI pipeline passes