### PR TITLE
fix: prevent webhook DNS rebinding with SSRF-safe transport

### DIFF
--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 
@@ -48,7 +49,8 @@ func NewDispatcher(s Store, logger *slog.Logger) *Dispatcher {
 	return &Dispatcher{
 		store: s,
 		client: &http.Client{
-			Timeout: deliveryTimeout,
+			Timeout:   deliveryTimeout,
+			Transport: newSSRFSafeTransport(),
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				if err := ValidateWebhookURL(req.URL.String()); err != nil {
 					return fmt.Errorf("redirect blocked: %w", err)
@@ -60,6 +62,39 @@ func NewDispatcher(s Store, logger *slog.Logger) *Dispatcher {
 			},
 		},
 		logger: logger,
+	}
+}
+
+// newSSRFSafeTransport returns an http.Transport that validates the resolved
+// IP address at connection time. This prevents DNS rebinding attacks where a
+// hostname resolves to a public IP at validation time but a private IP later.
+func newSSRFSafeTransport() *http.Transport {
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	return &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid address %q: %w", addr, err)
+			}
+
+			ips, err := net.DefaultResolver.LookupHost(ctx, host)
+			if err != nil {
+				return nil, fmt.Errorf("DNS resolution failed for %q: %w", host, err)
+			}
+
+			for _, ipStr := range ips {
+				ip := net.ParseIP(ipStr)
+				if ip == nil {
+					continue
+				}
+				if err := checkIP(ip); err != nil {
+					return nil, fmt.Errorf("SSRF blocked: resolved IP %s for %q: %w", ipStr, host, err)
+				}
+			}
+
+			// Connect to the first resolved IP that passed validation.
+			return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0], port))
+		},
 	}
 }
 

--- a/internal/webhook/dispatcher_test.go
+++ b/internal/webhook/dispatcher_test.go
@@ -62,6 +62,14 @@ func (m *mockStore) GetAuditEventByID(_ context.Context, id uuid.UUID) (*model.A
 	return nil, nil
 }
 
+// newTestDispatcher creates a dispatcher with the default transport (no SSRF
+// validation) so tests can use httptest.NewServer on localhost.
+func newTestDispatcher(s *mockStore) *Dispatcher {
+	d := NewDispatcher(s, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	d.client.Transport = http.DefaultTransport
+	return d
+}
+
 func TestDispatch_EnqueuesDeliveries(t *testing.T) {
 	orgID := uuid.New()
 	whID := uuid.New()
@@ -121,7 +129,7 @@ func TestDeliver_SuccessfulDelivery(t *testing.T) {
 		},
 	}
 
-	d := NewDispatcher(store, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	d := newTestDispatcher(store)
 	d.ProcessPending(context.Background())
 
 	if len(store.updates) != 1 {
@@ -154,7 +162,7 @@ func TestDeliver_FailedDelivery_Retries(t *testing.T) {
 		},
 	}
 
-	d := NewDispatcher(store, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	d := newTestDispatcher(store)
 	d.ProcessPending(context.Background())
 
 	if len(store.updates) != 1 {
@@ -188,7 +196,7 @@ func TestDeliver_MaxAttempts_PermanentFailure(t *testing.T) {
 		},
 	}
 
-	d := NewDispatcher(store, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	d := newTestDispatcher(store)
 	d.ProcessPending(context.Background())
 
 	if len(store.updates) != 1 {
@@ -196,6 +204,29 @@ func TestDeliver_MaxAttempts_PermanentFailure(t *testing.T) {
 	}
 	if store.updates[0].Status != "failed" {
 		t.Errorf("expected status 'failed' after max attempts, got %q", store.updates[0].Status)
+	}
+}
+
+func TestSSRFSafeTransport_BlocksLoopback(t *testing.T) {
+	// Verify the SSRF-safe transport blocks connections to loopback addresses.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: newSSRFSafeTransport(),
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Do(req)
+	if err == nil {
+		t.Fatal("expected SSRF-safe transport to block loopback connection")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `newSSRFSafeTransport()` with custom `DialContext` that validates resolved IPs at connection time
- Eliminates DNS rebinding window: hostname validated at creation could resolve differently at delivery
- Blocks loopback, private, link-local, and cloud metadata IPs at TCP dial level
- Added test verifying loopback connections are blocked by the transport

Closes #218

## Test plan
- [x] `go test ./... -count=1` — all pass
- [x] SSRF transport test verifies loopback blocking
- [x] `golangci-lint run` — 0 issues