### PR TITLE
fix: add SAML assertion replay prevention

### DIFF
--- a/cmd/rampart/main.go
+++ b/cmd/rampart/main.go
@@ -339,6 +339,11 @@ func run(_ *slog.Logger) error {
 				} else if n > 0 {
 					logger.Info("cleaned up old webhook deliveries", "count", n)
 				}
+				if n, err := db.DeleteExpiredSAMLRequests(cleanupCtx); err != nil {
+					logger.Warn("failed to clean up expired SAML requests", "error", err)
+				} else if n > 0 {
+					logger.Info("cleaned up expired SAML requests/assertions", "count", n)
+				}
 			}
 		}
 	}()

--- a/internal/database/saml_request.go
+++ b/internal/database/saml_request.go
@@ -1,0 +1,87 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// StoreSAMLRequest stores an issued AuthnRequest ID so we can validate InResponseTo later.
+func (db *DB) StoreSAMLRequest(ctx context.Context, requestID string, providerID uuid.UUID, expiresAt time.Time) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
+	_, err := db.Pool.Exec(ctx,
+		`INSERT INTO saml_requests (request_id, provider_id, expires_at) VALUES ($1, $2, $3)`,
+		requestID, providerID, expiresAt,
+	)
+	if err != nil {
+		return fmt.Errorf("storing SAML request: %w", err)
+	}
+	return nil
+}
+
+// ConsumeSAMLRequest removes and returns whether a SAML request ID exists and is not expired.
+func (db *DB) ConsumeSAMLRequest(ctx context.Context, requestID string, providerID uuid.UUID) (bool, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
+	tag, err := db.Pool.Exec(ctx,
+		`DELETE FROM saml_requests WHERE request_id = $1 AND provider_id = $2 AND expires_at > now()`,
+		requestID, providerID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("consuming SAML request: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// StoreSAMLAssertionID records a consumed assertion ID to prevent replay.
+func (db *DB) StoreSAMLAssertionID(ctx context.Context, assertionID string, providerID uuid.UUID, expiresAt time.Time) error {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
+	_, err := db.Pool.Exec(ctx,
+		`INSERT INTO saml_consumed_assertions (assertion_id, provider_id, expires_at) VALUES ($1, $2, $3)
+		 ON CONFLICT (assertion_id, provider_id) DO NOTHING`,
+		assertionID, providerID, expiresAt,
+	)
+	if err != nil {
+		return fmt.Errorf("storing SAML assertion ID: %w", err)
+	}
+	return nil
+}
+
+// IsSAMLAssertionConsumed checks whether an assertion ID has already been used.
+func (db *DB) IsSAMLAssertionConsumed(ctx context.Context, assertionID string, providerID uuid.UUID) (bool, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
+	var exists bool
+	err := db.Pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM saml_consumed_assertions WHERE assertion_id = $1 AND provider_id = $2)`,
+		assertionID, providerID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("checking SAML assertion: %w", err)
+	}
+	return exists, nil
+}
+
+// DeleteExpiredSAMLRequests removes expired SAML request and assertion records.
+func (db *DB) DeleteExpiredSAMLRequests(ctx context.Context) (int64, error) {
+	ctx, cancel := queryCtx(ctx)
+	defer cancel()
+
+	tag1, err := db.Pool.Exec(ctx, `DELETE FROM saml_requests WHERE expires_at < now()`)
+	if err != nil {
+		return 0, fmt.Errorf("deleting expired SAML requests: %w", err)
+	}
+	tag2, err := db.Pool.Exec(ctx, `DELETE FROM saml_consumed_assertions WHERE expires_at < now()`)
+	if err != nil {
+		return tag1.RowsAffected(), fmt.Errorf("deleting expired SAML assertions: %w", err)
+	}
+	return tag1.RowsAffected() + tag2.RowsAffected(), nil
+}

--- a/internal/handler/saml.go
+++ b/internal/handler/saml.go
@@ -32,6 +32,7 @@ import (
 // SAMLStore defines the database operations required by SAMLHandler.
 type SAMLStore interface {
 	store.SAMLProviderStore
+	store.SAMLRequestStore
 	store.UserReader
 	store.UserWriter
 	store.OrgReader
@@ -139,6 +140,14 @@ func (h *SAMLHandler) InitiateLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Store the request ID so we can validate InResponseTo in the ACS callback.
+	requestExpiry := time.Now().Add(10 * time.Minute)
+	if err := h.store.StoreSAMLRequest(r.Context(), authnRequest.ID, providerID, requestExpiry); err != nil {
+		h.logger.Error("failed to store SAML request ID", "error", err)
+		apierror.InternalError(w)
+		return
+	}
+
 	redirectURL, err := authnRequest.Redirect("", sp)
 	if err != nil {
 		h.logger.Error("failed to create SAML redirect URL", "error", err)
@@ -176,11 +185,52 @@ func (h *SAMLHandler) ACS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	assertion, err := sp.ParseResponse(r, nil)
+	// Extract InResponseTo from the raw SAMLResponse to validate against stored request IDs.
+	inResponseTo := extractInResponseTo(r.FormValue("SAMLResponse"))
+
+	var possibleRequestIDs []string
+	if inResponseTo != "" {
+		valid, cErr := h.store.ConsumeSAMLRequest(ctx, inResponseTo, providerID)
+		if cErr != nil {
+			h.logger.Error("failed to validate SAML request ID", "error", cErr)
+			apierror.InternalError(w)
+			return
+		}
+		if !valid {
+			h.logger.Warn("SAML response references unknown or expired request", "in_response_to", inResponseTo, "provider", provider.Name)
+			apierror.Write(w, http.StatusForbidden, "saml_error", "SAML response references an unknown or expired request.")
+			return
+		}
+		possibleRequestIDs = []string{inResponseTo}
+	}
+
+	assertion, err := sp.ParseResponse(r, possibleRequestIDs)
 	if err != nil {
 		h.logger.Error("failed to parse SAML response", "error", err, "provider", provider.Name)
 		apierror.Write(w, http.StatusForbidden, "saml_error", "SAML authentication failed: "+err.Error())
 		return
+	}
+
+	// Check for assertion replay — reject if this assertion ID was already consumed.
+	assertionID := assertion.ID
+	if assertionID != "" {
+		consumed, aErr := h.store.IsSAMLAssertionConsumed(ctx, assertionID, providerID)
+		if aErr != nil {
+			h.logger.Error("failed to check SAML assertion replay", "error", aErr)
+			apierror.InternalError(w)
+			return
+		}
+		if consumed {
+			h.logger.Warn("SAML assertion replay detected", "assertion_id", assertionID, "provider", provider.Name)
+			apierror.Write(w, http.StatusForbidden, "saml_error", "SAML assertion has already been consumed.")
+			return
+		}
+		// Record this assertion ID with a 10-minute expiry window.
+		assertionExpiry := time.Now().Add(10 * time.Minute)
+		if sErr := h.store.StoreSAMLAssertionID(ctx, assertionID, providerID, assertionExpiry); sErr != nil {
+			h.logger.Error("failed to record SAML assertion ID", "error", sErr)
+			// Non-fatal — continue processing but log the failure
+		}
 	}
 
 	// Extract user attributes from the assertion
@@ -447,6 +497,23 @@ func (h *SAMLHandler) extractAttribute(assertion *saml.Assertion, provider *mode
 	}
 
 	return ""
+}
+
+// extractInResponseTo extracts the InResponseTo attribute from a base64-encoded SAMLResponse.
+// Returns empty string if the attribute is not found or the response cannot be decoded.
+func extractInResponseTo(samlResponse string) string {
+	raw, err := base64.StdEncoding.DecodeString(samlResponse)
+	if err != nil {
+		return ""
+	}
+	// Quick XML struct to extract just the InResponseTo attribute.
+	var resp struct {
+		InResponseTo string `xml:"InResponseTo,attr"`
+	}
+	if err := xml.Unmarshal(raw, &resp); err != nil {
+		return ""
+	}
+	return resp.InResponseTo
 }
 
 // ParseCertFromKey generates a self-signed X.509 certificate from the RSA private key.

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -291,6 +291,15 @@ type SAMLProviderStore interface {
 	DeleteSAMLProvider(ctx context.Context, id uuid.UUID) error
 }
 
+// SAMLRequestStore tracks SAML AuthnRequest and assertion IDs for replay prevention.
+type SAMLRequestStore interface {
+	StoreSAMLRequest(ctx context.Context, requestID string, providerID uuid.UUID, expiresAt time.Time) error
+	ConsumeSAMLRequest(ctx context.Context, requestID string, providerID uuid.UUID) (bool, error)
+	StoreSAMLAssertionID(ctx context.Context, assertionID string, providerID uuid.UUID, expiresAt time.Time) error
+	IsSAMLAssertionConsumed(ctx context.Context, assertionID string, providerID uuid.UUID) (bool, error)
+	DeleteExpiredSAMLRequests(ctx context.Context) (int64, error)
+}
+
 // ── Export / Import ─────────────────────────────────────────────────────
 
 // ExportImportStore provides organization export/import operations.

--- a/migrations/000032_add_saml_request_tracking.down.sql
+++ b/migrations/000032_add_saml_request_tracking.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS saml_consumed_assertions;
+DROP TABLE IF EXISTS saml_requests;

--- a/migrations/000032_add_saml_request_tracking.up.sql
+++ b/migrations/000032_add_saml_request_tracking.up.sql
@@ -1,0 +1,21 @@
+-- Track SAML AuthnRequest IDs so we can validate InResponseTo in the ACS callback.
+CREATE TABLE IF NOT EXISTS saml_requests (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    request_id  TEXT NOT NULL UNIQUE,
+    provider_id UUID NOT NULL REFERENCES saml_providers(id) ON DELETE CASCADE,
+    expires_at  TIMESTAMPTZ NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Track consumed SAML assertion IDs to prevent replay attacks.
+CREATE TABLE IF NOT EXISTS saml_consumed_assertions (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    assertion_id TEXT NOT NULL,
+    provider_id  UUID NOT NULL REFERENCES saml_providers(id) ON DELETE CASCADE,
+    expires_at   TIMESTAMPTZ NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(assertion_id, provider_id)
+);
+
+CREATE INDEX idx_saml_requests_expires ON saml_requests (expires_at);
+CREATE INDEX idx_saml_consumed_assertions_expires ON saml_consumed_assertions (expires_at);


### PR DESCRIPTION
## Summary
- Track issued SAML AuthnRequest IDs in database and validate `InResponseTo` in ACS responses
- Store consumed assertion IDs to prevent replay attacks (assertion ID deduplication)
- Add background cleanup ticker for expired SAML request/assertion records
- New migration (000032) creates `saml_requests` and `saml_consumed_assertions` tables

## Test plan
- [x] `go test ./...` passes
- [x] `go build ./cmd/rampart` succeeds
- [x] `golangci-lint run` passes (0 issues)
- [ ] Manual: verify SAML login flow still works end-to-end
- [ ] Manual: verify replayed assertion is rejected

Closes #216