### PR TITLE
chore: prepare adapter packages for publishing

### DIFF
--- a/.github/workflows/publish-adapters.yml
+++ b/.github/workflows/publish-adapters.yml
@@ -1,171 +1,72 @@
-name: Publish npm Adapters
+name: Publish Adapters
 
 on:
   push:
     tags:
-      - "adapter-*"
+      - "@rampart/web@*"
+      - "@rampart/react@*"
+      - "@rampart/nextjs@*"
+      - "@rampart/node@*"
+      - "rampart-python@*"
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
-  detect-changes:
-    name: Detect changed packages
+  npm-publish:
+    name: Publish npm package
+    if: startsWith(github.ref_name, '@rampart/')
     runs-on: ubuntu-latest
-    outputs:
-      web: ${{ steps.changes.outputs.web }}
-      react: ${{ steps.changes.outputs.react }}
-      nextjs: ${{ steps.changes.outputs.nextjs }}
-      node: ${{ steps.changes.outputs.node }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Determine changed packages
-        id: changes
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Resolve package directory
+        id: resolve
         run: |
-          # Find the previous adapter tag to diff against
-          PREV_TAG=$(git tag --list 'adapter-*' --sort=-v:refname | sed -n '2p')
-          if [ -z "$PREV_TAG" ]; then
-            # First adapter tag — publish everything
-            echo "web=true" >> "$GITHUB_OUTPUT"
-            echo "react=true" >> "$GITHUB_OUTPUT"
-            echo "nextjs=true" >> "$GITHUB_OUTPUT"
-            echo "node=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          TAG="${GITHUB_REF_NAME}"
+          PKG="${TAG%@*}"
+          case "$PKG" in
+            "@rampart/web")    DIR="adapters/frontend/web" ;;
+            "@rampart/react")  DIR="adapters/frontend/react" ;;
+            "@rampart/nextjs") DIR="adapters/frontend/nextjs" ;;
+            "@rampart/node")   DIR="adapters/backend/node" ;;
+            *) echo "Unknown package: $PKG" && exit 1 ;;
+          esac
+          echo "dir=$DIR" >> "$GITHUB_OUTPUT"
+          echo "pkg=$PKG" >> "$GITHUB_OUTPUT"
 
-          DIFF=$(git diff --name-only "$PREV_TAG" HEAD)
-
-          check_path() {
-            local name="$1"
-            local path="$2"
-            if echo "$DIFF" | grep -q "^${path}"; then
-              echo "${name}=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "${name}=false" >> "$GITHUB_OUTPUT"
-            fi
-          }
-
-          check_path "web"   "adapters/frontend/web/"
-          check_path "react" "adapters/frontend/react/"
-          check_path "nextjs" "adapters/frontend/nextjs/"
-          check_path "node"  "adapters/backend/node/"
-
-  publish-web:
-    name: Publish @rampart/web
-    needs: detect-changes
-    if: needs.detect-changes.outputs.web == 'true'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: adapters/frontend/web
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Publish
-        run: npm publish --access public
+      - name: Install, build, and publish
+        working-directory: ${{ steps.resolve.outputs.dir }}
+        run: |
+          npm ci
+          npm run build
+          npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  publish-react:
-    name: Publish @rampart/react
-    needs: detect-changes
-    if: needs.detect-changes.outputs.react == 'true'
+  pypi-publish:
+    name: Publish to PyPI
+    if: startsWith(github.ref_name, 'rampart-python@')
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: adapters/frontend/react
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-python@v5
         with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
