### PR TITLE
fix: invalidate sessions on admin password reset

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -417,6 +417,12 @@ func (h *AdminHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Invalidate all sessions for the user after password reset to prevent
+	// continued access with potentially compromised credentials.
+	if err := h.sessions.DeleteByUserID(ctx, userID); err != nil {
+		h.logger.Error("failed to invalidate sessions after password reset", "user_id", userID, "error", err)
+	}
+
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/handler/admin_console_users.go
+++ b/internal/handler/admin_console_users.go
@@ -301,6 +301,11 @@ func (h *AdminConsoleHandler) ResetPasswordAction(w http.ResponseWriter, r *http
 		return
 	}
 
+	// Invalidate all sessions for the user after password reset.
+	if err := h.sessions.DeleteByUserID(r.Context(), userID); err != nil {
+		h.logger.Error("failed to invalidate sessions after password reset", "user_id", userID, "error", err)
+	}
+
 	pwAuthUser := middleware.GetAuthenticatedUser(r.Context())
 	h.auditLog(r, pwAuthUser.OrgID, model.EventUserPasswordReset, "user", userID.String(), "")
 	middleware.SetFlash(w, "Password reset successfully.")


### PR DESCRIPTION
## Summary
- Admin API `POST /api/v1/admin/users/{id}/reset-password` now invalidates all user sessions after password change
- Admin console `POST /admin/users/{id}/reset-password` now invalidates all user sessions after password change
- Prevents continued access with potentially compromised credentials

User-initiated password reset (`POST /reset-password`) already had this behavior.

Closes #217

## Test plan
- [x] `go test ./... -count=1` — all pass
- [x] `go build ./...` — clean
- [x] `golangci-lint run` — 0 issues