### PR TITLE
fix: adapters CI npm install instead of npm ci

### DIFF
--- a/.github/workflows/adapters-ci.yml
+++ b/.github/workflows/adapters-ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build & Test
         working-directory: adapters/backend/node
         run: |
-          npm ci
+          npm install
           npm run build
           npm test
 
@@ -98,7 +98,7 @@ jobs:
       - name: Build
         working-directory: adapters/frontend/react
         run: |
-          npm ci
+          npm install
           npm run build
 
   web-adapter:
@@ -112,7 +112,7 @@ jobs:
       - name: Build
         working-directory: adapters/frontend/web
         run: |
-          npm ci
+          npm install
           npm run build
 
   nextjs-adapter:
@@ -126,7 +126,7 @@ jobs:
       - name: Build
         working-directory: adapters/frontend/nextjs
         run: |
-          npm ci
+          npm install
           npm run build
 
   # Final status check — branch protection can require just this one job


### PR DESCRIPTION
Fix adapters CI workflow failing because adapter packages don't have package-lock.json committed.