### PR TITLE
docs: add missing cookbook READMEs and update adapters index

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -12,6 +12,7 @@ Server-side middleware for verifying Rampart JWTs on protected API routes.
 | [Go](./backend/go/) | `rampart` (Go module) | net/http, chi, gin | Ready |
 | [Python](./backend/python/) | `rampart-python` | FastAPI, Flask | Ready |
 | [Spring Boot](./backend/spring/) | `rampart-spring-boot-starter` | Spring Boot 3.x | Ready |
+| [.NET](./backend/dotnet/) | `Rampart.AspNetCore` (NuGet) | ASP.NET Core (.NET 8+) | Ready |
 
 ## Frontend
 

--- a/cookbook/express-backend/README.md
+++ b/cookbook/express-backend/README.md
@@ -1,0 +1,51 @@
+# Express Backend Sample
+
+A Node.js/Express backend that demonstrates the [@rampart-auth/node](../../adapters/backend/node/) adapter for JWT authentication and RBAC. This serves as the reference backend implementation for the React and web frontend samples.
+
+## Prerequisites
+
+- Node.js 18+
+- A running Rampart server (default: `http://localhost:8080`)
+
+## Quick Start
+
+```bash
+cd cookbook/express-backend
+npm install
+npm run dev
+```
+
+The server starts on `http://localhost:3001`.
+
+## Configuration
+
+| Environment Variable | Default                 | Description                    |
+|----------------------|-------------------------|--------------------------------|
+| `RAMPART_ISSUER`     | `http://localhost:8080` | Rampart server URL             |
+| `PORT`               | `3001`                  | Port to listen on              |
+
+## Endpoints
+
+| Method | Path                    | Auth     | Description                      |
+|--------|-------------------------|----------|----------------------------------|
+| GET    | `/api/health`           | Public   | Health check, returns issuer URL |
+| GET    | `/api/profile`          | JWT      | Returns authenticated user info  |
+| GET    | `/api/claims`           | JWT      | Returns all JWT claims           |
+| GET    | `/api/editor/dashboard` | JWT+RBAC | Requires "editor" role           |
+| GET    | `/api/manager/reports`  | JWT+RBAC | Requires "manager" role          |
+
+## Usage with the React Frontend
+
+Start both the backend and the React sample app:
+
+```bash
+# Terminal 1 — backend
+cd cookbook/express-backend
+npm run dev
+
+# Terminal 2 — frontend
+cd cookbook/react-app
+npm run dev
+```
+
+The React app on port 3002 proxies `/api` requests to `http://localhost:3001`.

--- a/cookbook/react-app/README.md
+++ b/cookbook/react-app/README.md
@@ -1,0 +1,40 @@
+# React Sample App
+
+A React 19 single-page application that demonstrates the [@rampart-auth/react](../../adapters/frontend/react/) adapter with OAuth 2.0 PKCE authentication. Uses React Router for navigation and Tailwind CSS for styling.
+
+## Prerequisites
+
+- Node.js 18+
+- A running Rampart server (default: `http://localhost:8080`)
+- A running backend on port 3001 (see [express-backend](../express-backend/), [go-backend](../go-backend/), or [fastapi-backend](../fastapi-backend/))
+
+## Quick Start
+
+```bash
+cd cookbook/react-app
+npm install
+npm run dev
+```
+
+The app starts on `http://localhost:3002` and proxies `/api` requests to `http://localhost:3001`.
+
+## Features
+
+- **Login / Logout** -- OAuth 2.0 Authorization Code with PKCE via Rampart
+- **Dashboard** -- Displays authenticated user profile, JWT claims, and an API tester for backend endpoints
+- **API Tester** -- Call protected backend endpoints with the user's access token
+- **RBAC** -- Role-based access control with `ProtectedRoute` components
+- **Admin Page** -- Restricted to users with the "admin" role
+
+## Pages
+
+| Path         | Description                                      |
+|--------------|--------------------------------------------------|
+| `/`          | Landing page (redirects to dashboard if logged in) |
+| `/callback`  | OAuth callback handler                           |
+| `/dashboard` | Protected user dashboard with API tester         |
+| `/admin`     | Protected admin page (requires "admin" role)     |
+
+## Configuration
+
+The Rampart issuer URL and OAuth client ID are configured in `src/main.tsx`. The Vite dev server port and API proxy are configured in `vite.config.ts`.

--- a/cookbook/web-frontend/README.md
+++ b/cookbook/web-frontend/README.md
@@ -1,0 +1,31 @@
+# Vanilla Web Frontend Sample
+
+A vanilla TypeScript single-page application that demonstrates the [@rampart-auth/web](../../adapters/frontend/web/) adapter with OAuth 2.0 PKCE authentication. No framework required -- just HTML, CSS, and TypeScript compiled with Vite.
+
+## Prerequisites
+
+- Node.js 18+
+- A running Rampart server (default: `http://localhost:8080`)
+- A running backend on port 3001 (see [express-backend](../express-backend/), [go-backend](../go-backend/), or [fastapi-backend](../fastapi-backend/))
+
+## Quick Start
+
+```bash
+cd cookbook/web-frontend
+npm install
+npm run dev
+```
+
+The app starts on `http://localhost:3000` and proxies `/api` requests to `http://localhost:3001`.
+
+## Features
+
+- **Login / Logout** -- OAuth 2.0 Authorization Code with PKCE via `RampartClient`
+- **User Profile** -- Displays authenticated user details after login
+- **API Tester** -- Call `/api/profile`, `/api/claims`, and `/me` endpoints with automatic token attachment
+- **Unauthenticated Tests** -- Demonstrate 401 responses when calling protected endpoints without a token
+- **Token Persistence** -- Tokens stored in `localStorage` and restored on page load
+
+## Configuration
+
+The Rampart issuer URL and OAuth client ID are configured at the top of `src/main.ts`. The Vite dev server port and API proxy are configured in `vite.config.ts`.


### PR DESCRIPTION
## Summary

- Add README.md for express-backend, react-app, and web-frontend cookbook entries
- Add .NET adapter (Rampart.AspNetCore) to adapters/README.md index

Quality audit improvement: documentation score 8 → 9.