### PR TITLE
fix: add 10s timeout to social provider HTTP clients

### DIFF
--- a/internal/social/apple.go
+++ b/internal/social/apple.go
@@ -170,7 +170,7 @@ func (a *AppleProvider) httpClient() *http.Client {
 	if a.HTTPClient != nil {
 		return a.HTTPClient
 	}
-	return http.DefaultClient
+	return defaultHTTPClient
 }
 
 func (a *AppleProvider) getClientSecret() (string, error) {

--- a/internal/social/github.go
+++ b/internal/social/github.go
@@ -108,7 +108,7 @@ func (g *GitHubProvider) httpClient() *http.Client {
 	if g.HTTPClient != nil {
 		return g.HTTPClient
 	}
-	return http.DefaultClient
+	return defaultHTTPClient
 }
 
 func (g *GitHubProvider) exchangeToken(ctx context.Context, client *http.Client, code, redirectURL string) (*githubTokenResponse, error) {

--- a/internal/social/google.go
+++ b/internal/social/google.go
@@ -101,7 +101,7 @@ func (g *GoogleProvider) httpClient() *http.Client {
 	if g.HTTPClient != nil {
 		return g.HTTPClient
 	}
-	return http.DefaultClient
+	return defaultHTTPClient
 }
 
 func (g *GoogleProvider) exchangeToken(ctx context.Context, client *http.Client, code, redirectURL string) (*googleTokenResponse, error) {

--- a/internal/social/provider.go
+++ b/internal/social/provider.go
@@ -2,8 +2,16 @@ package social
 
 import (
 	"context"
+	"net/http"
 	"time"
 )
+
+// defaultHTTPClient is a shared HTTP client with a 10-second timeout,
+// used by social providers when no custom HTTPClient is provided.
+// This prevents hanging indefinitely on slow upstream servers.
+var defaultHTTPClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
 
 // UserInfo represents the normalized user info returned by any social provider.
 type UserInfo struct {

--- a/internal/social/provider_test.go
+++ b/internal/social/provider_test.go
@@ -1876,8 +1876,12 @@ func TestGitHubExchangeNoEmails(t *testing.T) {
 
 func TestAppleHTTPClient(t *testing.T) {
 	provider := &AppleProvider{}
-	if provider.httpClient() != http.DefaultClient {
-		t.Error("expected default client when HTTPClient is nil")
+	client := provider.httpClient()
+	if client == nil || client == http.DefaultClient {
+		t.Error("expected non-nil default client with timeout when HTTPClient is nil")
+	}
+	if client.Timeout == 0 {
+		t.Error("expected default client to have a timeout")
 	}
 
 	custom := &http.Client{Timeout: 5 * time.Second}
@@ -1889,8 +1893,12 @@ func TestAppleHTTPClient(t *testing.T) {
 
 func TestGoogleHTTPClient(t *testing.T) {
 	provider := &GoogleProvider{}
-	if provider.httpClient() != http.DefaultClient {
-		t.Error("expected default client when HTTPClient is nil")
+	client := provider.httpClient()
+	if client == nil || client == http.DefaultClient {
+		t.Error("expected non-nil default client with timeout when HTTPClient is nil")
+	}
+	if client.Timeout == 0 {
+		t.Error("expected default client to have a timeout")
 	}
 
 	custom := &http.Client{Timeout: 5 * time.Second}
@@ -1902,8 +1910,12 @@ func TestGoogleHTTPClient(t *testing.T) {
 
 func TestGitHubHTTPClient(t *testing.T) {
 	provider := &GitHubProvider{}
-	if provider.httpClient() != http.DefaultClient {
-		t.Error("expected default client when HTTPClient is nil")
+	client := provider.httpClient()
+	if client == nil || client == http.DefaultClient {
+		t.Error("expected non-nil default client with timeout when HTTPClient is nil")
+	}
+	if client.Timeout == 0 {
+		t.Error("expected default client to have a timeout")
 	}
 
 	custom := &http.Client{Timeout: 5 * time.Second}


### PR DESCRIPTION
## Summary
- Social providers (Google, GitHub, Apple) fell back to `http.DefaultClient` (no timeout)
- Added shared `defaultHTTPClient` with 10-second timeout
- Updated tests to verify timeout is set

Closes #215

## Test plan
- [x] `go test ./... -count=1` — all pass
- [x] `golangci-lint run` — 0 issues