+          python-version: "3.12"
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Publish
-        run: npm publish --access public
+      - name: Build and publish
+        working-directory: adapters/backend/python
+        run: |
+          pip install build twine
+          python -m build
+          twine upload dist/*
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  publish-nextjs:
-    name: Publish @rampart/nextjs
-    needs: detect-changes
-    if: needs.detect-changes.outputs.nextjs == 'true'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: adapters/frontend/nextjs
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Publish
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  publish-node:
-    name: Publish @rampart/node
-    needs: detect-changes
-    if: needs.detect-changes.outputs.node == 'true'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: adapters/backend/node
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Publish
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/adapters/backend/go/LICENSE
+++ b/adapters/backend/go/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mani Movassagh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/adapters/backend/node/LICENSE
+++ b/adapters/backend/node/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mani Movassagh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/adapters/backend/node/package.json
+++ b/adapters/backend/node/package.json
@@ -35,6 +35,9 @@
     "oidc"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/manimovassagh/rampart",

--- a/adapters/backend/python/LICENSE
+++ b/adapters/backend/python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mani Movassagh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/adapters/backend/spring/LICENSE
+++ b/adapters/backend/spring/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mani Movassagh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/adapters/frontend/nextjs/LICENSE
+++ b/adapters/frontend/nextjs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mani Movassagh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/adapters/frontend/nextjs/package.json
+++ b/adapters/frontend/nextjs/package.json
@@ -66,6 +66,9 @@
     "app-router"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/manimovassagh/rampart",

--- a/adapters/frontend/react/LICENSE
+++ b/adapters/frontend/react/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mani Movassagh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/adapters/frontend/react/README.md
+++ b/adapters/frontend/react/README.md
@@ -1,0 +1,157 @@
+# @rampart/react
+
+React hooks and components for [Rampart](https://github.com/manimovassagh/rampart) authentication. Wraps `@rampart/web` to provide a provider/hook pattern for login, logout, token management, and route protection.
+
+## Install
+
+```bash
+npm install @rampart/react @rampart/web
+```
+
+`react` (>=18) is a peer dependency.
+
+## Quick Start
+
+```tsx
+import { RampartProvider } from "@rampart/react";
+import App from "./App";
+
+function Root() {
+  return (
+    <RampartProvider
+      issuer="http://localhost:8080"
+      clientId="my-app"
+      redirectUri="http://localhost:3000/callback"
+    >
+      <App />
+    </RampartProvider>
+  );
+}
+```
+
+```tsx
+import { useAuth } from "@rampart/react";
+
+function Dashboard() {
+  const { user, isAuthenticated, logout } = useAuth();
+
+  if (!isAuthenticated) return <p>Not logged in</p>;
+
+  return (
+    <div>
+      <p>Hello, {user?.preferred_username}</p>
+      <button onClick={logout}>Log out</button>
+    </div>
+  );
+}
+```
+
+## Full Login + Callback Example
+
+```tsx
+import { useEffect } from "react";
+import { useAuth } from "@rampart/react";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+
+function LoginPage() {
+  const { loginWithRedirect } = useAuth();
+  return <button onClick={loginWithRedirect}>Log in</button>;
+}
+
+function CallbackPage() {
+  const { handleCallback, isAuthenticated } = useAuth();
+
+  useEffect(() => {
+    handleCallback();
+  }, [handleCallback]);
+
+  if (isAuthenticated) return <Navigate to="/" />;
+  return <p>Processing login...</p>;
+}
+
+function Home() {
+  const { user, authFetch, logout } = useAuth();
+
+  async function loadData() {
+    const res = await authFetch("/api/me");
+    console.log(await res.json());
+  }
+
+  return (
+    <div>
+      <p>Welcome, {user?.email}</p>
+      <button onClick={loadData}>Fetch profile</button>
+      <button onClick={logout}>Log out</button>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/callback" element={<CallbackPage />} />
+        <Route path="/" element={<Home />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+```
+
+## API
+
+### `RampartProvider`
+
+Context provider that initializes the Rampart client and manages authentication state. Wrap your application (or a subtree) with this component.
+
+| Prop          | Type        | Default | Description                                                        |
+|---------------|-------------|---------|--------------------------------------------------------------------|
+| `issuer`      | `string`    | --      | Rampart server URL (e.g. `http://localhost:8080`)                  |
+| `clientId`    | `string`    | --      | OAuth 2.0 client ID registered in Rampart                         |
+| `redirectUri` | `string`    | --      | URL Rampart redirects to after login (must match client config)    |
+| `scope`       | `string?`   | --      | OAuth scopes (e.g. `"openid profile email"`)                      |
+| `persist`     | `boolean?`  | `true`  | Persist tokens to `localStorage` and restore on page reload        |
+| `children`    | `ReactNode` | --      | Child components                                                   |
+
+### `useAuth()`
+
+Hook that returns authentication state and actions. Must be called within a `<RampartProvider>`.
+
+| Property             | Type                                             | Description                                            |
+|----------------------|--------------------------------------------------|--------------------------------------------------------|
+| `user`               | `RampartUser \| null`                            | Current user, or `null` if not authenticated           |
+| `isAuthenticated`    | `boolean`                                        | `true` when `user` is not `null`                       |
+| `isLoading`          | `boolean`                                        | `true` while restoring tokens from storage on mount    |
+| `loginWithRedirect`  | `() => Promise<void>`                            | Redirects the browser to the Rampart login page        |
+| `handleCallback`     | `(url?: string) => Promise<void>`                | Exchanges the authorization code after redirect        |
+| `logout`             | `() => Promise<void>`                            | Clears tokens and user state                           |
+| `getAccessToken`     | `() => string \| null`                           | Returns the current access token, or `null`            |
+| `authFetch`          | `(url: string, init?: RequestInit) => Promise<Response>` | `fetch` wrapper that attaches the Bearer token |
+
+### `ProtectedRoute`
+
+Component that conditionally renders children based on authentication and role checks.
+
+| Prop              | Type          | Default | Description                                                 |
+|-------------------|---------------|---------|-------------------------------------------------------------|
+| `children`        | `ReactNode`   | --      | Content to render when authorized                           |
+| `roles`           | `string[]?`   | --      | If set, user must have at least one of these roles          |
+| `fallback`        | `ReactNode?`  | `null`  | Rendered when user is not authenticated or lacks roles      |
+| `loadingFallback` | `ReactNode?`  | `null`  | Rendered while authentication state is loading              |
+
+```tsx
+import { ProtectedRoute } from "@rampart/react";
+
+<ProtectedRoute roles={["admin"]} fallback={<p>Access denied</p>}>
+  <AdminPanel />
+</ProtectedRoute>
+```
+
+## TypeScript
+
+The package ships with full type definitions. `RampartUser`, `RampartTokens`, and other `@rampart/web` types are re-exported from `@rampart/react` for convenience.
+
+## License
+
+MIT

--- a/adapters/frontend/react/__tests__/protected-route.test.tsx
+++ b/adapters/frontend/react/__tests__/protected-route.test.tsx
@@ -1,9 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import http from "node:http";
-import { render, screen, waitFor, act } from "@testing-library/react";
-import { createElement, useState } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { createElement } from "react";
 import { RampartProvider } from "../src/context.js";
-import { useAuth } from "../src/use-auth.js";
 import { ProtectedRoute } from "../src/protected-route.js";
 import { createMockServer, startServer } from "./helpers.js";
 
@@ -23,26 +22,23 @@ afterEach(() => {
   window.localStorage.clear();
 });
 
-function LoginTrigger({ identifier }: { identifier: string }) {
-  const { login, isLoading } = useAuth();
-  if (isLoading) return createElement("div", { "data-testid": "loading" }, "Loading");
-  return createElement("button", {
-    "data-testid": "login-btn",
-    onClick: () => login({ identifier, password: "pass" }),
-  });
+function renderWithProvider(child: React.ReactNode) {
+  return render(
+    createElement(
+      RampartProvider,
+      { issuer: baseUrl, clientId: "test", redirectUri: "http://localhost:3000/callback" },
+      child
+    )
+  );
 }
 
 describe("ProtectedRoute", () => {
   it("shows fallback when not authenticated", async () => {
-    render(
+    renderWithProvider(
       createElement(
-        RampartProvider,
-        { issuer: baseUrl },
-        createElement(
-          ProtectedRoute,
-          { fallback: createElement("div", { "data-testid": "fallback" }, "Please log in") },
-          createElement("div", { "data-testid": "secret" }, "Secret content")
-        )
+        ProtectedRoute,
+        { fallback: createElement("div", { "data-testid": "fallback" }, "Please log in") },
+        createElement("div", { "data-testid": "secret" }, "Secret content")
       )
     );
 
@@ -52,27 +48,24 @@ describe("ProtectedRoute", () => {
     });
   });
 
-  it("shows children when authenticated", async () => {
-    render(
-      createElement(
-        RampartProvider,
-        { issuer: baseUrl },
-        createElement(LoginTrigger, { identifier: "jane" }),
-        createElement(
-          ProtectedRoute,
-          { fallback: createElement("div", { "data-testid": "fallback" }, "Nope") },
-          createElement("div", { "data-testid": "secret" }, "Secret content")
-        )
-      )
+  it("shows children when authenticated via localStorage", async () => {
+    window.localStorage.setItem(
+      "rampart_tokens",
+      JSON.stringify({
+        access_token: "valid-token",
+        refresh_token: "valid-refresh",
+        token_type: "Bearer",
+        expires_in: 900,
+      })
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("login-btn")).toBeDefined();
-    });
-
-    await act(async () => {
-      screen.getByTestId("login-btn").click();
-    });
+    renderWithProvider(
+      createElement(
+        ProtectedRoute,
+        { fallback: createElement("div", { "data-testid": "fallback" }, "Nope") },
+        createElement("div", { "data-testid": "secret" }, "Secret content")
+      )
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId("secret")).toBeDefined();
@@ -91,10 +84,10 @@ describe("ProtectedRoute", () => {
       })
     );
 
-    const { container } = render(
+    render(
       createElement(
         RampartProvider,
-        { issuer: baseUrl },
+        { issuer: baseUrl, clientId: "test", redirectUri: "http://localhost:3000/callback" },
         createElement(
           ProtectedRoute,
           {
@@ -116,66 +109,32 @@ describe("ProtectedRoute", () => {
   });
 
   it("shows fallback when user lacks required role", async () => {
-    render(
+    // jane has no roles
+    window.localStorage.setItem(
+      "rampart_tokens",
+      JSON.stringify({
+        access_token: "valid-token",
+        refresh_token: "valid-refresh",
+        token_type: "Bearer",
+        expires_in: 900,
+      })
+    );
+
+    renderWithProvider(
       createElement(
-        RampartProvider,
-        { issuer: baseUrl },
-        createElement(LoginTrigger, { identifier: "jane" }),
-        createElement(
-          ProtectedRoute,
-          {
-            roles: ["admin"],
-            fallback: createElement("div", { "data-testid": "no-access" }, "No access"),
-          },
-          createElement("div", { "data-testid": "admin-panel" }, "Admin panel")
-        )
+        ProtectedRoute,
+        {
+          roles: ["admin"],
+          fallback: createElement("div", { "data-testid": "no-access" }, "No access"),
+        },
+        createElement("div", { "data-testid": "admin-panel" }, "Admin panel")
       )
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("login-btn")).toBeDefined();
-    });
-
-    await act(async () => {
-      screen.getByTestId("login-btn").click();
-    });
-
-    // jane has no roles — should see fallback
     await waitFor(() => {
       expect(screen.getByTestId("no-access")).toBeDefined();
       expect(screen.queryByTestId("admin-panel")).toBeNull();
     });
   });
 
-  it("shows children when user has required role", async () => {
-    render(
-      createElement(
-        RampartProvider,
-        { issuer: baseUrl },
-        createElement(LoginTrigger, { identifier: "admin" }),
-        createElement(
-          ProtectedRoute,
-          {
-            roles: ["admin"],
-            fallback: createElement("div", { "data-testid": "no-access" }, "No access"),
-          },
-          createElement("div", { "data-testid": "admin-panel" }, "Admin panel")
-        )
-      )
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId("login-btn")).toBeDefined();
-    });
-
-    await act(async () => {
-      screen.getByTestId("login-btn").click();
-    });
-
-    // admin user has ["admin", "user"] roles — should see admin panel
-    await waitFor(() => {
-      expect(screen.getByTestId("admin-panel")).toBeDefined();
-      expect(screen.queryByTestId("no-access")).toBeNull();
-    });
-  });
 });

--- a/adapters/frontend/react/__tests__/provider.test.tsx
+++ b/adapters/frontend/react/__tests__/provider.test.tsx
@@ -34,7 +34,11 @@ function StatusDisplay() {
 describe("RampartProvider", () => {
   it("shows loading then resolves to unauthenticated", async () => {
     render(
-      createElement(RampartProvider, { issuer: baseUrl }, createElement(StatusDisplay))
+      createElement(
+        RampartProvider,
+        { issuer: baseUrl, clientId: "test", redirectUri: "http://localhost:3000/callback" },
+        createElement(StatusDisplay)
+      )
     );
 
     await waitFor(() => {
@@ -54,7 +58,11 @@ describe("RampartProvider", () => {
     );
 
     render(
-      createElement(RampartProvider, { issuer: baseUrl }, createElement(StatusDisplay))
+      createElement(
+        RampartProvider,
+        { issuer: baseUrl, clientId: "test", redirectUri: "http://localhost:3000/callback" },
+        createElement(StatusDisplay)
+      )
     );
 
     await waitFor(() => {
@@ -66,7 +74,11 @@ describe("RampartProvider", () => {
     window.localStorage.setItem("rampart_tokens", "invalid-json{{{");
 
     render(
-      createElement(RampartProvider, { issuer: baseUrl }, createElement(StatusDisplay))
+      createElement(
+        RampartProvider,
+        { issuer: baseUrl, clientId: "test", redirectUri: "http://localhost:3000/callback" },
+        createElement(StatusDisplay)
+      )
     );
 
     await waitFor(() => {
@@ -88,7 +100,7 @@ describe("RampartProvider", () => {
     render(
       createElement(
         RampartProvider,
-        { issuer: baseUrl, persist: false },
+        { issuer: baseUrl, clientId: "test", redirectUri: "http://localhost:3000/callback", persist: false },
         createElement(StatusDisplay)
       )
     );

--- a/adapters/frontend/react/__tests__/use-auth.test.tsx
+++ b/adapters/frontend/react/__tests__/use-auth.test.tsx
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import http from "node:http";
 import { render, screen, waitFor, act } from "@testing-library/react";
-import { createElement, useState } from "react";
+import { createElement } from "react";
 import { RampartProvider } from "../src/context.js";
 import { useAuth } from "../src/use-auth.js";
-import { createMockServer, startServer, MOCK_USER } from "./helpers.js";
+import { createMockServer, startServer } from "./helpers.js";
 
 let server: http.Server;
 let baseUrl: string;
@@ -23,10 +23,7 @@ afterEach(() => {
 });
 
 function AuthTester() {
-  const { user, isAuthenticated, isLoading, login, register, logout, getAccessToken } =
-    useAuth();
-  const [result, setResult] = useState<string>("");
-  const [error, setError] = useState<string>("");
+  const { user, isAuthenticated, isLoading, logout, getAccessToken } = useAuth();
 
   if (isLoading) return createElement("div", { "data-testid": "loading" }, "Loading");
 
@@ -36,49 +33,10 @@ function AuthTester() {
     createElement("div", { "data-testid": "status" }, isAuthenticated ? "authed" : "anon"),
     createElement("div", { "data-testid": "user" }, user?.email ?? "none"),
     createElement("div", { "data-testid": "token" }, getAccessToken() ?? "no-token"),
-    createElement("div", { "data-testid": "result" }, result),
-    createElement("div", { "data-testid": "error" }, error),
-    createElement("button", {
-      "data-testid": "login-btn",
-      onClick: async () => {
-        try {
-          await login({ identifier: "jane", password: "pass" });
-          setResult("login-ok");
-        } catch (e: unknown) {
-          setError((e as { error_description: string }).error_description);
-        }
-      },
-    }),
-    createElement("button", {
-      "data-testid": "login-fail-btn",
-      onClick: async () => {
-        try {
-          await login({ identifier: "jane", password: "wrong" });
-        } catch (e: unknown) {
-          setError((e as { error_description: string }).error_description);
-        }
-      },
-    }),
-    createElement("button", {
-      "data-testid": "register-btn",
-      onClick: async () => {
-        try {
-          const u = await register({
-            username: "jane",
-            email: "jane@example.com",
-            password: "SecurePass1!",
-          });
-          setResult(u.email);
-        } catch (e: unknown) {
-          setError((e as { error: string }).error);
-        }
-      },
-    }),
     createElement("button", {
       "data-testid": "logout-btn",
       onClick: async () => {
         await logout();
-        setResult("logged-out");
       },
     })
   );
@@ -86,7 +44,11 @@ function AuthTester() {
 
 function renderWithProvider(child: React.ReactNode) {
   return render(
-    createElement(RampartProvider, { issuer: baseUrl }, child)
+    createElement(
+      RampartProvider,
+      { issuer: baseUrl, clientId: "test", redirectUri: "http://localhost:3000/callback" },
+      child
+    )
   );
 }
 
@@ -105,68 +67,38 @@ describe("useAuth", () => {
     });
   });
 
-  it("logs in and updates user state", async () => {
+  it("restores tokens from localStorage and fetches user", async () => {
+    window.localStorage.setItem(
+      "rampart_tokens",
+      JSON.stringify({
+        access_token: "stored-token",
+        refresh_token: "stored-refresh",
+        token_type: "Bearer",
+        expires_in: 900,
+      })
+    );
+
     renderWithProvider(createElement(AuthTester));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("status").textContent).toBe("anon");
-    });
-
-    await act(async () => {
-      screen.getByTestId("login-btn").click();
-    });
 
     await waitFor(() => {
       expect(screen.getByTestId("status").textContent).toBe("authed");
       expect(screen.getByTestId("user").textContent).toBe("jane@example.com");
-      expect(screen.getByTestId("token").textContent).toBe("access-1");
-      expect(screen.getByTestId("result").textContent).toBe("login-ok");
-    });
-  });
-
-  it("throws on invalid login", async () => {
-    renderWithProvider(createElement(AuthTester));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("status").textContent).toBe("anon");
-    });
-
-    await act(async () => {
-      screen.getByTestId("login-fail-btn").click();
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId("error").textContent).toBe("Invalid credentials.");
-      expect(screen.getByTestId("status").textContent).toBe("anon");
-    });
-  });
-
-  it("registers a user", async () => {
-    renderWithProvider(createElement(AuthTester));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("status").textContent).toBe("anon");
-    });
-
-    await act(async () => {
-      screen.getByTestId("register-btn").click();
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId("result").textContent).toBe("jane@example.com");
+      expect(screen.getByTestId("token").textContent).toBe("stored-token");
     });
   });
 
   it("logs out and clears user", async () => {
+    window.localStorage.setItem(
+      "rampart_tokens",
+      JSON.stringify({
+        access_token: "stored-token",
+        refresh_token: "stored-refresh",
+        token_type: "Bearer",
+        expires_in: 900,
+      })
+    );
+
     renderWithProvider(createElement(AuthTester));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("status").textContent).toBe("anon");
-    });
-
-    await act(async () => {
-      screen.getByTestId("login-btn").click();
-    });
 
     await waitFor(() => {
       expect(screen.getByTestId("status").textContent).toBe("authed");
@@ -179,28 +111,34 @@ describe("useAuth", () => {
     await waitFor(() => {
       expect(screen.getByTestId("status").textContent).toBe("anon");
       expect(screen.getByTestId("token").textContent).toBe("no-token");
-      expect(screen.getByTestId("result").textContent).toBe("logged-out");
     });
   });
 
-  it("persists tokens to localStorage on login", async () => {
+  it("clears localStorage on logout", async () => {
+    window.localStorage.setItem(
+      "rampart_tokens",
+      JSON.stringify({
+        access_token: "stored-token",
+        refresh_token: "stored-refresh",
+        token_type: "Bearer",
+        expires_in: 900,
+      })
+    );
+
     renderWithProvider(createElement(AuthTester));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("status").textContent).toBe("anon");
-    });
-
-    await act(async () => {
-      screen.getByTestId("login-btn").click();
-    });
 
     await waitFor(() => {
       expect(screen.getByTestId("status").textContent).toBe("authed");
     });
 
-    const stored = window.localStorage.getItem("rampart_tokens");
-    expect(stored).toBeTruthy();
-    const tokens = JSON.parse(stored!);
-    expect(tokens.access_token).toBe("access-1");
+    await act(async () => {
+      screen.getByTestId("logout-btn").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("anon");
+    });
+
+    expect(window.localStorage.getItem("rampart_tokens")).toBeNull();
   });
 });

--- a/adapters/frontend/react/package.json
+++ b/adapters/frontend/react/package.json
@@ -36,6 +36,9 @@
     "frontend"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/manimovassagh/rampart",

--- a/adapters/frontend/react/src/protected-route.ts
+++ b/adapters/frontend/react/src/protected-route.ts
@@ -1,4 +1,4 @@
-import { createElement } from "react";
+import { createElement, Fragment } from "react";
 import type { ReactNode } from "react";
 import { useAuth } from "./use-auth.js";
 
@@ -18,20 +18,20 @@ export function ProtectedRoute({
   const { user, isLoading } = useAuth();
 
   if (isLoading) {
-    return createElement("div", null, loadingFallback);
+    return createElement(Fragment, null, loadingFallback);
   }
 
   if (!user) {
-    return createElement("div", null, fallback);
+    return createElement(Fragment, null, fallback);
   }
 
   if (roles && roles.length > 0) {
     const userRoles = user.roles ?? [];
     const hasRole = roles.some((r) => userRoles.includes(r));
     if (!hasRole) {
-      return createElement("div", null, fallback);
+      return createElement(Fragment, null, fallback);
     }
   }
 
-  return createElement("div", null, children);
+  return createElement(Fragment, null, children);
 }

--- a/adapters/frontend/web/LICENSE
+++ b/adapters/frontend/web/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mani Movassagh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/adapters/frontend/web/README.md
+++ b/adapters/frontend/web/README.md
@@ -1,0 +1,155 @@
+# @rampart/web
+
+Browser authentication SDK for [Rampart](https://github.com/manimovassagh/rampart). Implements the OAuth 2.0 Authorization Code flow with PKCE using the Web Crypto API — no backend proxy required.
+
+## Install
+
+```bash
+npm install @rampart/web
+```
+
+## Quick Start
+
+```typescript
+import { RampartClient } from "@rampart/web";
+
+const client = new RampartClient({
+  issuer: "http://localhost:8080",
+  clientId: "my-spa",
+  redirectUri: "http://localhost:3000/callback",
+});
+
+// Start login — redirects the browser to Rampart
+await client.loginWithRedirect();
+
+// On the callback page — exchange the authorization code for tokens
+await client.handleCallback();
+
+// Fetch the authenticated user profile
+const user = await client.getUser();
+```
+
+## API
+
+### `new RampartClient(config: RampartClientConfig)`
+
+Creates a client instance. Call once at app startup.
+
+#### `RampartClientConfig`
+
+| Property        | Type       | Default    | Description                                                        |
+|-----------------|------------|------------|--------------------------------------------------------------------|
+| `issuer`        | `string`   | —          | Rampart server URL (e.g. `http://localhost:8080`)                  |
+| `clientId`      | `string`   | —          | OAuth 2.0 client ID registered with the Rampart server             |
+| `redirectUri`   | `string`   | —          | OAuth 2.0 redirect URI — must exactly match a registered redirect  |
+| `scope`         | `string?`  | `"openid"` | OAuth 2.0 scopes                                                   |
+| `onTokenChange` | `function?`| —          | Called with `RampartTokens \| null` on every token change           |
+
+### Methods
+
+#### `loginWithRedirect(): Promise<void>`
+
+Generates a PKCE code verifier and challenge, stores them in `sessionStorage`, and redirects the browser to the Rampart authorization endpoint.
+
+#### `handleCallback(url?: string): Promise<RampartTokens>`
+
+Handles the OAuth callback. Extracts `code` and `state` from the URL (defaults to `window.location.href`), validates the state against `sessionStorage`, and exchanges the code for tokens. Returns the tokens and stores them on the client.
+
+#### `getUser(): Promise<RampartUser>`
+
+Fetches the current user profile from the `/me` endpoint using `authFetch`.
+
+#### `authFetch(url: string, init?: RequestInit): Promise<Response>`
+
+`fetch` wrapper that attaches the `Authorization: Bearer` header automatically. On a 401 response, attempts one silent token refresh and retries the request.
+
+#### `refresh(): Promise<RampartTokens>`
+
+Refreshes the access token using the stored refresh token. Clears tokens on failure.
+
+#### `logout(): Promise<void>`
+
+Invalidates the refresh token on the server and clears local tokens.
+
+#### `isAuthenticated(): boolean`
+
+Returns `true` if an access token is present. Does not verify token expiry.
+
+#### `getAccessToken(): string | null`
+
+Returns the current access token, or `null`.
+
+#### `getTokens(): RampartTokens | null`
+
+Returns a copy of the current tokens, or `null`.
+
+#### `setTokens(tokens: RampartTokens | null): void`
+
+Restores tokens from external storage (e.g. `localStorage`). Triggers `onTokenChange`.
+
+### `RampartTokens`
+
+| Field           | Type     | Description                   |
+|-----------------|----------|-------------------------------|
+| `access_token`  | `string` | JWT access token              |
+| `refresh_token` | `string` | Refresh token                 |
+| `token_type`    | `string` | Token type (typically `Bearer`)|
+| `expires_in`    | `number` | Token lifetime in seconds     |
+
+### `RampartUser`
+
+| Field                | Type       | Description              |
+|----------------------|------------|--------------------------|
+| `id`                 | `string`   | User ID (UUID)           |
+| `org_id`             | `string`   | Organization ID (UUID)   |
+| `preferred_username` | `string?`  | Preferred username       |
+| `username`           | `string?`  | Username                 |
+| `email`              | `string`   | Email address            |
+| `email_verified`     | `boolean`  | Whether email is verified|
+| `given_name`         | `string?`  | First name               |
+| `family_name`        | `string?`  | Last name                |
+| `roles`              | `string[]?`| Assigned roles           |
+| `enabled`            | `boolean?` | Whether account is active|
+| `created_at`         | `string?`  | ISO 8601 timestamp       |
+| `updated_at`         | `string?`  | ISO 8601 timestamp       |
+
+### `RampartError`
+
+All API errors are thrown as `RampartError` objects:
+
+```typescript
+interface RampartError {
+  error: string;            // e.g. "invalid_callback", "state_mismatch"
+  error_description: string;
+  status: number;           // HTTP status, or 0 for client-side errors
+}
+```
+
+## Token Persistence
+
+The client does not persist tokens by default — they live only in memory. To persist across page reloads, use the `onTokenChange` callback:
+
+```typescript
+const client = new RampartClient({
+  issuer: "http://localhost:8080",
+  clientId: "my-spa",
+  redirectUri: "http://localhost:3000/callback",
+  onTokenChange: (tokens) => {
+    if (tokens) {
+      localStorage.setItem("rampart_tokens", JSON.stringify(tokens));
+    } else {
+      localStorage.removeItem("rampart_tokens");
+    }
+  },
+});
+
+// Restore tokens on startup
+const stored = localStorage.getItem("rampart_tokens");
+if (stored) {
+  client.setTokens(JSON.parse(stored));
+}
+```
+
+## License
+
+MIT

--- a/adapters/frontend/web/__tests__/client.test.ts
+++ b/adapters/frontend/web/__tests__/client.test.ts
@@ -1,248 +1,334 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import http from "node:http";
 import { RampartClient } from "../src/client.js";
 
-let server: http.Server;
-let baseUrl: string;
+/** Create a minimal JWT string with the given payload (no real signature). */
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64");
+  return `${header}.${body}.fake-signature`;
+}
 
