### PR TITLE
fix: add json:"-" tags to sensitive model fields

### DIFF
--- a/internal/model/mfa.go
+++ b/internal/model/mfa.go
@@ -12,7 +12,7 @@ type MFADevice struct {
 	UserID     uuid.UUID
 	DeviceType string
 	Name       string
-	Secret     string
+	Secret     string `json:"-"`
 	Verified   bool
 	CreatedAt  time.Time
 	UpdatedAt  time.Time

--- a/internal/model/saml.go
+++ b/internal/model/saml.go
@@ -13,10 +13,10 @@ type SAMLProvider struct {
 	Name             string
 	EntityID         string
 	MetadataURL      string
-	MetadataXML      string
+	MetadataXML      string `json:"-"`
 	SSOURL           string
 	SLOURL           string
-	Certificate      string
+	Certificate      string `json:"-"`
 	NameIDFormat     string
 	AttributeMapping map[string]string // maps SAML attributes to Rampart fields (email, given_name, family_name, username)
 	Enabled          bool

--- a/internal/model/webhook.go
+++ b/internal/model/webhook.go
@@ -11,7 +11,7 @@ type Webhook struct {
 	ID          uuid.UUID
 	OrgID       uuid.UUID
 	URL         string
-	Secret      string
+	Secret      string `json:"-"`
 	Description string
 	EventTypes  []string
 	Enabled     bool


### PR DESCRIPTION
## Summary
- Add `json:"-"` to `MFADevice.Secret` (TOTP shared secret)
- Add `json:"-"` to `Webhook.Secret` (HMAC signing secret)
- Add `json:"-"` to `SAMLProvider.Certificate` and `MetadataXML` (IdP credentials)

Prevents accidental serialization of secrets in API responses.

Closes #225

## Test plan
- [x] `go test ./... -count=1` — all pass
- [x] `go build ./...` — clean