### PR TITLE
fix: add query timeouts to all database functions

### DIFF
--- a/internal/database/audit.go
+++ b/internal/database/audit.go
@@ -15,6 +15,9 @@ import (
 
 // CreateAuditEvent inserts a new audit event and populates the ID and CreatedAt fields.
 func (db *DB) CreateAuditEvent(ctx context.Context, event *model.AuditEvent) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	detailsJSON, err := json.Marshal(event.Details)
 	if err != nil {
 		detailsJSON = []byte("{}")
@@ -37,6 +40,9 @@ func (db *DB) CreateAuditEvent(ctx context.Context, event *model.AuditEvent) err
 
 // GetAuditEventByID returns a single audit event by ID.
 func (db *DB) GetAuditEventByID(ctx context.Context, id uuid.UUID) (*model.AuditEvent, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var e model.AuditEvent
 	var detailsJSON []byte
 	err := db.Pool.QueryRow(ctx,
@@ -56,6 +62,9 @@ func (db *DB) GetAuditEventByID(ctx context.Context, id uuid.UUID) (*model.Audit
 
 // ListAuditEvents returns a paginated, filterable list of audit events.
 func (db *DB) ListAuditEvents(ctx context.Context, orgID uuid.UUID, eventType, search string, limit, offset int) ([]*model.AuditEvent, int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	where := []string{"org_id = $1"}
 	args := []any{orgID}
 	paramIdx := 2
@@ -122,6 +131,9 @@ func (db *DB) ListAuditEvents(ctx context.Context, orgID uuid.UUID, eventType, s
 
 // LoginCountsByDay returns login event counts per day for the last N days.
 func (db *DB) LoginCountsByDay(ctx context.Context, orgID uuid.UUID, days int) ([]model.DayCount, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT d::date AS day, COALESCE(c.cnt, 0) AS count
 		FROM generate_series(
@@ -160,6 +172,9 @@ func (db *DB) LoginCountsByDay(ctx context.Context, orgID uuid.UUID, days int) (
 
 // CountRecentEvents returns the number of audit events in the last N hours.
 func (db *DB) CountRecentEvents(ctx context.Context, orgID uuid.UUID, hours int) (int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var count int
 	err := db.Pool.QueryRow(ctx,
 		"SELECT COUNT(*) FROM audit_events WHERE org_id = $1 AND created_at > now() - make_interval(hours => $2)",

--- a/internal/database/authorization_code.go
+++ b/internal/database/authorization_code.go
@@ -14,6 +14,9 @@ import (
 
 // StoreAuthorizationCode persists an authorization code (as SHA-256 hash) in the database.
 func (db *DB) StoreAuthorizationCode(ctx context.Context, code, clientID string, userID, orgID uuid.UUID, redirectURI, codeChallenge, scope, nonce string, expiresAt time.Time) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	hash := sha256.Sum256([]byte(code))
 	_, err := db.Pool.Exec(ctx, `
 		INSERT INTO authorization_codes (code_hash, client_id, user_id, org_id, redirect_uri, code_challenge, scope, nonce, expires_at)
@@ -53,6 +56,9 @@ func (db *DB) ConsumeAuthorizationCode(ctx context.Context, code string) (*model
 
 // DeleteExpiredAuthorizationCodes removes authorization codes that have expired.
 func (db *DB) DeleteExpiredAuthorizationCodes(ctx context.Context) (int64, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	tag, err := db.Pool.Exec(ctx, "DELETE FROM authorization_codes WHERE expires_at < now()")
 	if err != nil {
 		return 0, fmt.Errorf("deleting expired authorization codes: %w", err)

--- a/internal/database/consent.go
+++ b/internal/database/consent.go
@@ -22,6 +22,9 @@ type UserConsent struct {
 
 // HasConsent checks if a user has already granted consent for a client with the given scopes.
 func (db *DB) HasConsent(ctx context.Context, userID uuid.UUID, clientID, scopes string) (bool, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var exists bool
 	err := db.Pool.QueryRow(ctx,
 		`SELECT EXISTS(SELECT 1 FROM user_consents WHERE user_id = $1 AND client_id = $2 AND scopes = $3)`,
@@ -35,6 +38,9 @@ func (db *DB) HasConsent(ctx context.Context, userID uuid.UUID, clientID, scopes
 
 // GrantConsent stores or updates a user's consent for an OAuth client.
 func (db *DB) GrantConsent(ctx context.Context, userID uuid.UUID, clientID, scopes string) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		`INSERT INTO user_consents (user_id, client_id, scopes)
 		 VALUES ($1, $2, $3)
@@ -50,6 +56,9 @@ func (db *DB) GrantConsent(ctx context.Context, userID uuid.UUID, clientID, scop
 
 // RevokeConsent removes a user's consent for an OAuth client.
 func (db *DB) RevokeConsent(ctx context.Context, userID uuid.UUID, clientID string) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		`DELETE FROM user_consents WHERE user_id = $1 AND client_id = $2`,
 		userID, clientID,
@@ -62,6 +71,9 @@ func (db *DB) RevokeConsent(ctx context.Context, userID uuid.UUID, clientID stri
 
 // ListUserConsents returns all active consents for a user.
 func (db *DB) ListUserConsents(ctx context.Context, userID uuid.UUID) ([]UserConsent, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	rows, err := db.Pool.Query(ctx,
 		`SELECT id, user_id, client_id, scopes, created_at, updated_at
 		 FROM user_consents WHERE user_id = $1 ORDER BY created_at DESC`,
@@ -85,6 +97,9 @@ func (db *DB) ListUserConsents(ctx context.Context, userID uuid.UUID) ([]UserCon
 
 // GetConsent retrieves a specific consent record.
 func (db *DB) GetConsent(ctx context.Context, userID uuid.UUID, clientID string) (*UserConsent, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var c UserConsent
 	err := db.Pool.QueryRow(ctx,
 		`SELECT id, user_id, client_id, scopes, created_at, updated_at

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -20,6 +20,9 @@ const (
 	// connections indefinitely.
 	defaultQueryTimeout = 5 * time.Second
 
+	// defaultTxTimeout is the maximum duration for a multi-statement transaction.
+	defaultTxTimeout = 30 * time.Second
+
 	// pgUniqueViolation is the PostgreSQL error code for unique constraint violations.
 	pgUniqueViolation = "23505"
 )
@@ -28,6 +31,12 @@ const (
 // Callers must call the returned cancel function when done (typically via defer).
 func queryCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, defaultQueryTimeout)
+}
+
+// txCtx derives a child context with the default transaction timeout.
+// Use this instead of queryCtx for multi-statement transactions.
+func txCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, defaultTxTimeout)
 }
 
 // DB wraps a pgx connection pool.

--- a/internal/database/email_verification.go
+++ b/internal/database/email_verification.go
@@ -15,6 +15,9 @@ import (
 // The plaintext token is NOT stored — only its SHA-256 hash.
 // Any existing unused tokens for the user are invalidated.
 func (db *DB) CreateEmailVerificationToken(ctx context.Context, userID uuid.UUID, tokenPlaintext string, expiresAt time.Time) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	hash := sha256.Sum256([]byte(tokenPlaintext))
 
 	// Invalidate any existing unused tokens for this user
@@ -33,6 +36,9 @@ func (db *DB) CreateEmailVerificationToken(ctx context.Context, userID uuid.UUID
 // ConsumeEmailVerificationToken validates and consumes an email verification token.
 // Returns the user ID if valid, or an error if expired/used/not found.
 func (db *DB) ConsumeEmailVerificationToken(ctx context.Context, tokenPlaintext string) (uuid.UUID, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	hash := sha256.Sum256([]byte(tokenPlaintext))
 
 	var userID uuid.UUID
@@ -53,6 +59,9 @@ func (db *DB) ConsumeEmailVerificationToken(ctx context.Context, tokenPlaintext 
 
 // MarkEmailVerified sets email_verified = true for the given user.
 func (db *DB) MarkEmailVerified(ctx context.Context, userID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		`UPDATE users SET email_verified = true, updated_at = now() WHERE id = $1`,
 		userID,
@@ -65,6 +74,9 @@ func (db *DB) MarkEmailVerified(ctx context.Context, userID uuid.UUID) error {
 
 // DeleteExpiredEmailVerificationTokens removes expired or consumed tokens.
 func (db *DB) DeleteExpiredEmailVerificationTokens(ctx context.Context) (int64, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	tag, err := db.Pool.Exec(ctx,
 		`DELETE FROM email_verification_tokens WHERE expires_at < now() OR (used = true AND created_at < now() - interval '1 day')`,
 	)

--- a/internal/database/export.go
+++ b/internal/database/export.go
@@ -105,6 +105,9 @@ func (db *DB) ExportOrganization(ctx context.Context, orgID uuid.UUID) (*model.O
 // ImportOrganization imports an organization snapshot in a single transaction.
 // It upserts the organization, settings, roles, groups (with role assignments), and clients.
 func (db *DB) ImportOrganization(ctx context.Context, export *model.OrgExport) error {
+	ctx, cancel := txCtx(ctx)
+	defer cancel()
+
 	tx, err := db.Pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("beginning import transaction: %w", err)

--- a/internal/database/group.go
+++ b/internal/database/group.go
@@ -16,6 +16,9 @@ import (
 
 // ListGroups returns a paginated, searchable list of groups for an org.
 func (db *DB) ListGroups(ctx context.Context, orgID uuid.UUID, search string, limit, offset int) ([]*model.Group, int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	where := []string{"org_id = $1"}
 	args := []any{orgID}
 	paramIdx := 2
@@ -63,6 +66,9 @@ func (db *DB) ListGroups(ctx context.Context, orgID uuid.UUID, search string, li
 
 // GetGroupByID retrieves a group by its UUID.
 func (db *DB) GetGroupByID(ctx context.Context, id uuid.UUID) (*model.Group, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var g model.Group
 	err := db.Pool.QueryRow(ctx,
 		"SELECT id, org_id, name, description, created_at, updated_at FROM groups WHERE id = $1", id,
@@ -78,6 +84,9 @@ func (db *DB) GetGroupByID(ctx context.Context, id uuid.UUID) (*model.Group, err
 
 // CreateGroup inserts a new group.
 func (db *DB) CreateGroup(ctx context.Context, group *model.Group) (*model.Group, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var g model.Group
 	err := db.Pool.QueryRow(ctx,
 		`INSERT INTO groups (org_id, name, description) VALUES ($1, $2, $3)
@@ -96,6 +105,9 @@ func (db *DB) CreateGroup(ctx context.Context, group *model.Group) (*model.Group
 
 // UpdateGroup updates mutable fields on a group.
 func (db *DB) UpdateGroup(ctx context.Context, id uuid.UUID, req *model.UpdateGroupRequest) (*model.Group, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var g model.Group
 	err := db.Pool.QueryRow(ctx,
 		`UPDATE groups SET name = COALESCE(NULLIF($2, ''), name), description = $3, updated_at = now()
@@ -114,6 +126,9 @@ func (db *DB) UpdateGroup(ctx context.Context, id uuid.UUID, req *model.UpdateGr
 
 // DeleteGroup removes a group by ID.
 func (db *DB) DeleteGroup(ctx context.Context, id uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	tag, err := db.Pool.Exec(ctx, "DELETE FROM groups WHERE id = $1", id)
 	if err != nil {
 		return fmt.Errorf("deleting group: %w", err)
@@ -126,6 +141,9 @@ func (db *DB) DeleteGroup(ctx context.Context, id uuid.UUID) error {
 
 // CountGroups returns the total number of groups in an org.
 func (db *DB) CountGroups(ctx context.Context, orgID uuid.UUID) (int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var count int
 	err := db.Pool.QueryRow(ctx, "SELECT COUNT(*) FROM groups WHERE org_id = $1", orgID).Scan(&count)
 	if err != nil {
@@ -136,6 +154,9 @@ func (db *DB) CountGroups(ctx context.Context, orgID uuid.UUID) (int, error) {
 
 // CountGroupMembers returns the number of members in a group.
 func (db *DB) CountGroupMembers(ctx context.Context, groupID uuid.UUID) (int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var count int
 	err := db.Pool.QueryRow(ctx, "SELECT COUNT(*) FROM user_groups WHERE group_id = $1", groupID).Scan(&count)
 	if err != nil {
@@ -146,6 +167,9 @@ func (db *DB) CountGroupMembers(ctx context.Context, groupID uuid.UUID) (int, er
 
 // CountGroupRoles returns the number of roles assigned to a group.
 func (db *DB) CountGroupRoles(ctx context.Context, groupID uuid.UUID) (int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var count int
 	err := db.Pool.QueryRow(ctx, "SELECT COUNT(*) FROM group_roles WHERE group_id = $1", groupID).Scan(&count)
 	if err != nil {
@@ -156,6 +180,9 @@ func (db *DB) CountGroupRoles(ctx context.Context, groupID uuid.UUID) (int, erro
 
 // AddUserToGroup adds a user to a group.
 func (db *DB) AddUserToGroup(ctx context.Context, userID, groupID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		"INSERT INTO user_groups (user_id, group_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
 		userID, groupID)
@@ -167,6 +194,9 @@ func (db *DB) AddUserToGroup(ctx context.Context, userID, groupID uuid.UUID) err
 
 // RemoveUserFromGroup removes a user from a group.
 func (db *DB) RemoveUserFromGroup(ctx context.Context, userID, groupID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx, "DELETE FROM user_groups WHERE user_id = $1 AND group_id = $2", userID, groupID)
 	if err != nil {
 		return fmt.Errorf("removing user from group: %w", err)
@@ -176,6 +206,9 @@ func (db *DB) RemoveUserFromGroup(ctx context.Context, userID, groupID uuid.UUID
 
 // GetGroupMembers returns all members of a group.
 func (db *DB) GetGroupMembers(ctx context.Context, groupID uuid.UUID) ([]*model.GroupMember, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	rows, err := db.Pool.Query(ctx,
 		`SELECT u.id, u.username, u.email, ug.added_at
 		 FROM users u JOIN user_groups ug ON ug.user_id = u.id
@@ -201,6 +234,9 @@ func (db *DB) GetGroupMembers(ctx context.Context, groupID uuid.UUID) ([]*model.
 
 // AssignRoleToGroup assigns a role to a group.
 func (db *DB) AssignRoleToGroup(ctx context.Context, groupID, roleID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		"INSERT INTO group_roles (group_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
 		groupID, roleID)
@@ -212,6 +248,9 @@ func (db *DB) AssignRoleToGroup(ctx context.Context, groupID, roleID uuid.UUID) 
 
 // UnassignRoleFromGroup removes a role from a group.
 func (db *DB) UnassignRoleFromGroup(ctx context.Context, groupID, roleID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx, "DELETE FROM group_roles WHERE group_id = $1 AND role_id = $2", groupID, roleID)
 	if err != nil {
 		return fmt.Errorf("unassigning role from group: %w", err)
@@ -221,6 +260,9 @@ func (db *DB) UnassignRoleFromGroup(ctx context.Context, groupID, roleID uuid.UU
 
 // GetGroupRoles returns all roles assigned to a group.
 func (db *DB) GetGroupRoles(ctx context.Context, groupID uuid.UUID) ([]*model.GroupRoleAssignment, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	rows, err := db.Pool.Query(ctx,
 		`SELECT r.id, r.name, r.description
 		 FROM roles r JOIN group_roles gr ON gr.role_id = r.id
@@ -246,6 +288,9 @@ func (db *DB) GetGroupRoles(ctx context.Context, groupID uuid.UUID) ([]*model.Gr
 
 // GetEffectiveUserRoles returns role names that include both direct and group-inherited roles.
 func (db *DB) GetEffectiveUserRoles(ctx context.Context, userID uuid.UUID) ([]string, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT DISTINCT r.name FROM roles r
 		JOIN user_roles ur ON ur.role_id = r.id
@@ -279,6 +324,9 @@ func (db *DB) GetEffectiveUserRoles(ctx context.Context, userID uuid.UUID) ([]st
 
 // GetUserGroups returns all groups a user belongs to.
 func (db *DB) GetUserGroups(ctx context.Context, userID uuid.UUID) ([]*model.Group, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	rows, err := db.Pool.Query(ctx,
 		`SELECT g.id, g.org_id, g.name, g.description, g.created_at, g.updated_at
 		 FROM groups g JOIN user_groups ug ON ug.group_id = g.id

--- a/internal/database/mfa.go
+++ b/internal/database/mfa.go
@@ -13,6 +13,9 @@ import (
 
 // CreateMFADevice inserts a new unverified MFA device.
 func (db *DB) CreateMFADevice(ctx context.Context, userID uuid.UUID, deviceType, name, secret string) (*model.MFADevice, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	encSecret, err := db.encryptToken(secret)
 	if err != nil {
 		return nil, fmt.Errorf("encrypting MFA secret: %w", err)
@@ -36,6 +39,9 @@ func (db *DB) CreateMFADevice(ctx context.Context, userID uuid.UUID, deviceType,
 
 // VerifyMFADevice marks a device as verified and enables MFA on the user.
 func (db *DB) VerifyMFADevice(ctx context.Context, deviceID, userID uuid.UUID) error {
+	ctx, cancel := txCtx(ctx)
+	defer cancel()
+
 	tx, err := db.Pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("beginning transaction: %w", err)
@@ -55,6 +61,9 @@ func (db *DB) VerifyMFADevice(ctx context.Context, deviceID, userID uuid.UUID) e
 
 // GetVerifiedMFADevice returns the verified TOTP device for a user, if any.
 func (db *DB) GetVerifiedMFADevice(ctx context.Context, userID uuid.UUID) (*model.MFADevice, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var d model.MFADevice
 	err := db.Pool.QueryRow(ctx,
 		`SELECT id, user_id, device_type, name, secret, verified, created_at, updated_at
@@ -77,6 +86,9 @@ func (db *DB) GetVerifiedMFADevice(ctx context.Context, userID uuid.UUID) (*mode
 
 // GetPendingMFADevice returns the unverified TOTP device for a user (enrollment in progress).
 func (db *DB) GetPendingMFADevice(ctx context.Context, userID uuid.UUID) (*model.MFADevice, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var d model.MFADevice
 	err := db.Pool.QueryRow(ctx,
 		`SELECT id, user_id, device_type, name, secret, verified, created_at, updated_at
@@ -99,12 +111,18 @@ func (db *DB) GetPendingMFADevice(ctx context.Context, userID uuid.UUID) (*model
 
 // DeleteUnverifiedMFADevices removes all unverified devices for a user.
 func (db *DB) DeleteUnverifiedMFADevices(ctx context.Context, userID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx, `DELETE FROM mfa_devices WHERE user_id = $1 AND verified = false`, userID)
 	return err
 }
 
 // DisableMFA removes all MFA devices and backup codes, and sets mfa_enabled=false.
 func (db *DB) DisableMFA(ctx context.Context, userID uuid.UUID) error {
+	ctx, cancel := txCtx(ctx)
+	defer cancel()
+
 	tx, err := db.Pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("beginning transaction: %w", err)
@@ -123,6 +141,9 @@ func (db *DB) DisableMFA(ctx context.Context, userID uuid.UUID) error {
 // StoreBackupCodes stores hashed backup codes for a user.
 // The delete + insert is wrapped in a transaction so codes are never partially replaced.
 func (db *DB) StoreBackupCodes(ctx context.Context, userID uuid.UUID, codeHashes [][]byte) error {
+	ctx, cancel := txCtx(ctx)
+	defer cancel()
+
 	tx, err := db.Pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("beginning transaction: %w", err)
@@ -150,6 +171,9 @@ func (db *DB) StoreBackupCodes(ctx context.Context, userID uuid.UUID, codeHashes
 // ConsumeBackupCode marks a backup code as used if the hash matches.
 // Returns true if a valid code was consumed.
 func (db *DB) ConsumeBackupCode(ctx context.Context, userID uuid.UUID, codeHash []byte) (bool, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	tag, err := db.Pool.Exec(ctx,
 		`UPDATE mfa_backup_codes SET used = true
 		 WHERE user_id = $1 AND code_hash = $2 AND used = false`,

--- a/internal/database/oauth_client.go
+++ b/internal/database/oauth_client.go
@@ -51,6 +51,9 @@ func ValidateRedirectURI(client *model.OAuthClient, uri string) bool {
 
 // ListOAuthClients returns a paginated, searchable list of OAuth clients for an org.
 func (db *DB) ListOAuthClients(ctx context.Context, orgID uuid.UUID, search string, limit, offset int) ([]*model.OAuthClient, int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	where := []string{"org_id = $1"}
 	args := []any{orgID}
 	paramIdx := 2
@@ -106,6 +109,9 @@ func (db *DB) ListOAuthClients(ctx context.Context, orgID uuid.UUID, search stri
 
 // CreateOAuthClient inserts a new OAuth client with a generated client ID.
 func (db *DB) CreateOAuthClient(ctx context.Context, client *model.OAuthClient) (*model.OAuthClient, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	if client.ID == "" {
 		client.ID = generateClientID()
 	}
@@ -131,6 +137,9 @@ func (db *DB) CreateOAuthClient(ctx context.Context, client *model.OAuthClient) 
 
 // UpdateOAuthClient updates mutable fields on an OAuth client, scoped to the given organization.
 func (db *DB) UpdateOAuthClient(ctx context.Context, clientID string, orgID uuid.UUID, req *model.UpdateClientRequest) (*model.OAuthClient, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	uris := parseRedirectURIs(req.RedirectURIs)
 
 	query := `
@@ -160,6 +169,9 @@ func (db *DB) UpdateOAuthClient(ctx context.Context, clientID string, orgID uuid
 
 // DeleteOAuthClient removes an OAuth client by ID, scoped to the given organization.
 func (db *DB) DeleteOAuthClient(ctx context.Context, clientID string, orgID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	tag, err := db.Pool.Exec(ctx, "DELETE FROM oauth_clients WHERE id = $1 AND org_id = $2", clientID, orgID)
 	if err != nil {
 		return fmt.Errorf("deleting oauth client: %w", err)
@@ -172,6 +184,9 @@ func (db *DB) DeleteOAuthClient(ctx context.Context, clientID string, orgID uuid
 
 // UpdateClientSecret sets a new secret hash for a confidential client, scoped to the given organization.
 func (db *DB) UpdateClientSecret(ctx context.Context, clientID string, orgID uuid.UUID, secretHash []byte) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		"UPDATE oauth_clients SET client_secret_hash = $2, updated_at = now() WHERE id = $1 AND org_id = $3",
 		clientID, secretHash, orgID)
@@ -183,6 +198,9 @@ func (db *DB) UpdateClientSecret(ctx context.Context, clientID string, orgID uui
 
 // CountOAuthClients returns the total number of OAuth clients in an org.
 func (db *DB) CountOAuthClients(ctx context.Context, orgID uuid.UUID) (int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var count int
 	err := db.Pool.QueryRow(ctx, "SELECT COUNT(*) FROM oauth_clients WHERE org_id = $1", orgID).Scan(&count)
 	if err != nil {

--- a/internal/database/organization.go
+++ b/internal/database/organization.go
@@ -64,6 +64,9 @@ func (db *DB) GetOrganizationByID(ctx context.Context, id uuid.UUID) (*model.Org
 
 // ListOrganizations returns a paginated, searchable list of organizations.
 func (db *DB) ListOrganizations(ctx context.Context, search string, limit, offset int) ([]*model.Organization, int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	where := []string{"1=1"}
 	args := []any{}
 	paramIdx := 1
@@ -118,6 +121,9 @@ func (db *DB) ListOrganizations(ctx context.Context, search string, limit, offse
 
 // CreateOrganization inserts an organization and its default settings atomically.
 func (db *DB) CreateOrganization(ctx context.Context, req *model.CreateOrgRequest) (*model.Organization, error) {
+	ctx, cancel := txCtx(ctx)
+	defer cancel()
+
 	tx, err := db.Pool.Begin(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("beginning transaction: %w", err)
@@ -155,6 +161,9 @@ func (db *DB) CreateOrganization(ctx context.Context, req *model.CreateOrgReques
 
 // UpdateOrganization updates mutable fields on an organization.
 func (db *DB) UpdateOrganization(ctx context.Context, id uuid.UUID, req *model.UpdateOrgRequest) (*model.Organization, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		UPDATE organizations
 		SET name = COALESCE(NULLIF($2, ''), name),
@@ -179,6 +188,9 @@ func (db *DB) UpdateOrganization(ctx context.Context, id uuid.UUID, req *model.U
 
 // DeleteOrganization removes an organization by ID. The default org cannot be deleted.
 func (db *DB) DeleteOrganization(ctx context.Context, id uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	// Check that it's not the default org.
 	var slug string
 	err := db.Pool.QueryRow(ctx, "SELECT slug FROM organizations WHERE id = $1", id).Scan(&slug)
@@ -204,6 +216,9 @@ func (db *DB) DeleteOrganization(ctx context.Context, id uuid.UUID) error {
 
 // CountOrganizations returns the total number of organizations.
 func (db *DB) CountOrganizations(ctx context.Context) (int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var count int
 	err := db.Pool.QueryRow(ctx, "SELECT COUNT(*) FROM organizations").Scan(&count)
 	if err != nil {

--- a/internal/database/organization_settings.go
+++ b/internal/database/organization_settings.go
@@ -14,6 +14,9 @@ import (
 
 // GetOrgSettings returns the settings for an organization.
 func (db *DB) GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*model.OrgSettings, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT id, org_id,
 		       password_min_length, password_require_uppercase, password_require_lowercase,
@@ -80,6 +83,9 @@ func (db *DB) GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*model.OrgSe
 
 // UpdateOrgSettings updates the settings for an organization.
 func (db *DB) UpdateOrgSettings(ctx context.Context, orgID uuid.UUID, req *model.UpdateOrgSettingsRequest) (*model.OrgSettings, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	accessTTL := fmt.Sprintf("%d seconds", req.AccessTokenTTLSeconds)
 	refreshTTL := fmt.Sprintf("%d seconds", req.RefreshTokenTTLSeconds)
 

--- a/internal/database/password_reset.go
+++ b/internal/database/password_reset.go
@@ -23,6 +23,9 @@ type PasswordResetToken struct {
 // CreatePasswordResetToken stores a hashed token and returns the record.
 // The plaintext token is NOT stored — only its SHA-256 hash.
 func (db *DB) CreatePasswordResetToken(ctx context.Context, userID uuid.UUID, tokenPlaintext string, expiresAt time.Time) error {
+	ctx, cancel := txCtx(ctx)
+	defer cancel()
+
 	hash := sha256.Sum256([]byte(tokenPlaintext))
 
 	tx, err := db.Pool.Begin(ctx)
@@ -50,6 +53,9 @@ func (db *DB) CreatePasswordResetToken(ctx context.Context, userID uuid.UUID, to
 // ConsumePasswordResetToken validates and consumes a password reset token.
 // Returns the user ID if valid, or an error if expired/used/not found.
 func (db *DB) ConsumePasswordResetToken(ctx context.Context, tokenPlaintext string) (uuid.UUID, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	hash := sha256.Sum256([]byte(tokenPlaintext))
 
 	var token PasswordResetToken
@@ -70,6 +76,9 @@ func (db *DB) ConsumePasswordResetToken(ctx context.Context, tokenPlaintext stri
 
 // DeleteExpiredPasswordResetTokens removes tokens older than the given age.
 func (db *DB) DeleteExpiredPasswordResetTokens(ctx context.Context) (int64, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	tag, err := db.Pool.Exec(ctx,
 		`DELETE FROM password_reset_tokens WHERE expires_at < now() OR (used = true AND created_at < now() - interval '1 day')`,
 	)

--- a/internal/database/role.go
+++ b/internal/database/role.go
@@ -16,6 +16,9 @@ import (
 
 // ListRoles returns a paginated, searchable list of roles for an org.
 func (db *DB) ListRoles(ctx context.Context, orgID uuid.UUID, search string, limit, offset int) ([]*model.Role, int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	where := []string{"org_id = $1"}
 	args := []any{orgID}
 	paramIdx := 2
@@ -65,6 +68,9 @@ func (db *DB) ListRoles(ctx context.Context, orgID uuid.UUID, search string, lim
 
 // GetRoleByID retrieves a role by its UUID.
 func (db *DB) GetRoleByID(ctx context.Context, id uuid.UUID) (*model.Role, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `SELECT id, org_id, name, description, builtin, created_at, updated_at FROM roles WHERE id = $1`
 
 	var r model.Role
@@ -80,6 +86,9 @@ func (db *DB) GetRoleByID(ctx context.Context, id uuid.UUID) (*model.Role, error
 
 // CreateRole inserts a new role.
 func (db *DB) CreateRole(ctx context.Context, role *model.Role) (*model.Role, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		INSERT INTO roles (org_id, name, description)
 		VALUES ($1, $2, $3)
@@ -100,6 +109,9 @@ func (db *DB) CreateRole(ctx context.Context, role *model.Role) (*model.Role, er
 
 // UpdateRole updates mutable fields on a role, scoped to the given organization.
 func (db *DB) UpdateRole(ctx context.Context, id, orgID uuid.UUID, req *model.UpdateRoleRequest) (*model.Role, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		UPDATE roles
 		SET name = COALESCE(NULLIF($2, ''), name),
@@ -122,6 +134,9 @@ func (db *DB) UpdateRole(ctx context.Context, id, orgID uuid.UUID, req *model.Up
 
 // DeleteRole removes a role by ID, scoped to the given organization. Rejects deletion of builtin roles.
 func (db *DB) DeleteRole(ctx context.Context, id, orgID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	// Distinguish "not found" from "is builtin" before attempting delete.
 	var builtin bool
 	err := db.Pool.QueryRow(ctx, "SELECT builtin FROM roles WHERE id = $1 AND org_id = $2", id, orgID).Scan(&builtin)
@@ -147,6 +162,9 @@ func (db *DB) DeleteRole(ctx context.Context, id, orgID uuid.UUID) error {
 
 // UserCountsByRole returns the number of users per role in an org.
 func (db *DB) UserCountsByRole(ctx context.Context, orgID uuid.UUID) ([]model.RoleCount, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT r.name, COUNT(ur.user_id) AS cnt
 		FROM roles r
@@ -174,6 +192,9 @@ func (db *DB) UserCountsByRole(ctx context.Context, orgID uuid.UUID) ([]model.Ro
 
 // CountRoles returns the total number of roles in an org.
 func (db *DB) CountRoles(ctx context.Context, orgID uuid.UUID) (int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var count int
 	err := db.Pool.QueryRow(ctx, "SELECT COUNT(*) FROM roles WHERE org_id = $1", orgID).Scan(&count)
 	if err != nil {
@@ -184,6 +205,9 @@ func (db *DB) CountRoles(ctx context.Context, orgID uuid.UUID) (int, error) {
 
 // CountRoleUsers returns the number of users assigned to a role.
 func (db *DB) CountRoleUsers(ctx context.Context, roleID uuid.UUID) (int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var count int
 	err := db.Pool.QueryRow(ctx, "SELECT COUNT(*) FROM user_roles WHERE role_id = $1", roleID).Scan(&count)
 	if err != nil {
@@ -194,6 +218,9 @@ func (db *DB) CountRoleUsers(ctx context.Context, roleID uuid.UUID) (int, error)
 
 // AssignRole assigns a role to a user.
 func (db *DB) AssignRole(ctx context.Context, userID, roleID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		"INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
 		userID, roleID)
@@ -205,6 +232,9 @@ func (db *DB) AssignRole(ctx context.Context, userID, roleID uuid.UUID) error {
 
 // UnassignRole removes a role from a user.
 func (db *DB) UnassignRole(ctx context.Context, userID, roleID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx, "DELETE FROM user_roles WHERE user_id = $1 AND role_id = $2", userID, roleID)
 	if err != nil {
 		return fmt.Errorf("unassigning role: %w", err)
@@ -214,6 +244,9 @@ func (db *DB) UnassignRole(ctx context.Context, userID, roleID uuid.UUID) error 
 
 // GetUserRoles returns all roles assigned to a user.
 func (db *DB) GetUserRoles(ctx context.Context, userID uuid.UUID) ([]*model.Role, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT r.id, r.org_id, r.name, r.description, r.builtin, r.created_at, r.updated_at
 		FROM roles r
@@ -243,6 +276,9 @@ func (db *DB) GetUserRoles(ctx context.Context, userID uuid.UUID) ([]*model.Role
 
 // GetUserRoleNames returns the role names for a user (for JWT claims).
 func (db *DB) GetUserRoleNames(ctx context.Context, userID uuid.UUID) ([]string, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT r.name
 		FROM roles r
@@ -272,6 +308,9 @@ func (db *DB) GetUserRoleNames(ctx context.Context, userID uuid.UUID) ([]string,
 
 // GetRoleUsers returns all users assigned to a role.
 func (db *DB) GetRoleUsers(ctx context.Context, roleID uuid.UUID) ([]*model.UserRoleAssignment, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT u.id, u.username, u.email, ur.assigned_at
 		FROM users u

--- a/internal/database/saml.go
+++ b/internal/database/saml.go
@@ -14,6 +14,9 @@ import (
 
 // CreateSAMLProvider inserts a new SAML provider configuration.
 func (db *DB) CreateSAMLProvider(ctx context.Context, p *model.SAMLProvider) (*model.SAMLProvider, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	attrJSON, _ := json.Marshal(p.AttributeMapping)
 
 	var out model.SAMLProvider
@@ -36,6 +39,9 @@ func (db *DB) CreateSAMLProvider(ctx context.Context, p *model.SAMLProvider) (*m
 
 // GetSAMLProviderByID returns a SAML provider by ID.
 func (db *DB) GetSAMLProviderByID(ctx context.Context, id uuid.UUID) (*model.SAMLProvider, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var p model.SAMLProvider
 	var attrBytes []byte
 	err := db.Pool.QueryRow(ctx,
@@ -56,6 +62,9 @@ func (db *DB) GetSAMLProviderByID(ctx context.Context, id uuid.UUID) (*model.SAM
 
 // ListSAMLProviders returns all SAML providers for an organization.
 func (db *DB) ListSAMLProviders(ctx context.Context, orgID uuid.UUID) ([]*model.SAMLProvider, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	rows, err := db.Pool.Query(ctx,
 		`SELECT id, org_id, name, entity_id, metadata_url, metadata_xml, sso_url, slo_url, certificate, name_id_format, attribute_mapping, enabled, created_at, updated_at
 		 FROM saml_providers WHERE org_id = $1 ORDER BY name ASC`, orgID,
@@ -85,6 +94,9 @@ func (db *DB) ListSAMLProviders(ctx context.Context, orgID uuid.UUID) ([]*model.
 
 // GetEnabledSAMLProviders returns enabled SAML providers for an organization.
 func (db *DB) GetEnabledSAMLProviders(ctx context.Context, orgID uuid.UUID) ([]*model.SAMLProvider, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	rows, err := db.Pool.Query(ctx,
 		`SELECT id, org_id, name, entity_id, metadata_url, metadata_xml, sso_url, slo_url, certificate, name_id_format, attribute_mapping, enabled, created_at, updated_at
 		 FROM saml_providers WHERE org_id = $1 AND enabled = true ORDER BY name ASC`, orgID,
@@ -114,6 +126,9 @@ func (db *DB) GetEnabledSAMLProviders(ctx context.Context, orgID uuid.UUID) ([]*
 
 // UpdateSAMLProvider updates a SAML provider configuration.
 func (db *DB) UpdateSAMLProvider(ctx context.Context, id uuid.UUID, req *model.UpdateSAMLProviderRequest) (*model.SAMLProvider, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	attrJSON, _ := json.Marshal(req.AttributeMapping)
 
 	var p model.SAMLProvider
@@ -138,6 +153,9 @@ func (db *DB) UpdateSAMLProvider(ctx context.Context, id uuid.UUID, req *model.U
 
 // DeleteSAMLProvider deletes a SAML provider.
 func (db *DB) DeleteSAMLProvider(ctx context.Context, id uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx, `DELETE FROM saml_providers WHERE id = $1`, id)
 	return err
 }

--- a/internal/database/social_account.go
+++ b/internal/database/social_account.go
@@ -31,6 +31,9 @@ func (db *DB) decryptToken(value string) (string, error) {
 
 // CreateSocialAccount inserts a new social account link and returns the populated struct.
 func (db *DB) CreateSocialAccount(ctx context.Context, account *model.SocialAccount) (*model.SocialAccount, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	encAccess, err := db.encryptToken(account.AccessToken)
 	if err != nil {
 		return nil, fmt.Errorf("encrypting access token: %w", err)
@@ -97,6 +100,9 @@ func (db *DB) decryptSocialAccount(sa *model.SocialAccount) error {
 
 // GetSocialAccount finds a social account by provider and provider user ID.
 func (db *DB) GetSocialAccount(ctx context.Context, provider, providerUserID string) (*model.SocialAccount, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT id, user_id, provider, provider_user_id, email, name, avatar_url,
 		       access_token, refresh_token, token_expires_at, created_at, updated_at
@@ -124,6 +130,9 @@ func (db *DB) GetSocialAccount(ctx context.Context, provider, providerUserID str
 
 // GetSocialAccountsByUserID returns all linked social accounts for a user.
 func (db *DB) GetSocialAccountsByUserID(ctx context.Context, userID uuid.UUID) ([]*model.SocialAccount, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT id, user_id, provider, provider_user_id, email, name, avatar_url,
 		       access_token, refresh_token, token_expires_at, created_at, updated_at
@@ -162,6 +171,9 @@ func (db *DB) GetSocialAccountsByUserID(ctx context.Context, userID uuid.UUID) (
 
 // UpdateSocialAccountTokens updates the OAuth tokens for a social account.
 func (db *DB) UpdateSocialAccountTokens(ctx context.Context, id uuid.UUID, accessToken, refreshToken string, expiresAt *time.Time) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	encAccess, err := db.encryptToken(accessToken)
 	if err != nil {
 		return fmt.Errorf("encrypting access token: %w", err)
@@ -188,6 +200,9 @@ func (db *DB) UpdateSocialAccountTokens(ctx context.Context, id uuid.UUID, acces
 
 // DeleteSocialAccount removes a social account link by ID.
 func (db *DB) DeleteSocialAccount(ctx context.Context, id uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	tag, err := db.Pool.Exec(ctx, "DELETE FROM social_accounts WHERE id = $1", id)
 	if err != nil {
 		return fmt.Errorf("deleting social account: %w", err)

--- a/internal/database/social_provider_config.go
+++ b/internal/database/social_provider_config.go
@@ -11,6 +11,9 @@ import (
 
 // UpsertSocialProviderConfig creates or updates a social provider config for an org.
 func (db *DB) UpsertSocialProviderConfig(ctx context.Context, cfg *model.SocialProviderConfig) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	extra, err := json.Marshal(cfg.ExtraConfig)
 	if err != nil {
 		return fmt.Errorf("marshalling extra_config: %w", err)
@@ -39,6 +42,9 @@ func (db *DB) UpsertSocialProviderConfig(ctx context.Context, cfg *model.SocialP
 
 // GetSocialProviderConfig returns a single provider config for an org.
 func (db *DB) GetSocialProviderConfig(ctx context.Context, orgID uuid.UUID, provider string) (*model.SocialProviderConfig, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT id, org_id, provider, enabled, client_id, client_secret, extra_config, created_at, updated_at
 		FROM social_provider_configs
@@ -66,6 +72,9 @@ func (db *DB) GetSocialProviderConfig(ctx context.Context, orgID uuid.UUID, prov
 
 // ListSocialProviderConfigs returns all provider configs for an org.
 func (db *DB) ListSocialProviderConfigs(ctx context.Context, orgID uuid.UUID) ([]*model.SocialProviderConfig, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT id, org_id, provider, enabled, client_id, client_secret, extra_config, created_at, updated_at
 		FROM social_provider_configs
@@ -105,6 +114,9 @@ func (db *DB) ListSocialProviderConfigs(ctx context.Context, orgID uuid.UUID) ([
 
 // DeleteSocialProviderConfig removes a provider config for an org.
 func (db *DB) DeleteSocialProviderConfig(ctx context.Context, orgID uuid.UUID, provider string) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx, `DELETE FROM social_provider_configs WHERE org_id = $1 AND provider = $2`, orgID, provider)
 	if err != nil {
 		return fmt.Errorf("deleting social provider config: %w", err)

--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -17,6 +17,9 @@ import (
 
 // CreateUser inserts a new user and returns the populated User struct.
 func (db *DB) CreateUser(ctx context.Context, user *model.User) (*model.User, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		INSERT INTO users (org_id, username, email, given_name, family_name, password_hash)
 		VALUES ($1, $2, $3, $4, $5, $6)
@@ -88,6 +91,9 @@ func (db *DB) GetUserByEmail(ctx context.Context, email string, orgID uuid.UUID)
 // FindUserByEmail finds a user by email across all organizations.
 // Used for password reset where org context is not available.
 func (db *DB) FindUserByEmail(ctx context.Context, email string) (*model.User, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		SELECT id, org_id, username, email, email_verified, COALESCE(given_name, '') AS given_name, COALESCE(family_name, '') AS family_name,
 		       enabled, mfa_enabled, password_hash, failed_login_attempts, locked_until,
@@ -142,6 +148,9 @@ func (db *DB) GetUserByID(ctx context.Context, id uuid.UUID) (*model.User, error
 
 // UpdateLastLoginAt sets the last_login_at timestamp for a user.
 func (db *DB) UpdateLastLoginAt(ctx context.Context, userID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx, "UPDATE users SET last_login_at = now() WHERE id = $1", userID)
 	if err != nil {
 		return fmt.Errorf("updating last_login_at: %w", err)
@@ -151,6 +160,9 @@ func (db *DB) UpdateLastLoginAt(ctx context.Context, userID uuid.UUID) error {
 
 // IncrementFailedLogins increments the failed login counter and optionally locks the account.
 func (db *DB) IncrementFailedLogins(ctx context.Context, userID uuid.UUID, maxAttempts int, lockoutDuration time.Duration) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		UPDATE users
 		SET failed_login_attempts = failed_login_attempts + 1,
@@ -168,6 +180,9 @@ func (db *DB) IncrementFailedLogins(ctx context.Context, userID uuid.UUID, maxAt
 
 // ResetFailedLogins clears the failed login counter and lock on successful login.
 func (db *DB) ResetFailedLogins(ctx context.Context, userID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		"UPDATE users SET failed_login_attempts = 0, locked_until = NULL WHERE id = $1", userID)
 	if err != nil {
@@ -206,6 +221,9 @@ func (db *DB) GetUserByUsername(ctx context.Context, username string, orgID uuid
 
 // ListUsers returns a paginated, searchable, filterable list of users.
 func (db *DB) ListUsers(ctx context.Context, orgID uuid.UUID, search, status string, limit, offset int) ([]*model.User, int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	where := []string{"org_id = $1"}
 	args := []any{orgID}
 	paramIdx := 2
@@ -277,6 +295,9 @@ func (db *DB) ListUsers(ctx context.Context, orgID uuid.UUID, search, status str
 // UpdateUser updates mutable fields on a user. The orgID parameter ensures
 // the operation is scoped to a single organization (prevents cross-tenant IDOR).
 func (db *DB) UpdateUser(ctx context.Context, id, orgID uuid.UUID, req *model.UpdateUserRequest) (*model.User, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	query := `
 		UPDATE users
 		SET username = COALESCE(NULLIF($2, ''), username),
@@ -311,6 +332,9 @@ func (db *DB) UpdateUser(ctx context.Context, id, orgID uuid.UUID, req *model.Up
 
 // DeleteUser removes a user by ID, scoped to the given organization.
 func (db *DB) DeleteUser(ctx context.Context, id, orgID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	tag, err := db.Pool.Exec(ctx, "DELETE FROM users WHERE id = $1 AND org_id = $2", id, orgID)
 	if err != nil {
 		return fmt.Errorf("deleting user: %w", err)
@@ -323,6 +347,9 @@ func (db *DB) DeleteUser(ctx context.Context, id, orgID uuid.UUID) error {
 
 // UpdatePassword sets a new password hash for a user, scoped to the given organization.
 func (db *DB) UpdatePassword(ctx context.Context, id, orgID uuid.UUID, passwordHash []byte) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx, "UPDATE users SET password_hash = $2, updated_at = now() WHERE id = $1 AND org_id = $3", id, passwordHash, orgID)
 	if err != nil {
 		return fmt.Errorf("updating password: %w", err)
@@ -332,6 +359,9 @@ func (db *DB) UpdatePassword(ctx context.Context, id, orgID uuid.UUID, passwordH
 
 // CountUsers returns the total number of users in an organization.
 func (db *DB) CountUsers(ctx context.Context, orgID uuid.UUID) (int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var count int
 	err := db.Pool.QueryRow(ctx, "SELECT COUNT(*) FROM users WHERE org_id = $1", orgID).Scan(&count)
 	if err != nil {
@@ -342,6 +372,9 @@ func (db *DB) CountUsers(ctx context.Context, orgID uuid.UUID) (int, error) {
 
 // CountRecentUsers returns the number of users created in the last N days.
 func (db *DB) CountRecentUsers(ctx context.Context, orgID uuid.UUID, days int) (int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var count int
 	err := db.Pool.QueryRow(ctx,
 		"SELECT COUNT(*) FROM users WHERE org_id = $1 AND created_at > now() - make_interval(days => $2)",

--- a/internal/database/webauthn.go
+++ b/internal/database/webauthn.go
@@ -12,6 +12,9 @@ import (
 
 // CreateWebAuthnCredential inserts a new WebAuthn credential.
 func (db *DB) CreateWebAuthnCredential(ctx context.Context, cred *model.WebAuthnCredential) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		`INSERT INTO webauthn_credentials (user_id, credential_id, public_key, attestation_type, transport, flags_raw, aaguid, sign_count, name)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
@@ -26,6 +29,9 @@ func (db *DB) CreateWebAuthnCredential(ctx context.Context, cred *model.WebAuthn
 
 // GetWebAuthnCredentialsByUserID returns all WebAuthn credentials for a user.
 func (db *DB) GetWebAuthnCredentialsByUserID(ctx context.Context, userID uuid.UUID) ([]*model.WebAuthnCredential, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	rows, err := db.Pool.Query(ctx,
 		`SELECT id, user_id, credential_id, public_key, attestation_type, transport, flags_raw, aaguid, sign_count, name, created_at, updated_at
 		 FROM webauthn_credentials WHERE user_id = $1
@@ -55,6 +61,9 @@ func (db *DB) GetWebAuthnCredentialsByUserID(ctx context.Context, userID uuid.UU
 
 // UpdateWebAuthnSignCount updates the sign counter for a credential after successful authentication.
 func (db *DB) UpdateWebAuthnSignCount(ctx context.Context, credentialID []byte, signCount uint32) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		`UPDATE webauthn_credentials SET sign_count = $2, updated_at = now() WHERE credential_id = $1`,
 		credentialID, signCount,
@@ -64,6 +73,9 @@ func (db *DB) UpdateWebAuthnSignCount(ctx context.Context, credentialID []byte, 
 
 // DeleteWebAuthnCredential deletes a credential by ID for a given user.
 func (db *DB) DeleteWebAuthnCredential(ctx context.Context, id, userID uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		`DELETE FROM webauthn_credentials WHERE id = $1 AND user_id = $2`,
 		id, userID,
@@ -73,6 +85,9 @@ func (db *DB) DeleteWebAuthnCredential(ctx context.Context, id, userID uuid.UUID
 
 // CountWebAuthnCredentials returns the number of WebAuthn credentials for a user.
 func (db *DB) CountWebAuthnCredentials(ctx context.Context, userID uuid.UUID) (int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var count int
 	err := db.Pool.QueryRow(ctx,
 		`SELECT COUNT(*) FROM webauthn_credentials WHERE user_id = $1`, userID,
@@ -82,6 +97,9 @@ func (db *DB) CountWebAuthnCredentials(ctx context.Context, userID uuid.UUID) (i
 
 // StoreWebAuthnSessionData stores temporary session data for a WebAuthn ceremony.
 func (db *DB) StoreWebAuthnSessionData(ctx context.Context, userID uuid.UUID, data []byte, ceremony string, expiresAt time.Time) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	// Clean up any previous session data for this user+ceremony
 	_, _ = db.Pool.Exec(ctx,
 		`DELETE FROM webauthn_session_data WHERE user_id = $1 AND ceremony = $2`,
@@ -98,6 +116,9 @@ func (db *DB) StoreWebAuthnSessionData(ctx context.Context, userID uuid.UUID, da
 
 // GetWebAuthnSessionData retrieves and deletes the session data for a ceremony (one-time use).
 func (db *DB) GetWebAuthnSessionData(ctx context.Context, userID uuid.UUID, ceremony string) ([]byte, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var data []byte
 	err := db.Pool.QueryRow(ctx,
 		`DELETE FROM webauthn_session_data
@@ -113,6 +134,9 @@ func (db *DB) GetWebAuthnSessionData(ctx context.Context, userID uuid.UUID, cere
 
 // DeleteExpiredWebAuthnSessions cleans up expired ceremony sessions.
 func (db *DB) DeleteExpiredWebAuthnSessions(ctx context.Context) (int64, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	tag, err := db.Pool.Exec(ctx,
 		`DELETE FROM webauthn_session_data WHERE expires_at < now()`,
 	)

--- a/internal/database/webhook.go
+++ b/internal/database/webhook.go
@@ -14,6 +14,9 @@ import (
 
 // CreateWebhook inserts a new webhook subscription.
 func (db *DB) CreateWebhook(ctx context.Context, w *model.Webhook) (*model.Webhook, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var wh model.Webhook
 	err := db.Pool.QueryRow(ctx,
 		`INSERT INTO webhooks (org_id, url, secret, description, event_types, enabled)
@@ -29,6 +32,9 @@ func (db *DB) CreateWebhook(ctx context.Context, w *model.Webhook) (*model.Webho
 
 // GetWebhookByID returns a webhook by its ID.
 func (db *DB) GetWebhookByID(ctx context.Context, id uuid.UUID) (*model.Webhook, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var wh model.Webhook
 	err := db.Pool.QueryRow(ctx,
 		`SELECT id, org_id, url, secret, description, event_types, enabled, created_at, updated_at
@@ -46,6 +52,9 @@ func (db *DB) GetWebhookByID(ctx context.Context, id uuid.UUID) (*model.Webhook,
 
 // ListWebhooks returns paginated webhooks for an organization.
 func (db *DB) ListWebhooks(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]*model.Webhook, int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var total int
 	err := db.Pool.QueryRow(ctx, `SELECT COUNT(*) FROM webhooks WHERE org_id = $1`, orgID).Scan(&total)
 	if err != nil {
@@ -79,6 +88,9 @@ func (db *DB) ListWebhooks(ctx context.Context, orgID uuid.UUID, limit, offset i
 
 // UpdateWebhook updates a webhook's settings.
 func (db *DB) UpdateWebhook(ctx context.Context, id uuid.UUID, req *model.UpdateWebhookRequest) (*model.Webhook, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var wh model.Webhook
 	err := db.Pool.QueryRow(ctx,
 		`UPDATE webhooks SET url = $2, description = $3, event_types = $4, enabled = $5, updated_at = now()
@@ -94,12 +106,18 @@ func (db *DB) UpdateWebhook(ctx context.Context, id uuid.UUID, req *model.Update
 
 // DeleteWebhook deletes a webhook by ID.
 func (db *DB) DeleteWebhook(ctx context.Context, id uuid.UUID) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx, `DELETE FROM webhooks WHERE id = $1`, id)
 	return err
 }
 
 // GetEnabledWebhooksForEvent returns all enabled webhooks for an org that match the given event type.
 func (db *DB) GetEnabledWebhooksForEvent(ctx context.Context, orgID uuid.UUID, eventType string) ([]*model.Webhook, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	rows, err := db.Pool.Query(ctx,
 		`SELECT id, org_id, url, secret, description, event_types, enabled, created_at, updated_at
 		 FROM webhooks
@@ -128,6 +146,9 @@ func (db *DB) GetEnabledWebhooksForEvent(ctx context.Context, orgID uuid.UUID, e
 
 // CreateWebhookDelivery inserts a new delivery record.
 func (db *DB) CreateWebhookDelivery(ctx context.Context, d *model.WebhookDelivery) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		`INSERT INTO webhook_deliveries (webhook_id, event_id, status, attempts, next_retry_at)
 		 VALUES ($1, $2, $3, $4, $5)`,
@@ -138,6 +159,9 @@ func (db *DB) CreateWebhookDelivery(ctx context.Context, d *model.WebhookDeliver
 
 // UpdateWebhookDelivery updates a delivery record after an attempt.
 func (db *DB) UpdateWebhookDelivery(ctx context.Context, id uuid.UUID, status string, attempts int, responseCode *int, lastError string, nextRetry *time.Time, completedAt *time.Time) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	_, err := db.Pool.Exec(ctx,
 		`UPDATE webhook_deliveries
 		 SET status = $2, attempts = $3, last_response_code = $4, last_error = $5, next_retry_at = $6, completed_at = $7
@@ -150,6 +174,9 @@ func (db *DB) UpdateWebhookDelivery(ctx context.Context, id uuid.UUID, status st
 // GetPendingDeliveries returns deliveries ready for retry.
 // Uses FOR UPDATE SKIP LOCKED to prevent duplicate delivery in multi-instance deployments.
 func (db *DB) GetPendingDeliveries(ctx context.Context, limit int) ([]*model.WebhookDelivery, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	rows, err := db.Pool.Query(ctx,
 		`SELECT d.id, d.webhook_id, d.event_id, d.status, d.attempts, d.next_retry_at,
 		        d.last_response_code, d.last_error, d.created_at, d.completed_at
@@ -181,6 +208,9 @@ func (db *DB) GetPendingDeliveries(ctx context.Context, limit int) ([]*model.Web
 
 // DeleteOldDeliveries removes completed deliveries older than the given duration.
 func (db *DB) DeleteOldDeliveries(ctx context.Context, olderThan time.Duration) (int64, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	tag, err := db.Pool.Exec(ctx,
 		`DELETE FROM webhook_deliveries WHERE status IN ('success', 'failed') AND completed_at < $1`,
 		time.Now().Add(-olderThan),
@@ -193,6 +223,9 @@ func (db *DB) DeleteOldDeliveries(ctx context.Context, olderThan time.Duration) 
 
 // ListWebhookDeliveries returns recent deliveries for a webhook.
 func (db *DB) ListWebhookDeliveries(ctx context.Context, webhookID uuid.UUID, limit, offset int) ([]*model.WebhookDelivery, int, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
 	var total int
 	err := db.Pool.QueryRow(ctx, `SELECT COUNT(*) FROM webhook_deliveries WHERE webhook_id = $1`, webhookID).Scan(&total)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Apply `queryCtx` (5s timeout) to all ~130 database functions that previously passed raw request context to `QueryRow`, `Query`, and `Exec` calls
- Add `txCtx` (30s timeout) helper for multi-statement transactions (org creation, MFA operations, password reset tokens, import)
- Prevents runaway queries from holding PostgreSQL connections indefinitely

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] `golangci-lint run` passes with 0 issues
- [x] Build succeeds (`go build ./...`)
- [x] Verified no functions were double-wrapped (already had queryCtx)
- [x] Verified transaction functions use txCtx, not queryCtx

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)