### PR TITLE
chore: rename npm scope from @rampart to @rampart-auth

### DIFF
--- a/.github/workflows/publish-adapters.yml
+++ b/.github/workflows/publish-adapters.yml
@@ -3,10 +3,10 @@ name: Publish Adapters
 on:
   push:
     tags:
-      - "@rampart/web@*"
-      - "@rampart/react@*"
-      - "@rampart/nextjs@*"
-      - "@rampart/node@*"
+      - "@rampart-auth/web@*"
+      - "@rampart-auth/react@*"
+      - "@rampart-auth/nextjs@*"
+      - "@rampart-auth/node@*"
       - "rampart-python@*"
 
 permissions:
@@ -16,7 +16,7 @@ permissions:
 jobs:
   npm-publish:
     name: Publish npm package
-    if: startsWith(github.ref_name, '@rampart/')
+    if: startsWith(github.ref_name, '@rampart-auth/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -32,10 +32,10 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           PKG="${TAG%@*}"
           case "$PKG" in
-            "@rampart/web")    DIR="adapters/frontend/web" ;;
-            "@rampart/react")  DIR="adapters/frontend/react" ;;
-            "@rampart/nextjs") DIR="adapters/frontend/nextjs" ;;
-            "@rampart/node")   DIR="adapters/backend/node" ;;
+            "@rampart-auth/web")    DIR="adapters/frontend/web" ;;
+            "@rampart-auth/react")  DIR="adapters/frontend/react" ;;
+            "@rampart-auth/nextjs") DIR="adapters/frontend/nextjs" ;;
+            "@rampart-auth/node")   DIR="adapters/backend/node" ;;
             *) echo "Unknown package: $PKG" && exit 1 ;;
           esac
           echo "dir=$DIR" >> "$GITHUB_OUTPUT"

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -8,7 +8,7 @@ Server-side middleware for verifying Rampart JWTs on protected API routes.
 
 | Adapter | Package | Framework | Status |
 |---------|---------|-----------|--------|
-| [Node.js](./backend/node/) | `@rampart/node` | Express >=4 | Ready |
+| [Node.js](./backend/node/) | `@rampart-auth/node` | Express >=4 | Ready |
 | [Go](./backend/go/) | `rampart` (Go module) | net/http, chi, gin | Ready |
 | [Python](./backend/python/) | `rampart-python` | FastAPI, Flask | Ready |
 | [Spring Boot](./backend/spring/) | `rampart-spring-boot-starter` | Spring Boot 3.x | Ready |
@@ -19,6 +19,6 @@ Client-side libraries for login, token management, and authenticated API calls.
 
 | Adapter | Package | Framework | Status |
 |---------|---------|-----------|--------|
-| [Web](./frontend/web/) | `@rampart/web` | Any (vanilla JS/TS) | Ready |
-| [React](./frontend/react/) | `@rampart/react` | React >=18 | Ready |
-| [Next.js](./frontend/nextjs/) | `@rampart/nextjs` | Next.js 13+ | Ready |
+| [Web](./frontend/web/) | `@rampart-auth/web` | Any (vanilla JS/TS) | Ready |
+| [React](./frontend/react/) | `@rampart-auth/react` | React >=18 | Ready |
+| [Next.js](./frontend/nextjs/) | `@rampart-auth/nextjs` | Next.js 13+ | Ready |

