### PR TITLE
fix: batch 5 — query timeouts, RSA 4096, docs fixes

### DIFF
--- a/adapters/backend/go/rampart_test.go
+++ b/adapters/backend/go/rampart_test.go
@@ -18,7 +18,7 @@ import (
 func generateTestKeys(t *testing.T) (*rsa.PrivateKey, []byte) {
 	t.Helper()
 
-	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	privKey, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
 		t.Fatalf("generate RSA key: %v", err)
 	}

--- a/docs-site/docs/comparison/vs-authentik.md
+++ b/docs-site/docs/comparison/vs-authentik.md
@@ -18,8 +18,8 @@ Authentik is an open-source identity provider built in Python (Django) with a fo
 | **Request throughput** | High (compiled, goroutines) | Lower (interpreted, GIL constraints) |
 | **Deployment** | Single binary, Docker optional | Docker required (multiple containers) |
 | **Required services** | PostgreSQL | PostgreSQL, Redis, worker process, server process |
-| **Admin UI** | React + Vite + Tailwind | lit-element web components |
-| **Login UI** | React SPA, CSS variable themes | Flow-based, customizable |
+| **Admin UI** | htmx + Go templates + Tailwind | lit-element web components |
+| **Login UI** | htmx + Go templates, CSS variable themes | Flow-based, customizable |
 | **Configuration** | YAML + REST API | Admin UI + REST API, YAML (limited) |
 | **Flow engine** | Standard OAuth 2.0/OIDC flows | Visual flow designer (stages, policies) |
 | **Protocol support** | OAuth 2.0, OIDC, SAML (planned) | OAuth 2.0, OIDC, SAML, LDAP, SCIM, Proxy |
@@ -143,7 +143,7 @@ Authentik's proxy provider and LDAP outbound provider are particularly useful fo
 - You prefer lower operational complexity (one process vs four).
 - Your authentication flows follow standard OAuth 2.0/OIDC patterns.
 - You are running in resource-constrained environments (edge, small VMs, ARM devices).
-- You want a modern React-based admin UI.
+- You want a modern htmx + Go templates admin UI.
 - Your team has Go expertise for extending and contributing.
 
 ## When to Choose Authentik

--- a/docs-site/docs/comparison/vs-keycloak.md
+++ b/docs-site/docs/comparison/vs-keycloak.md
@@ -18,10 +18,10 @@ Both are excellent choices depending on your requirements. This page offers a fa
 | **Memory usage** | ~30 MB idle | 512 MB+ idle (JVM heap) |
 | **Startup time** | < 1 second | 10–30 seconds |
 | **Binary size** | ~20 MB single binary | 200+ MB (with dependencies) |
-| **Deployment** | Single binary, Docker, or systemd | Docker, Kubernetes, or application server |
+| **Deployment** | Single binary, Docker, or systemd | Docker, Kubernetes, or bare metal (Quarkus-based since v17) |
 | **Database** | PostgreSQL | PostgreSQL, MySQL, Oracle, MSSQL |
-| **Admin UI** | React + Vite + Tailwind | React (PatternFly, v22+) |
-| **Login UI** | React SPA with CSS variable themes | FreeMarker templates |
+| **Admin UI** | htmx + Go templates + Tailwind | React (PatternFly, v22+) |
+| **Login UI** | htmx + Go templates with CSS variable themes | FreeMarker templates |
 | **Theming** | CSS variables, instant switching | FreeMarker template overrides |
 | **Configuration** | Environment variables + REST API | Admin console, CLI, REST API |
 | **Extension model** | Plugin system (planned) | Java SPIs |
@@ -60,7 +60,7 @@ Single binary with PostgreSQL as the only external dependency.
 
 ### Keycloak
 
-Keycloak requires a Java runtime and a database. Production deployments typically involve JVM tuning, clustering configuration via Infinispan, and a reverse proxy. Kubernetes deployments can use the Keycloak Operator.
+Since version 17, Keycloak runs on Quarkus (replacing the legacy WildFly/application server model). It requires a Java runtime and a database. Production deployments typically involve JVM tuning, clustering configuration via Infinispan, and a reverse proxy. Kubernetes deployments can use the Keycloak Operator.
 
 ## Where Keycloak Excels
 
@@ -78,7 +78,7 @@ Keycloak has significant strengths:
 - **Resource efficiency.** Significantly lower memory and faster startup.
 - **Deployment simplicity.** Single binary, minimal configuration.
 - **Theming.** CSS variable-based themes with instant switching, no server restart needed.
-- **Modern stack.** Go backend, React admin UI, built-in observability with Prometheus metrics.
+- **Modern stack.** Go backend, htmx + Go templates admin UI, built-in observability with Prometheus metrics.
 
 ## Migration Considerations
 

--- a/docs-site/docs/comparison/vs-ory.md
+++ b/docs-site/docs/comparison/vs-ory.md
@@ -14,8 +14,8 @@ Ory provides a suite of open-source identity and access management services: Hyd
 |--------|---------|----------------------------|
 | **Architecture** | Single binary, all-in-one | Microservices (3–4 separate services) |
 | **Language** | Go | Go |
-| **Admin UI** | Included (React SPA) | Not included (build your own or use Ory Cloud) |
-| **Login UI** | Included (React SPA, themeable) | Not included (you must build it) |
+| **Admin UI** | Included (htmx + Go templates) | Not included (build your own or use Ory Cloud) |
+| **Login UI** | Included (htmx + Go templates, themeable) | Not included (you must build it) |
 | **Deployment** | 1 binary + PostgreSQL | 3–4 binaries + PostgreSQL + migrations per service |
 | **Configuration** | Single YAML file | Separate config per service |
 | **User management** | Built-in admin API + UI | Kratos handles identity, no admin UI |

--- a/docs-site/docs/comparison/vs-zitadel.md
+++ b/docs-site/docs/comparison/vs-zitadel.md
@@ -16,8 +16,8 @@ Zitadel is a Go-based identity management platform that provides OAuth 2.0/OIDC,
 | **Database** | PostgreSQL | CockroachDB (primary) or PostgreSQL (added later) |
 | **Cache/Sessions** | PostgreSQL | In-process (event-sourced projections) |
 | **Architecture** | Traditional CRUD + event audit log | Full event sourcing (CQRS) |
-| **Admin UI** | React + Vite + Tailwind | Angular (custom framework) |
-| **Login UI** | React SPA, CSS variable themes | Server-rendered Go templates |
+| **Admin UI** | htmx + Go templates + Tailwind | Angular (custom framework) |
+| **Login UI** | htmx + Go templates, CSS variable themes | Server-rendered Go templates |
 | **Deployment** | Single binary + PostgreSQL | Single binary + CockroachDB (or PostgreSQL) |
 | **Extensibility** | Plugin system (planned), webhooks | Actions (JavaScript/TypeScript runtime) |
 | **Multi-tenancy** | Organizations | Organizations + instances |
@@ -100,7 +100,7 @@ Zitadel's admin console is built with Angular using a custom component framework
 
 ### Rampart
 
-Rampart's admin dashboard and login UI are both React SPAs built with Vite and Tailwind CSS. The login UI supports per-tenant theming via CSS variables with instant preview in the admin dashboard. No server restart is required to change themes.
+Rampart's admin dashboard and login UI are both built with htmx and Go server-side templates, styled with Tailwind CSS. The login UI supports per-tenant theming via CSS variables with instant preview in the admin dashboard. No server restart is required to change themes.
 
 ## Where Zitadel Wins
 
@@ -116,7 +116,7 @@ Rampart's admin dashboard and login UI are both React SPAs built with Vite and T
 - Your infrastructure runs PostgreSQL and you do not want to introduce CockroachDB.
 - You prefer a simpler, CRUD-based architecture that is easy to reason about and debug.
 - Lower resource usage is important (edge deployments, cost-sensitive environments).
-- You want a modern React-based admin UI and login experience with easy theming.
+- You want a modern htmx-based admin UI and login experience with easy theming.
 - Your team has Go expertise and wants to extend the IAM server in Go.
 - Fast startup time matters (CI/CD pipelines, auto-scaling, development).
 

--- a/docs-site/docs/contributing.md
+++ b/docs-site/docs/contributing.md
@@ -112,11 +112,11 @@ golangci-lint run ./...
 - **String constants** — extract string literals used 3+ times into named constants.
 - **Keep functions short** — if a function needs a comment explaining what it does, consider splitting it.
 
-### Frontend (TypeScript / React)
+### Frontend (htmx + Go Templates)
 
-- Follow the existing ESLint and Prettier configuration in `client/` and `login-ui/`.
-- Use functional components with hooks.
-- Use TypeScript strict mode — no `any` types.
+- The admin UI and login UI use htmx with Go server-side templates, styled with Tailwind CSS.
+- Follow the existing template conventions in the `internal/` handler and template directories.
+- Keep JavaScript minimal — prefer htmx attributes for interactivity.
 
 ## Testing Requirements
 

--- a/docs-site/docs/getting-started/login-themes.md
+++ b/docs-site/docs/getting-started/login-themes.md
@@ -5,7 +5,7 @@ title: Login Page Themes
 
 # Login Page Themes
 
-Rampart ships with **5 built-in themes** for the login and consent pages. Changing the theme for an organization is a single API call — no server restart, no template files, no WAR overlays.
+Rampart ships with **5 built-in themes** for the login and consent pages. Changing the theme for an organization is a single API call — no server restart, no template files, no theme archive deployments.
 
 ## Built-in Themes
 

--- a/docs-site/docs/intro.md
+++ b/docs-site/docs/intro.md
@@ -8,7 +8,7 @@ description: Rampart is a lightweight, modern identity and access management ser
 
 Rampart is a lightweight, production-grade identity and access management (IAM) server. It provides OAuth 2.0 and OpenID Connect out of the box, with an admin console, CLI tool, and SDK adapters for every major stack — all shipped as a single binary.
 
-Built in Go with PostgreSQL, Rampart starts in under 1 second and runs at approximately 30 MB of memory. No Java runtime, no WAR files, no complex dependency chains. Just download, configure, and run.
+Built in Go with PostgreSQL, Rampart starts in under 1 second and runs at approximately 30 MB of memory. No Java runtime, no complex dependency chains. Just download, configure, and run.
 
 ## Key Features
 
@@ -38,7 +38,7 @@ Built in Go with PostgreSQL, Rampart starts in under 1 second and runs at approx
 | Language | Go | Java | Go | Go | Python |
 | Startup Time | < 1s | 10-30s | < 1s | ~3s | ~10s |
 | Memory | ~30 MB | 512 MB+ | ~50 MB | ~100 MB | ~300 MB |
-| Deployment | Single binary | WAR + WildFly | Multiple services | Single binary | Docker required |
+| Deployment | Single binary | Docker or Kubernetes (Quarkus-based) | Multiple services | Single binary | Docker required |
 | Admin UI | Yes | Yes | No (headless) | Yes | Yes |
 
 ## Next Steps

--- a/internal/database/authorization_code.go
+++ b/internal/database/authorization_code.go
@@ -28,6 +28,9 @@ func (db *DB) StoreAuthorizationCode(ctx context.Context, code, clientID string,
 // ConsumeAuthorizationCode atomically marks an authorization code as used and returns it.
 // Returns nil if the code doesn't exist, is already used, or is expired.
 func (db *DB) ConsumeAuthorizationCode(ctx context.Context, code string) (*model.AuthorizationCode, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	hash := sha256.Sum256([]byte(code))
 	row := db.Pool.QueryRow(ctx, `
 		UPDATE authorization_codes

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -15,9 +15,20 @@ const (
 	defaultMinConns = 2
 	connectTimeout  = 10 * time.Second
 
+	// defaultQueryTimeout is the maximum duration a single database query should
+	// take before being cancelled. This prevents runaway queries from holding
+	// connections indefinitely.
+	defaultQueryTimeout = 5 * time.Second
+
 	// pgUniqueViolation is the PostgreSQL error code for unique constraint violations.
 	pgUniqueViolation = "23505"
 )
+
+// queryCtx derives a child context with the default query timeout.
+// Callers must call the returned cancel function when done (typically via defer).
+func queryCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, defaultQueryTimeout)
+}
 
 // DB wraps a pgx connection pool.
 type DB struct {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -37,3 +37,37 @@ func TestCloseNilPool(t *testing.T) {
 	// Should not panic
 	db.Close()
 }
+
+func TestQueryCtxAppliesTimeout(t *testing.T) {
+	parent := context.Background()
+	ctx, cancel := queryCtx(parent)
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected context to have a deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 || remaining > defaultQueryTimeout {
+		t.Fatalf("expected deadline within %v, got %v remaining", defaultQueryTimeout, remaining)
+	}
+}
+
+func TestQueryCtxRespectsExistingTighterDeadline(t *testing.T) {
+	tighterTimeout := 1 * time.Second
+	parent, parentCancel := context.WithTimeout(context.Background(), tighterTimeout)
+	defer parentCancel()
+
+	ctx, cancel := queryCtx(parent)
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected context to have a deadline")
+	}
+	remaining := time.Until(deadline)
+	// The effective deadline should be the tighter parent deadline, not defaultQueryTimeout.
+	if remaining > tighterTimeout {
+		t.Fatalf("expected deadline within %v (parent), got %v remaining", tighterTimeout, remaining)
+	}
+}

--- a/internal/database/oauth_client.go
+++ b/internal/database/oauth_client.go
@@ -16,6 +16,9 @@ import (
 
 // GetOAuthClient retrieves an OAuth client by its ID.
 func (db *DB) GetOAuthClient(ctx context.Context, clientID string) (*model.OAuthClient, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	row := db.Pool.QueryRow(ctx, `
 		SELECT id, org_id, name, client_type, redirect_uris,
 		       COALESCE(client_secret_hash, ''::bytea), COALESCE(description, ''),

--- a/internal/database/organization.go
+++ b/internal/database/organization.go
@@ -23,6 +23,9 @@ func (db *DB) GetDefaultOrganizationID(ctx context.Context) (uuid.UUID, error) {
 
 // GetOrganizationIDBySlug returns the UUID of an organization by its slug.
 func (db *DB) GetOrganizationIDBySlug(ctx context.Context, slug string) (uuid.UUID, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var id uuid.UUID
 	err := db.Pool.QueryRow(ctx,
 		"SELECT id FROM organizations WHERE slug = $1", slug,
@@ -38,6 +41,9 @@ func (db *DB) GetOrganizationIDBySlug(ctx context.Context, slug string) (uuid.UU
 
 // GetOrganizationByID returns a full Organization by its UUID.
 func (db *DB) GetOrganizationByID(ctx context.Context, id uuid.UUID) (*model.Organization, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT id, name, slug, display_name, enabled, created_at, updated_at
 		FROM organizations

--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -59,6 +59,9 @@ func (db *DB) CreateUser(ctx context.Context, user *model.User) (*model.User, er
 
 // GetUserByEmail finds a user by email within an organization.
 func (db *DB) GetUserByEmail(ctx context.Context, email string, orgID uuid.UUID) (*model.User, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT id, org_id, username, email, email_verified, COALESCE(given_name, '') AS given_name, COALESCE(family_name, '') AS family_name,
 		       enabled, mfa_enabled, password_hash, failed_login_attempts, locked_until,
@@ -111,6 +114,9 @@ func (db *DB) FindUserByEmail(ctx context.Context, email string) (*model.User, e
 
 // GetUserByID finds a user by their UUID.
 func (db *DB) GetUserByID(ctx context.Context, id uuid.UUID) (*model.User, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT id, org_id, username, email, email_verified, COALESCE(given_name, '') AS given_name, COALESCE(family_name, '') AS family_name,
 		       enabled, mfa_enabled, password_hash, failed_login_attempts, locked_until,
@@ -172,6 +178,9 @@ func (db *DB) ResetFailedLogins(ctx context.Context, userID uuid.UUID) error {
 
 // GetUserByUsername finds a user by username within an organization.
 func (db *DB) GetUserByUsername(ctx context.Context, username string, orgID uuid.UUID) (*model.User, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT id, org_id, username, email, email_verified, COALESCE(given_name, '') AS given_name, COALESCE(family_name, '') AS family_name,
 		       enabled, mfa_enabled, password_hash, failed_login_attempts, locked_until,

--- a/internal/signing/signing.go
+++ b/internal/signing/signing.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 )
 
-const rsaKeyBits = 2048
+const rsaKeyBits = 4096
 
 // KeyPair holds the RSA key pair and its computed Key ID.
 type KeyPair struct {
@@ -24,7 +24,7 @@ type KeyPair struct {
 }
 
 // LoadOrGenerate loads an RSA private key from the given PEM file path.
-// If the file does not exist, it generates a new 2048-bit key pair,
+// If the file does not exist, it generates a new 4096-bit key pair,
 // writes it to the file, and returns the key pair.
 func LoadOrGenerate(path string) (*KeyPair, error) {
 	clean := filepath.Clean(path)

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -139,7 +139,7 @@ func TestVerifyAccessTokenWrongKey(t *testing.T) {
 		t.Fatalf("GenerateAccessToken error: %v", err)
 	}
 
-	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	otherKey, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
 		t.Fatalf("failed to generate other key: %v", err)
 	}


### PR DESCRIPTION
## Summary
- **#195**: 5s query timeouts on critical DB hot-path operations (user lookup, OAuth client, auth code, org resolution)
- **#179**: RSA key generation upgraded from 2048 to 4096 bits
- **#186**: OAuth discovery `refresh_token` grant now backed by actual handler (added in PR #211)
- **#177**: Docs corrected — admin UI uses htmx + Go templates, not React
- **#206**: Keycloak docs updated — Quarkus replaces WildFly since v17

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [ ] CI pipeline