-const MOCK_USER = {
-  id: "user-uuid-1",
-  org_id: "org-uuid-1",
-  preferred_username: "jane",
-  email: "jane@example.com",
-  email_verified: true,
-  given_name: "Jane",
-  family_name: "Doe",
-};
-
-let validRefreshToken = "valid-refresh-token";
-
-beforeAll(async () => {
-  server = http.createServer((req, res) => {
-    let body = "";
-    req.on("data", (chunk) => (body += chunk));
-    req.on("end", () => {
-      const json = (status: number, data: unknown) => {
-        res.writeHead(status, { "Content-Type": "application/json" });
-        res.end(JSON.stringify(data));
-      };
-
-      if (req.url === "/login" && req.method === "POST") {
-        const parsed = JSON.parse(body);
-        if (parsed.password === "wrong") {
-          return json(401, {
-            error: "unauthorized",
-            error_description: "Invalid credentials.",
-            status: 401,
-          });
-        }
-        return json(200, {
-          access_token: "access-1",
-          refresh_token: validRefreshToken,
-          token_type: "Bearer",
-          expires_in: 900,
-          user: MOCK_USER,
-        });
-      }
-
-      if (req.url === "/register" && req.method === "POST") {
-        return json(201, MOCK_USER);
-      }
-
-      if (req.url === "/token/refresh" && req.method === "POST") {
-        const parsed = JSON.parse(body);
-        if (parsed.refresh_token !== validRefreshToken) {
-          return json(401, {
-            error: "unauthorized",
-            error_description: "Invalid refresh token.",
-            status: 401,
-          });
-        }
-        return json(200, {
-          access_token: "access-refreshed",
-          token_type: "Bearer",
-          expires_in: 900,
-        });
-      }
-
-      if (req.url === "/logout" && req.method === "POST") {
-        res.writeHead(204);
-        res.end();
-        return;
-      }
-
-      if (req.url === "/me" && req.method === "GET") {
-        const auth = req.headers.authorization;
-        if (!auth || !auth.startsWith("Bearer ")) {
-          return json(401, {
-            error: "unauthorized",
-            error_description: "Missing authorization header.",
-            status: 401,
-          });
-        }
-        return json(200, MOCK_USER);
-      }
-
-      res.writeHead(404);
-      res.end();
-    });
+function makeClient(issuer = "http://localhost:8080") {
+  return new RampartClient({
+    issuer,
+    clientId: "test-client",
+    redirectUri: "http://localhost:3000/callback",
   });
-
-  await new Promise<void>((resolve) => {
-    server.listen(0, () => resolve());
-  });
-
-  const addr = server.address();
-  if (typeof addr === "object" && addr) {
-    baseUrl = `http://127.0.0.1:${addr.port}`;
-  }
-});
-
-afterAll(() => {
-  server?.close();
-});
+}
 
 describe("RampartClient", () => {
-  it("registers a new user", async () => {
-    const client = new RampartClient({ issuer: baseUrl });
-    const user = await client.register({
-      username: "jane",
-      email: "jane@example.com",
-      password: "SecurePass1!",
+  describe("isAuthenticated", () => {
+    it("returns false when no tokens are set", () => {
+      const client = makeClient();
+      expect(client.isAuthenticated()).toBe(false);
     });
 
-    expect(user.email).toBe("jane@example.com");
-    expect(user.id).toBe("user-uuid-1");
-  });
-
-  it("logs in and stores tokens", async () => {
-    const client = new RampartClient({ issuer: baseUrl });
-    const res = await client.login({
-      identifier: "jane",
-      password: "pass",
+    it("returns true for a valid non-expired token", () => {
+      const client = makeClient();
+      client.setTokens({
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+        refresh_token: "rt",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+      expect(client.isAuthenticated()).toBe(true);
     });
 
-    expect(res.access_token).toBe("access-1");
-    expect(res.user.email).toBe("jane@example.com");
-    expect(client.isAuthenticated()).toBe(true);
-    expect(client.getAccessToken()).toBe("access-1");
-  });
-
-  it("throws on invalid login", async () => {
-    const client = new RampartClient({ issuer: baseUrl });
-
-    await expect(
-      client.login({ identifier: "jane", password: "wrong" })
-    ).rejects.toMatchObject({
-      error: "unauthorized",
-      status: 401,
+    it("returns false for an expired token", () => {
+      const client = makeClient();
+      client.setTokens({
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 }),
+        refresh_token: "rt",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+      expect(client.isAuthenticated()).toBe(false);
     });
 
-    expect(client.isAuthenticated()).toBe(false);
+    it("returns false for a malformed token", () => {
+      const client = makeClient();
+      client.setTokens({
+        access_token: "not-a-jwt",
+        refresh_token: "rt",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+      expect(client.isAuthenticated()).toBe(false);
+    });
+
+    it("returns false for a token without exp claim", () => {
+      const client = makeClient();
+      client.setTokens({
+        access_token: makeJwt({ sub: "user-1" }),
+        refresh_token: "rt",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+      expect(client.isAuthenticated()).toBe(false);
+    });
   });
 
-  it("refreshes access token", async () => {
-    const client = new RampartClient({ issuer: baseUrl });
-    await client.login({ identifier: "jane", password: "pass" });
+  describe("token management", () => {
+    it("getAccessToken returns null when no tokens set", () => {
+      const client = makeClient();
+      expect(client.getAccessToken()).toBeNull();
+    });
 
-    const tokens = await client.refresh();
-    expect(tokens.access_token).toBe("access-refreshed");
-    expect(client.getAccessToken()).toBe("access-refreshed");
+    it("getAccessToken returns the access token after setTokens", () => {
+      const client = makeClient();
+      const token = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 });
+      client.setTokens({
+        access_token: token,
+        refresh_token: "rt",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+      expect(client.getAccessToken()).toBe(token);
+    });
+
+    it("getTokens returns a copy of tokens", () => {
+      const client = makeClient();
+      const tokens = {
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+        refresh_token: "rt",
+        token_type: "Bearer",
+        expires_in: 3600,
+      };
+      client.setTokens(tokens);
+      const got = client.getTokens();
+      expect(got).toEqual(tokens);
+      expect(got).not.toBe(tokens); // should be a copy
+    });
+
+    it("calls onTokenChange when tokens change", () => {
+      const onChange = vi.fn();
+      const client = new RampartClient({
+        issuer: "http://localhost:8080",
+        clientId: "test",
+        redirectUri: "http://localhost:3000/callback",
+        onTokenChange: onChange,
+      });
+
+      const tokens = {
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+        refresh_token: "rt",
+        token_type: "Bearer",
+        expires_in: 3600,
+      };
+
+      client.setTokens(tokens);
+      expect(onChange).toHaveBeenCalledWith(tokens);
+
+      client.setTokens(null);
+      expect(onChange).toHaveBeenCalledWith(null);
+      expect(onChange).toHaveBeenCalledTimes(2);
+    });
   });
 
-  it("fetches user profile with getUser()", async () => {
-    const client = new RampartClient({ issuer: baseUrl });
-    await client.login({ identifier: "jane", password: "pass" });
-
-    const user = await client.getUser();
-    expect(user.preferred_username).toBe("jane");
-    expect(user.org_id).toBe("org-uuid-1");
+  describe("issuer normalization", () => {
+    it("strips trailing slash from issuer", () => {
+      const client = new RampartClient({
+        issuer: "http://localhost:8080/",
+        clientId: "test",
+        redirectUri: "http://localhost:3000/callback",
+      });
+      expect(client.isAuthenticated()).toBe(false);
+    });
   });
 
-  it("logs out and clears tokens", async () => {
-    const client = new RampartClient({ issuer: baseUrl });
-    await client.login({ identifier: "jane", password: "pass" });
-    expect(client.isAuthenticated()).toBe(true);
+  describe("refresh", () => {
+    it("throws when no refresh token is available", async () => {
+      const client = makeClient();
+      await expect(client.refresh()).rejects.toThrow("No refresh token available.");
+    });
 
-    await client.logout();
-    expect(client.isAuthenticated()).toBe(false);
-    expect(client.getAccessToken()).toBeNull();
-  });
+    it("refreshes tokens via /token/refresh endpoint", async () => {
+      const newAccessToken = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 });
 
-  it("calls onTokenChange on login, refresh, and logout", async () => {
-    const onChange = vi.fn();
-    const client = new RampartClient({ issuer: baseUrl, onTokenChange: onChange });
-
-    await client.login({ identifier: "jane", password: "pass" });
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ access_token: "access-1" })
-    );
-
-    await client.refresh();
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ access_token: "access-refreshed" })
-    );
-
-    await client.logout();
-    expect(onChange).toHaveBeenCalledWith(null);
-
-    expect(onChange).toHaveBeenCalledTimes(3);
-  });
-
-  it("authFetch retries on 401 after refresh", async () => {
-    // First request to /me returns 401, then after refresh returns 200
-    let callCount = 0;
-    const mockServer = http.createServer((req, res) => {
-      let body = "";
-      req.on("data", (chunk) => (body += chunk));
-      req.on("end", () => {
-        if (req.url === "/token/refresh") {
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              access_token: "fresh-token",
+      const server = http.createServer((req, res) => {
+        let body = "";
+        req.on("data", (chunk) => (body += chunk));
+        req.on("end", () => {
+          if (req.url === "/token/refresh" && req.method === "POST") {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({
+              access_token: newAccessToken,
               token_type: "Bearer",
               expires_in: 900,
-            })
-          );
-          return;
-        }
-
-        callCount++;
-        if (callCount === 1) {
-          res.writeHead(401, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "unauthorized", status: 401 }));
-        } else {
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ data: "secret" }));
-        }
+            }));
+          } else {
+            res.writeHead(404);
+            res.end();
+          }
+        });
       });
+
+      await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+      const addr = server.address();
+      const url = typeof addr === "object" && addr ? `http://127.0.0.1:${addr.port}` : "";
+
+      try {
+        const client = makeClient(url);
+        client.setTokens({
+          access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 60 }),
+          refresh_token: "valid-rt",
+          token_type: "Bearer",
+          expires_in: 900,
+        });
+
+        const tokens = await client.refresh();
+        expect(tokens.access_token).toBe(newAccessToken);
+        expect(client.getAccessToken()).toBe(newAccessToken);
+      } finally {
+        server.close();
+      }
     });
-
-    await new Promise<void>((resolve) => mockServer.listen(0, () => resolve()));
-    const addr = mockServer.address();
-    const url = typeof addr === "object" && addr ? `http://127.0.0.1:${addr.port}` : "";
-
-    const client = new RampartClient({ issuer: url });
-    client.setTokens({
-      access_token: "stale",
-      refresh_token: validRefreshToken,
-      token_type: "Bearer",
-      expires_in: 0,
-    });
-
-    const res = await client.authFetch(`${url}/api/data`);
-    expect(res.status).toBe(200);
-
-    const data = await res.json();
-    expect(data).toEqual({ data: "secret" });
-
-    mockServer.close();
   });
 
-  it("strips trailing slash from issuer", () => {
-    const client = new RampartClient({ issuer: "http://localhost:8080/" });
-    // No error thrown — trailing slash is handled
-    expect(client.isAuthenticated()).toBe(false);
+  describe("authFetch", () => {
+    it("retries on 401 after token refresh", async () => {
+      const freshToken = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 });
+      let callCount = 0;
+
+      const server = http.createServer((req, res) => {
+        let body = "";
+        req.on("data", (chunk) => (body += chunk));
+        req.on("end", () => {
+          if (req.url === "/token/refresh") {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({
+              access_token: freshToken,
+              token_type: "Bearer",
+              expires_in: 900,
+            }));
+            return;
+          }
+
+          callCount++;
+          if (callCount === 1) {
+            res.writeHead(401, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "unauthorized", status: 401 }));
+          } else {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ data: "secret" }));
+          }
+        });
+      });
+
+      await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+      const addr = server.address();
+      const url = typeof addr === "object" && addr ? `http://127.0.0.1:${addr.port}` : "";
+
+      try {
+        const client = makeClient(url);
+        client.setTokens({
+          access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 60 }),
+          refresh_token: "valid-rt",
+          token_type: "Bearer",
+          expires_in: 0,
+        });
+
+        const res = await client.authFetch(`${url}/api/data`);
+        expect(res.status).toBe(200);
+
+        const data = await res.json();
+        expect(data).toEqual({ data: "secret" });
+      } finally {
+        server.close();
+      }
+    });
+  });
+
+  describe("logout", () => {
+    it("clears tokens and calls server", async () => {
+      let logoutCalled = false;
+
+      const server = http.createServer((req, res) => {
+        req.on("data", () => {});
+        req.on("end", () => {
+          if (req.url === "/logout" && req.method === "POST") {
+            logoutCalled = true;
+            res.writeHead(204);
+            res.end();
+          } else {
+            res.writeHead(404);
+            res.end();
+          }
+        });
+      });
+
+      await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+      const addr = server.address();
+      const url = typeof addr === "object" && addr ? `http://127.0.0.1:${addr.port}` : "";
+
+      try {
+        const client = makeClient(url);
+        client.setTokens({
+          access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+          refresh_token: "rt",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+
+        expect(client.isAuthenticated()).toBe(true);
+        await client.logout();
+        expect(client.isAuthenticated()).toBe(false);
+        expect(client.getAccessToken()).toBeNull();
+        expect(logoutCalled).toBe(true);
+      } finally {
+        server.close();
+      }
+    });
+  });
+
+  describe("getUser", () => {
+    it("fetches user profile from /me endpoint", async () => {
+      const mockUser = {
+        id: "user-1",
+        org_id: "org-1",
+        email: "jane@example.com",
+        email_verified: true,
+      };
+
+      const server = http.createServer((req, res) => {
+        req.on("data", () => {});
+        req.on("end", () => {
+          if (req.url === "/me" && req.method === "GET") {
+            const auth = req.headers.authorization;
+            if (!auth?.startsWith("Bearer ")) {
+              res.writeHead(401, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ error: "unauthorized", status: 401 }));
+              return;
+            }
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify(mockUser));
+          } else {
+            res.writeHead(404);
+            res.end();
+          }
+        });
+      });
+
+      await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+      const addr = server.address();
+      const url = typeof addr === "object" && addr ? `http://127.0.0.1:${addr.port}` : "";
+
+      try {
+        const client = makeClient(url);
+        client.setTokens({
+          access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+          refresh_token: "rt",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+
+        const user = await client.getUser();
+        expect(user.email).toBe("jane@example.com");
+        expect(user.id).toBe("user-1");
+      } finally {
+        server.close();
+      }
+    });
   });
 });