--- a/adapters/backend/node/README.md
+++ b/adapters/backend/node/README.md
@@ -1,11 +1,11 @@
-# @rampart/node
+# @rampart-auth/node
 
 Express middleware for verifying [Rampart](https://github.com/manimovassagh/rampart) JWTs. Handles JWKS fetching, RS256 verification, and claim extraction with zero configuration beyond the issuer URL.
 
 ## Install
 
 ```bash
-npm install @rampart/node jose
+npm install @rampart-auth/node jose
 ```
 
 `express` (>=4) is a peer dependency.
@@ -14,7 +14,7 @@ npm install @rampart/node jose
 
 ```typescript
 import express from "express";
-import { rampartAuth } from "@rampart/node";
+import { rampartAuth } from "@rampart-auth/node";
 
 const app = express();
 

--- a/adapters/backend/node/package.json
+++ b/adapters/backend/node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rampart/node",
+  "name": "@rampart-auth/node",
   "version": "0.1.0",
   "description": "Rampart authentication middleware for Express / Node.js",
   "type": "module",

--- a/adapters/frontend/nextjs/README.md
+++ b/adapters/frontend/nextjs/README.md
@@ -1,11 +1,11 @@
-# @rampart/nextjs
+# @rampart-auth/nextjs
 
 Rampart authentication adapter for Next.js App Router. Provides Edge Middleware auth guards, server-side JWT validation, and client-side session hooks.
 
 ## Install
 
 ```bash
-npm install @rampart/nextjs @rampart/web @rampart/react
+npm install @rampart-auth/nextjs @rampart-auth/web @rampart-auth/react
 ```
 
 ## Edge Middleware
@@ -13,7 +13,7 @@ npm install @rampart/nextjs @rampart/web @rampart/react
 Protect routes with JWT validation at the edge. Create `middleware.ts` in your project root:
 
 ```ts
-import { withRampartAuth } from "@rampart/nextjs/middleware";
+import { withRampartAuth } from "@rampart-auth/nextjs/middleware";
 
 export default withRampartAuth({
   issuer: "https://auth.example.com",
@@ -35,7 +35,7 @@ Read the authenticated user in Server Components or Route Handlers:
 
 ```ts
 import { cookies } from "next/headers";
-import { getServerAuth } from "@rampart/nextjs/server";
+import { getServerAuth } from "@rampart-auth/nextjs/server";
 import { redirect } from "next/navigation";
 
 export default async function DashboardPage() {
@@ -52,7 +52,7 @@ export default async function DashboardPage() {
 ### Validate a token directly
 
 ```ts
-import { validateToken } from "@rampart/nextjs/server";
+import { validateToken } from "@rampart-auth/nextjs/server";
 
 const claims = await validateToken(token, "https://auth.example.com");
 if (!claims) {
@@ -67,7 +67,7 @@ Create a session API route:
 ```ts
 // app/api/auth/session/route.ts
 import { cookies } from "next/headers";
-import { getServerAuth } from "@rampart/nextjs/server";
+import { getServerAuth } from "@rampart-auth/nextjs/server";
 
 export async function GET() {
   const auth = await getServerAuth(await cookies(), process.env.RAMPART_ISSUER!);
@@ -81,7 +81,7 @@ Then use the hook in client components:
 ```tsx
 "use client";
 
-import { useRampartSession } from "@rampart/nextjs/client";
+import { useRampartSession } from "@rampart-auth/nextjs/client";
 
 export function UserGreeting() {
   const { claims, isLoading, isAuthenticated } = useRampartSession();
@@ -95,12 +95,12 @@ export function UserGreeting() {
 
 ## Client-Side Auth (SPA flows)
 
-The `@rampart/react` hooks are re-exported from `@rampart/nextjs/client` for convenience:
+The `@rampart-auth/react` hooks are re-exported from `@rampart-auth/nextjs/client` for convenience:
 
 ```tsx
 "use client";
 
-import { RampartProvider, useAuth, ProtectedRoute } from "@rampart/nextjs/client";
+import { RampartProvider, useAuth, ProtectedRoute } from "@rampart-auth/nextjs/client";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
@@ -118,7 +118,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
 ## Types
 
 ```ts
-import type { RampartClaims, RampartMiddlewareConfig, ServerAuth } from "@rampart/nextjs";
+import type { RampartClaims, RampartMiddlewareConfig, ServerAuth } from "@rampart-auth/nextjs";
 ```
 
 ## Build

--- a/adapters/frontend/nextjs/package.json
+++ b/adapters/frontend/nextjs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rampart/nextjs",
+  "name": "@rampart-auth/nextjs",
   "version": "0.1.0",
   "description": "Rampart authentication adapter for Next.js (App Router)",
   "type": "module",
@@ -78,8 +78,8 @@
     "jose": "^6.0.0"
   },
   "peerDependencies": {
-    "@rampart/react": ">=0.1.0",
-    "@rampart/web": ">=0.1.0",
+    "@rampart-auth/react": ">=0.1.0",
+    "@rampart-auth/web": ">=0.1.0",
     "next": ">=14",
     "react": ">=18"
   },

--- a/adapters/frontend/nextjs/src/client.ts
+++ b/adapters/frontend/nextjs/src/client.ts
@@ -3,20 +3,20 @@
 import { useCallback, useEffect, useState } from "react";
 import type { RampartClaims } from "./types.js";
 
-// Re-export everything from @rampart/react for convenience
+// Re-export everything from @rampart-auth/react for convenience
 export {
   RampartProvider,
   RampartContext,
   useAuth,
   ProtectedRoute,
-} from "@rampart/react";
+} from "@rampart-auth/react";
 
 export type {
   RampartProviderProps,
   RampartContextValue,
   UseAuthReturn,
   ProtectedRouteProps,
-} from "@rampart/react";
+} from "@rampart-auth/react";
 
 const DEFAULT_SESSION_ENDPOINT = "/api/auth/session";
 
@@ -41,7 +41,7 @@ interface RampartSession {
  * ```ts
  * // app/api/auth/session/route.ts
  * import { cookies } from "next/headers";
- * import { getServerAuth } from "@rampart/nextjs/server";
+ * import { getServerAuth } from "@rampart-auth/nextjs/server";
  *
  * export async function GET() {
  *   const auth = await getServerAuth(await cookies(), process.env.RAMPART_ISSUER!);

--- a/adapters/frontend/nextjs/src/server.ts
+++ b/adapters/frontend/nextjs/src/server.ts
@@ -33,7 +33,7 @@ export async function validateToken(
  * Usage in App Router:
  * ```ts
  * import { cookies } from "next/headers";
- * import { getServerAuth } from "@rampart/nextjs/server";
+ * import { getServerAuth } from "@rampart-auth/nextjs/server";
  *
  * export default async function Page() {
  *   const auth = await getServerAuth(await cookies(), "https://auth.example.com");

--- a/adapters/frontend/nextjs/tsup.config.ts
+++ b/adapters/frontend/nextjs/tsup.config.ts
@@ -10,5 +10,5 @@ export default defineConfig({
   format: ["esm", "cjs"],
   dts: true,
   clean: true,
-  external: ["next", "react", "react-dom", "@rampart/web", "@rampart/react"],
+  external: ["next", "react", "react-dom", "@rampart-auth/web", "@rampart-auth/react"],
 });

--- a/adapters/frontend/react/README.md
+++ b/adapters/frontend/react/README.md
@@ -1,11 +1,11 @@
-# @rampart/react
+# @rampart-auth/react
 
-React hooks and components for [Rampart](https://github.com/manimovassagh/rampart) authentication. Wraps `@rampart/web` to provide a provider/hook pattern for login, logout, token management, and route protection.
+React hooks and components for [Rampart](https://github.com/manimovassagh/rampart) authentication. Wraps `@rampart-auth/web` to provide a provider/hook pattern for login, logout, token management, and route protection.
 
 ## Install
 
 ```bash
-npm install @rampart/react @rampart/web
+npm install @rampart-auth/react @rampart-auth/web
 ```
 
 `react` (>=18) is a peer dependency.
@@ -13,7 +13,7 @@ npm install @rampart/react @rampart/web
 ## Quick Start
 
 ```tsx
-import { RampartProvider } from "@rampart/react";
+import { RampartProvider } from "@rampart-auth/react";
 import App from "./App";
 
 function Root() {
@@ -30,7 +30,7 @@ function Root() {
 ```
 
 ```tsx
-import { useAuth } from "@rampart/react";
+import { useAuth } from "@rampart-auth/react";
 
 function Dashboard() {
   const { user, isAuthenticated, logout } = useAuth();
@@ -50,7 +50,7 @@ function Dashboard() {
 
 ```tsx
 import { useEffect } from "react";
-import { useAuth } from "@rampart/react";
+import { useAuth } from "@rampart-auth/react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 
 function LoginPage() {
@@ -141,7 +141,7 @@ Component that conditionally renders children based on authentication and role c
 | `loadingFallback` | `ReactNode?`  | `null`  | Rendered while authentication state is loading              |
 
 ```tsx
-import { ProtectedRoute } from "@rampart/react";
+import { ProtectedRoute } from "@rampart-auth/react";
 
 <ProtectedRoute roles={["admin"]} fallback={<p>Access denied</p>}>
   <AdminPanel />
@@ -150,7 +150,7 @@ import { ProtectedRoute } from "@rampart/react";
 
 ## TypeScript
 
-The package ships with full type definitions. `RampartUser`, `RampartTokens`, and other `@rampart/web` types are re-exported from `@rampart/react` for convenience.
+The package ships with full type definitions. `RampartUser`, `RampartTokens`, and other `@rampart-auth/web` types are re-exported from `@rampart-auth/react` for convenience.
 
 ## License
 

--- a/adapters/frontend/react/package.json
+++ b/adapters/frontend/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rampart/react",
+  "name": "@rampart-auth/react",
   "version": "0.1.0",
   "description": "Rampart authentication hooks and components for React",
   "type": "module",
@@ -45,7 +45,7 @@
     "directory": "adapters/frontend/react"
   },
   "dependencies": {
-    "@rampart/web": "file:../web"
+    "@rampart-auth/web": "^0.1.0"
   },
   "peerDependencies": {
     "react": ">=18"

--- a/adapters/frontend/react/src/context.ts
+++ b/adapters/frontend/react/src/context.ts
@@ -6,8 +6,8 @@ import {
   useState,
 } from "react";
 import type { ReactNode } from "react";
-import { RampartClient } from "@rampart/web";
-import type { RampartUser, RampartTokens } from "@rampart/web";
+import { RampartClient } from "@rampart-auth/web";
+import type { RampartUser, RampartTokens } from "@rampart-auth/web";
 
 export interface RampartContextValue {
   client: RampartClient;

--- a/adapters/frontend/react/src/index.ts
+++ b/adapters/frontend/react/src/index.ts
@@ -7,11 +7,11 @@ export type { UseAuthReturn } from "./use-auth.js";
 export { ProtectedRoute } from "./protected-route.js";
 export type { ProtectedRouteProps } from "./protected-route.js";
 
-// Re-export @rampart/web types so consumers only need @rampart/react
-export { RampartClient } from "@rampart/web";
+// Re-export @rampart-auth/web types so consumers only need @rampart-auth/react
+export { RampartClient } from "@rampart-auth/web";
 export type {
   RampartClientConfig,
   RampartTokens,
   RampartUser,
   RampartError,
-} from "@rampart/web";
+} from "@rampart-auth/web";

--- a/adapters/frontend/react/src/use-auth.ts
+++ b/adapters/frontend/react/src/use-auth.ts
@@ -1,5 +1,5 @@
 import { useCallback, useContext } from "react";
-import type { RampartUser } from "@rampart/web";
+import type { RampartUser } from "@rampart-auth/web";
 import { RampartContext } from "./context.js";
 
 export interface UseAuthReturn {

--- a/adapters/frontend/react/tsup.config.ts
+++ b/adapters/frontend/react/tsup.config.ts
@@ -5,5 +5,5 @@ export default defineConfig({
   format: ["esm", "cjs"],
   dts: true,
   clean: true,
-  external: ["react", "react-dom", "@rampart/web"],
+  external: ["react", "react-dom", "@rampart-auth/web"],
 });

--- a/adapters/frontend/web/README.md
+++ b/adapters/frontend/web/README.md
@@ -1,17 +1,17 @@
-# @rampart/web
+# @rampart-auth/web
 
 Browser authentication SDK for [Rampart](https://github.com/manimovassagh/rampart). Implements the OAuth 2.0 Authorization Code flow with PKCE using the Web Crypto API — no backend proxy required.
 
 ## Install
 
 ```bash
-npm install @rampart/web
+npm install @rampart-auth/web
 ```
 
 ## Quick Start
 
 ```typescript
-import { RampartClient } from "@rampart/web";
+import { RampartClient } from "@rampart-auth/web";
 
 const client = new RampartClient({
   issuer: "http://localhost:8080",

--- a/adapters/frontend/web/package.json
+++ b/adapters/frontend/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rampart/web",
+  "name": "@rampart-auth/web",
   "version": "0.1.0",
   "description": "Rampart authentication client for browsers and frontend apps",
   "type": "module",


### PR DESCRIPTION
## Summary
- Renamed all 4 npm adapter packages from `@rampart/*` to `@rampart-auth/*` (`@rampart` org was unavailable on npm)
- Updated all source imports, READMEs, tsup configs, and CI workflow
- All 4 packages published to npm as v0.1.0:
  - `@rampart-auth/web`
  - `@rampart-auth/node`
  - `@rampart-auth/react`
  - `@rampart-auth/nextjs`

## Test plan
- [ ] Verify `npm view @rampart-auth/web` returns package info
- [ ] Verify `npm view @rampart-auth/node` returns package info
- [ ] Verify `npm view @rampart-auth/react` returns package info
- [ ] Verify `npm view @rampart-auth/nextjs` returns package info
- [ ] CI passes (lint, test, build)