### PR TITLE
fix: use base64.RawURLEncoding for at_hash computation

### DIFF
--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -163,7 +162,7 @@ func GenerateIDToken(key *rsa.PrivateKey, kid, issuer, audience string, ttl time
 func computeAtHash(accessToken string) string {
 	h := sha256.Sum256([]byte(accessToken))
 	leftHalf := h[:sha256.Size/2]
-	return strings.TrimRight(base64.URLEncoding.EncodeToString(leftHalf), "=")
+	return base64.RawURLEncoding.EncodeToString(leftHalf)
 }
 
 // MFAAudience is the audience value for MFA challenge tokens.

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -707,7 +707,7 @@ func TestComputeAtHash_Correctness(t *testing.T) {
 	accessToken := "ya29.test-access-token-12345"
 	h := sha256.Sum256([]byte(accessToken))
 	leftHalf := h[:sha256.Size/2]
-	expected := strings.TrimRight(base64.URLEncoding.EncodeToString(leftHalf), "=")
+	expected := base64.RawURLEncoding.EncodeToString(leftHalf)
 
 	got := computeAtHash(accessToken)
 	if got != expected {


### PR DESCRIPTION
## Summary
- Replace `base64.URLEncoding` + `strings.TrimRight("=")` with `base64.RawURLEncoding` for `at_hash` computation
- Per RFC 7515, `at_hash` must use base64url without padding
- Output is identical; code is now idiomatic and matches rest of codebase

Closes #219

## Test plan
- [x] `go test ./... -count=1` — all pass
- [x] `go build ./...` — clean
- [x] `golangci-lint run` — 0 issues