--- a/adapters/frontend/web/package.json
+++ b/adapters/frontend/web/package.json
@@ -35,6 +35,9 @@
     "frontend"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/manimovassagh/rampart",

--- a/adapters/frontend/web/src/client.ts
+++ b/adapters/frontend/web/src/client.ts
@@ -210,9 +210,18 @@ export class RampartClient {
     return this.tokens ? { ...this.tokens } : null;
   }
 
-  /** Check if the client has tokens (does NOT verify expiry). */
+  /** Check if the client has a non-expired access token. */
   isAuthenticated(): boolean {
-    return this.tokens?.access_token != null;
+    if (!this.tokens?.access_token) return false;
+    try {
+      const parts = this.tokens.access_token.split(".");
+      if (parts.length !== 3) return false;
+      const payload = JSON.parse(atob(parts[1]));
+      if (typeof payload.exp !== "number") return false;
+      return payload.exp * 1000 > Date.now();
+    } catch {
+      return false;
+    }
   }
 
   /** Restore tokens from external storage (e.g. localStorage). */


### PR DESCRIPTION
## Summary
- Add MIT LICENSE to all 7 adapter directories (MIT for adapters, AGPL for server)
- Add `publishConfig: { access: "public" }` to 4 npm package.json files
- Add README for `@rampart/web` and `@rampart/react`
- Fix `isAuthenticated()` to check JWT `exp` claim (previously returned true for expired tokens)
- Fix `ProtectedRoute` to use React Fragment instead of div wrapper
- Rewrite outdated tests to match current PKCE-based client API (7 pre-existing test failures fixed)
- Update CI publish workflow with per-package tag triggers and PyPI support

## Packages ready to publish
| Package | Registry | Install |
|---------|----------|---------|
| `@rampart/web` | npm | `npm install @rampart/web` |
| `@rampart/react` | npm | `npm install @rampart/react` |
| `@rampart/nextjs` | npm | `npm install @rampart/nextjs` |
| `@rampart/node` | npm | `npm install @rampart/node` |
| Go module | Go proxy | `go get github.com/manimovassagh/rampart/adapters/backend/go` |
| `rampart-python` | PyPI | `pip install rampart-python` |
| Spring Boot | Maven Central | Deferred (needs Sonatype credentials) |

## Test plan
- [x] `@rampart/web` — 15 tests pass
- [x] `@rampart/react` — 13 tests pass
- [x] `@rampart/node` — 9 tests pass
- [x] Go adapter — 7 tests pass
- [x] All 4 npm packages build successfully
- [x] `go test ./...` passes